### PR TITLE
Add config structs and config yaml to build service binary

### DIFF
--- a/aggregation/quantile/cm/options.go
+++ b/aggregation/quantile/cm/options.go
@@ -55,7 +55,7 @@ type options struct {
 	capacity   int
 	streamPool StreamPool
 	samplePool SamplePool
-	floatsPool FloatsPool
+	floatsPool pool.FloatsPool
 }
 
 // NewOptions creates a new options
@@ -120,13 +120,13 @@ func (o *options) SamplePool() SamplePool {
 	return o.samplePool
 }
 
-func (o *options) SetFloatsPool(value FloatsPool) Options {
+func (o *options) SetFloatsPool(value pool.FloatsPool) Options {
 	opts := *o
 	opts.floatsPool = value
 	return &opts
 }
 
-func (o *options) FloatsPool() FloatsPool {
+func (o *options) FloatsPool() pool.FloatsPool {
 	return o.floatsPool
 }
 
@@ -158,7 +158,7 @@ func (o *options) initPools() {
 	o.samplePool = NewSamplePool(nil)
 	o.samplePool.Init()
 
-	o.floatsPool = NewFloatsPool(defaultBuckets, nil)
+	o.floatsPool = pool.NewFloatsPool(defaultBuckets, nil)
 	o.floatsPool.Init()
 
 	o.streamPool = NewStreamPool(nil)

--- a/aggregation/quantile/cm/stream.go
+++ b/aggregation/quantile/cm/stream.go
@@ -20,7 +20,11 @@
 
 package cm
 
-import "math"
+import (
+	"math"
+
+	"github.com/m3db/m3x/pool"
+)
 
 const (
 	minSamplesToCompress = 3
@@ -32,12 +36,12 @@ var (
 
 // stream represents a data stream
 type stream struct {
-	eps        float64    // desired epsilon for errors
-	quantiles  []float64  // sorted target quantiles
-	capacity   int        // stream capacity
-	streamPool StreamPool // pool of streams
-	samplePool SamplePool // pool of samples
-	floatsPool FloatsPool // pool of float64 slices
+	eps        float64         // desired epsilon for errors
+	quantiles  []float64       // sorted target quantiles
+	capacity   int             // stream capacity
+	streamPool StreamPool      // pool of streams
+	samplePool SamplePool      // pool of samples
+	floatsPool pool.FloatsPool // pool of float64 slices
 
 	closed          bool       // whether the stream is closed
 	numValues       int64      // number of values

--- a/aggregation/quantile/cm/stream_test.go
+++ b/aggregation/quantile/cm/stream_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3x/pool"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -184,7 +185,7 @@ func TestStreamClose(t *testing.T) {
 }
 
 func TestStreamAddToMinHeap(t *testing.T) {
-	floatsPool := NewFloatsPool(
+	floatsPool := pool.NewFloatsPool(
 		[]pool.Bucket{
 			{Capacity: 1, Count: 1},
 			{Capacity: 2, Count: 1},

--- a/aggregation/quantile/cm/types.go
+++ b/aggregation/quantile/cm/types.go
@@ -20,6 +20,8 @@
 
 package cm
 
+import "github.com/m3db/m3x/pool"
+
 // Sample represents a sampled value
 type Sample struct {
 	value    float64 // sampled value
@@ -39,18 +41,6 @@ type SamplePool interface {
 
 	// Put returns a sample to the pool
 	Put(sample *Sample)
-}
-
-// FloatsPool provides a pool for variable-sized float64 slices
-type FloatsPool interface {
-	// Init initializes the pool
-	Init()
-
-	// Get provides an float64 slice from the pool
-	Get(capacity int) []float64
-
-	// Put returns an float64 slice to the pool
-	Put(value []float64)
 }
 
 // Stream represents a data sample stream for floating point numbers
@@ -125,10 +115,10 @@ type Options interface {
 	SamplePool() SamplePool
 
 	// SetFloatsPool sets the floats pool
-	SetFloatsPool(value FloatsPool) Options
+	SetFloatsPool(value pool.FloatsPool) Options
 
 	// FloatsPool returns the floats pool
-	FloatsPool() FloatsPool
+	FloatsPool() pool.FloatsPool
 
 	// Validate validates the options
 	Validate() error

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -158,7 +158,7 @@ func (e *CounterElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion
 	if mu.Type != unaggregated.CounterType {
 		return errInvalidMetricType
 	}
-	alignedStart := timestamp.Truncate(e.policy.Resolution.Window).UnixNano()
+	alignedStart := timestamp.Truncate(e.policy.Resolution().Window).UnixNano()
 	e.Lock()
 	if e.closed {
 		e.Unlock()
@@ -186,7 +186,7 @@ func (e *CounterElem) Consume(earlierThan time.Time, fn aggMetricFn) bool {
 		if e.values[idx].timeNs >= earlierThanNs {
 			break
 		}
-		endAt := time.Unix(0, e.values[idx].timeNs).Add(e.policy.Resolution.Window)
+		endAt := time.Unix(0, e.values[idx].timeNs).Add(e.policy.Resolution().Window)
 		e.processValue(endAt, e.values[idx].counter, fn)
 		idx++
 	}
@@ -271,7 +271,7 @@ func (e *TimerElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 	if mu.Type != unaggregated.BatchTimerType {
 		return errInvalidMetricType
 	}
-	alignedStart := timestamp.Truncate(e.policy.Resolution.Window).UnixNano()
+	alignedStart := timestamp.Truncate(e.policy.Resolution().Window).UnixNano()
 	e.Lock()
 	if e.closed {
 		e.Unlock()
@@ -299,7 +299,7 @@ func (e *TimerElem) Consume(earlierThan time.Time, fn aggMetricFn) bool {
 		if e.values[idx].timeNs >= earlierThanNs {
 			break
 		}
-		endAt := time.Unix(0, e.values[idx].timeNs).Add(e.policy.Resolution.Window)
+		endAt := time.Unix(0, e.values[idx].timeNs).Add(e.policy.Resolution().Window)
 		e.processValue(endAt, e.values[idx].timer, fn)
 		// Close the timer after it's processed
 		e.values[idx].timer.Close()
@@ -421,7 +421,7 @@ func (e *GaugeElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 	if mu.Type != unaggregated.GaugeType {
 		return errInvalidMetricType
 	}
-	alignedStart := timestamp.Truncate(e.policy.Resolution.Window).UnixNano()
+	alignedStart := timestamp.Truncate(e.policy.Resolution().Window).UnixNano()
 	e.Lock()
 	if e.closed {
 		e.Unlock()
@@ -449,7 +449,7 @@ func (e *GaugeElem) Consume(earlierThan time.Time, fn aggMetricFn) bool {
 		if e.values[idx].timeNs >= earlierThanNs {
 			break
 		}
-		endAt := time.Unix(0, e.values[idx].timeNs).Add(e.policy.Resolution.Window)
+		endAt := time.Unix(0, e.values[idx].timeNs).Add(e.policy.Resolution().Window)
 		e.processValue(endAt, e.values[idx].gauge, fn)
 		idx++
 	}

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -36,11 +36,8 @@ import (
 )
 
 var (
-	testID     = metric.ID("foo")
-	testPolicy = policy.Policy{
-		Resolution: policy.Resolution{Window: 10 * time.Second, Precision: xtime.Second},
-		Retention:  policy.Retention(6 * time.Hour),
-	}
+	testID         = metric.ID("foo")
+	testPolicy     = policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour)
 	testTimestamps = []time.Time{
 		time.Unix(216, 0), time.Unix(217, 0), time.Unix(221, 0),
 	}

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -229,7 +229,7 @@ func (e *Entry) updatePoliciesWithLock(
 				return fmt.Errorf("unrecognized element type:%v", typ)
 			}
 			newElem.ResetSetData(id, policy)
-			list, err := e.lists.FindOrCreate(policy.Resolution.Window)
+			list, err := e.lists.FindOrCreate(policy.Resolution().Window)
 			if err != nil {
 				return err
 			}

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -133,7 +133,7 @@ func TestMetricListTick(t *testing.T) {
 		SetMaxFlushSize(100).
 		SetFlushFn(flushFn)
 	l := newMetricList(0, opts)
-	l.resolution = testPolicy.Resolution.Window
+	l.resolution = testPolicy.Resolution().Window
 	l.waitForFn = func(time.Duration) <-chan time.Time {
 		c := make(chan time.Time)
 		close(c)
@@ -166,7 +166,7 @@ func TestMetricListTick(t *testing.T) {
 	}
 	for _, ep := range elemPairs {
 		require.NoError(t, ep.elem.AddMetric(nowTs, ep.metric))
-		require.NoError(t, ep.elem.AddMetric(nowTs.Add(testPolicy.Resolution.Window), ep.metric))
+		require.NoError(t, ep.elem.AddMetric(nowTs.Add(testPolicy.Resolution().Window), ep.metric))
 		_, err := l.PushBack(ep.elem)
 		require.NoError(t, err)
 	}
@@ -181,14 +181,14 @@ func TestMetricListTick(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		// Move the time forward by one aggregation interval
-		nowTs = nowTs.Add(testPolicy.Resolution.Window)
+		nowTs = nowTs.Add(testPolicy.Resolution().Window)
 		atomic.StoreInt64(&now, nowTs.UnixNano())
 
 		// Force a tick
 		l.tickInternal()
 
 		var expected []testAggMetric
-		alignedStart := nowTs.Truncate(testPolicy.Resolution.Window)
+		alignedStart := nowTs.Truncate(testPolicy.Resolution().Window)
 		expected = append(expected, expectedAggMetricsForCounter(alignedStart, testPolicy)...)
 		expected = append(expected, expectedAggMetricsForTimer(alignedStart, testPolicy)...)
 		expected = append(expected, expectedAggMetricsForGauge(alignedStart, testPolicy)...)
@@ -207,7 +207,7 @@ func TestMetricListTick(t *testing.T) {
 	}
 
 	// Move the time forward by one aggregation interval
-	nowTs = nowTs.Add(testPolicy.Resolution.Window)
+	nowTs = nowTs.Add(testPolicy.Resolution().Window)
 	atomic.StoreInt64(&now, nowTs.UnixNano())
 
 	// Force a tick

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -21,6 +21,7 @@
 package aggregator
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -59,8 +60,7 @@ func defaultTimerQuantileSuffixFn(quantile float64) []byte {
 
 // By default we print out the buffer size
 func defaultFlushFn(buffer msgpack.Buffer) error {
-	fmt.Printf("buffer size=%d\n", len(buffer.Bytes()))
-	return nil
+	return errors.New("not implemented")
 }
 
 type options struct {

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -1,0 +1,99 @@
+# Copyright (c) 2017 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+metrics:
+  m3:
+    hostPort: 127.0.0.1:5000  # local collector host port for m3 metrics
+    service: m3aggregator
+    env: test
+    includeHost: true
+  samplingRate: 0.01
+
+aggregator:
+  stream:
+    eps: 0.001
+    quantiles:
+      - 0.5
+      - 0.95
+      - 0.99
+    capacity: 32
+    streamPool:
+      size: 4096
+    samplePool:
+      size: 4096
+    floatsPool:
+      buckets:
+        - count: 4096
+          capacity: 16
+        - count: 2048
+          capacity: 32
+        - count: 1024
+          capacity: 16
+  minFlushInterval: 5s
+  maxFlushSize: 1440
+  flush:
+    type: logging
+  entryTTL: 24h
+  entryCheckInterval: 1h
+  entryPool:
+    size: 4096
+  counterElemPool:
+    size: 4096
+  timerElemPool:
+    size: 4096
+  gaugeElemPool:
+    size: 4096
+  bufferedEncoderPool:
+    size: 4096
+
+msgpack:
+  listenAddress: 0.0.0.0:6000
+  retry:
+    initialBackoff: 5ms
+    backoffFactor: 2.0
+    maxBackoff: 1s
+    maxRetries: 2147483647 # TODO(xichen): hack to retry forever, will fix
+    jitter: true
+  iterator:
+    ignoreHigherVersion: false
+    floatsPool:
+      buckets:
+        - count: 4096
+          capacity: 16
+        - count: 2048
+          capacity: 32
+        - count: 1024
+          capacity: 16
+    policiesPool:
+      buckets:
+        - count: 8192
+          capacity: 2
+        - count: 4096
+          capacity: 4
+        - count: 1024
+          capacity: 8
+    iteratorPool:
+      size: 4096
+
+http:
+  listenAddress: 0.0.0.0:6001
+  debugListenAddress: 0.0.0.0:16000
+  readTimeout: 10s
+  writeTimeout: 10s

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -69,7 +69,7 @@ msgpack:
     initialBackoff: 5ms
     backoffFactor: 2.0
     maxBackoff: 1s
-    maxRetries: 2147483647 # TODO(xichen): hack to retry forever, will fix
+    forever: true
     jitter: true
   iterator:
     ignoreHigherVersion: false

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 86141e1bc760107379d8017b62717dd4c615b8fd4b2ee241a154f106a530e1d4
-updated: 2017-03-14T17:54:31.814405685-04:00
+hash: b1827151ef0dd3801f59c4941195d64ab09a135e8b1290a69b126fb33cd93095
+updated: 2017-04-17T18:52:58.373387324-04:00
 imports:
+- name: github.com/apache/thrift
+  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  subpackages:
+  - lib/go/thrift
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -12,25 +16,26 @@ imports:
   subpackages:
   - proto
 - name: github.com/m3db/m3metrics
-  version: 622fad952b35e8897af7ccefcdecea6fffc62253
+  version: 27d28ef612e44438df96be220a466877797e9cc4
   subpackages:
   - generated/proto/schema
   - metric
   - metric/aggregated
   - metric/unaggregated
   - policy
-  - pool
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: fcb5878c2ad11ab932afc2d30810da4a23986d0e
+  version: 7874f69f8ff1b9fa3e270c0f03786420e92cac7d
   subpackages:
   - checked
   - clock
+  - config
   - errors
   - instrument
   - log
   - net
   - pool
+  - pprof
   - retry
   - sync
   - time
@@ -38,17 +43,37 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/prometheus/common
+  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  subpackages:
+  - log
+- name: github.com/Sirupsen/logrus
+  version: cd7d1bbe41066b6c1f19780f895901052150a575
 - name: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
   subpackages:
   - assert
   - require
+- name: github.com/uber-go/atomic
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 1f0f7171f312a8cff5f697fe5f4d45dbaec8c3ac
+  version: 4b9d9de43ffcb0b7efe67dab2a92c2d58dbf16ab
+  subpackages:
+  - m3
+  - m3/customtransports
+  - m3/thrift
+  - m3/thriftudp
 - name: golang.org/x/net
   version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
   subpackages:
   - context
+- name: golang.org/x/sys
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  subpackages:
+  - unix
+  - windows
+  - windows/registry
+  - windows/svc/eventlog
 - name: google.golang.org/appengine
   version: 8758a385849434ba5eac8aeedcf5192c5a0f5f10
   subpackages:
@@ -60,8 +85,12 @@ imports:
   - internal/log
   - internal/modules
   - internal/remote_api
+- name: gopkg.in/validator.v2
+  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/vmihailenco/msgpack.v2
   version: a1382b1ce0c749733b814157c245e02cc1f41076
   subpackages:
   - codes
+- name: gopkg.in/yaml.v2
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b1827151ef0dd3801f59c4941195d64ab09a135e8b1290a69b126fb33cd93095
-updated: 2017-04-17T18:52:58.373387324-04:00
+hash: 0fa87d980a617b0a4ac56ba5f9d880721b03e22e372c68b4029515216b7f6326
+updated: 2017-04-17T22:07:47.457248347-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -25,7 +25,7 @@ imports:
   - policy
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: 7874f69f8ff1b9fa3e270c0f03786420e92cac7d
+  version: 0983ae8a74b716e37edd2675638dff80bf723e88
   subpackages:
   - checked
   - clock

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 27d28ef612e44438df96be220a466877797e9cc4
 
 - package: github.com/m3db/m3x
-  version: 7874f69f8ff1b9fa3e270c0f03786420e92cac7d
+  version: 0983ae8a74b716e37edd2675638dff80bf723e88
 
 - package: github.com/uber-go/tally
   version: 3.0.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,14 +1,17 @@
 package: github.com/m3db/m3aggregator
 
 import:
+- package: github.com/apache/thrift
+  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+
 - package: github.com/m3db/m3metrics
-  version: 622fad952b35e8897af7ccefcdecea6fffc62253
+  version: 27d28ef612e44438df96be220a466877797e9cc4
 
 - package: github.com/m3db/m3x
-  version: fcb5878c2ad11ab932afc2d30810da4a23986d0e
+  version: 7874f69f8ff1b9fa3e270c0f03786420e92cac7d
 
 - package: github.com/uber-go/tally
-  version: 1f0f7171f312a8cff5f697fe5f4d45dbaec8c3ac
+  version: 3.0.0
 
 - package: github.com/golang/protobuf
   version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
@@ -18,6 +21,21 @@ import:
 
 - package: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
-  subpackages:
-  - assert
-  - require
+
+- package: github.com/prometheus/common
+  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+
+- package: github.com/Sirupsen/logrus
+  version: cd7d1bbe41066b6c1f19780f895901052150a575
+
+- package: github.com/uber-go/atomic
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+
+- package: golang.org/x/sys
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+
+- package: gopkg.in/validator.v2
+  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
+
+- package: gopkg.in/yaml.v2
+  version: a83829b6f1293c91addabc89d0571c246397bbf4

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -132,7 +132,7 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 		resultLock.Unlock()
 		return nil
 	}
-	handler := handler.NewHandler(handleFn)
+	handler := handler.NewDecodingHandler(handleFn)
 
 	return &testSetup{
 		opts:              opts,

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -219,6 +219,6 @@ func (s *server) reportMetrics() {
 		if atomic.LoadInt32(&s.closed) == 1 {
 			return
 		}
-		s.metrics.openConnections.Update(int64(atomic.LoadInt32(&s.numConns)))
+		s.metrics.openConnections.Update(float64(atomic.LoadInt32(&s.numConns)))
 	}
 }

--- a/server/msgpack/server_test.go
+++ b/server/msgpack/server_test.go
@@ -71,10 +71,7 @@ var (
 			1,
 			time.Now(),
 			[]policy.Policy{
-				{
-					Resolution: policy.Resolution{Window: time.Duration(1), Precision: xtime.Second},
-					Retention:  policy.Retention(time.Hour),
-				},
+				policy.NewPolicy(time.Duration(1), xtime.Second, time.Hour),
 			},
 		),
 	}

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
+	"github.com/m3db/m3aggregator/aggregator"
+	"github.com/m3db/m3aggregator/services/m3aggregator/handler"
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3metrics/protocol/msgpack"
+	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
+)
+
+var (
+	errUnknownQuantileSuffixFnType = errors.New("unknown quantile suffix function type")
+	errUnknownFlushFnType          = errors.New("unknown flush function type")
+	errNoForwardFlushConfiguration = errors.New("no forward flush configuration")
+	emptyPolicy                    policy.Policy
+)
+
+// aggregatorConfiguration contains aggregator configuration.
+type aggregatorConfiguration struct {
+	// Common metric prefix.
+	MetricPrefix string `yaml:"metricPrefix"`
+
+	// Counter metric prefix.
+	CounterPrefix string `yaml:"counterPrefix"`
+
+	// Timer metric prefix.
+	TimerPrefix string `yaml:"timerPrefix"`
+
+	// Timer sum metric suffix.
+	TimerSumSuffix string `yaml:"timerSumSuffix"`
+
+	// Timer sum square metric suffix.
+	TimerSumSqSuffix string `yaml:"timerSumSqSuffix"`
+
+	// Timer sum mean metric suffix.
+	TimerMeanSuffix string `yaml:"timerMeanSuffix"`
+
+	// Timer lower metric suffix.
+	TimerLowerSuffix string `yaml:"timerLowerSuffix"`
+
+	// Timer upper metric suffix.
+	TimerUpperSuffix string `yaml:"timerUpperSuffix"`
+
+	// Timer count metric suffix.
+	TimerCountSuffix string `yaml:"timerCountSuffix"`
+
+	// Timer standard deviation metric suffix.
+	TimerStdevSuffix string `yaml:"timerStdevSuffix"`
+
+	// Timer median metric suffix.
+	TimerMedianSuffix string `yaml:"timerMedianSuffix"`
+
+	// Timer quantile suffix function type.
+	TimerQuantileSuffixFnType string `yaml:"timerQuantileSuffixFnType"`
+
+	// Gauge metric suffix.
+	GaugePrefix string `yaml:"gaugePrefix"`
+
+	// Stream configuration for computing quantiles.
+	Stream streamConfiguration `yaml:"stream"`
+
+	// Minimum flush interval across all resolutions.
+	MinFlushInterval time.Duration `yaml:"minFlushInterval"`
+
+	// Maximum flush size in bytes.
+	MaxFlushSize int `yaml:"maxFlushSize"`
+
+	// Flushing configuration.
+	Flush flushConfiguration `yaml:"flush"`
+
+	// EntryTTL determines how long an entry remains alive before it may be expired due to inactivity.
+	EntryTTL time.Duration `yaml:"entryTTL"`
+
+	// EntryCheckInterval determines how often entries are checked for expiration.
+	EntryCheckInterval time.Duration `yaml:"entryCheckInterval"`
+
+	// EntryCheckBatchPercent determines the percentage of entries checked in a batch.
+	EntryCheckBatchPercent float64 `yaml:"entryCheckBatchPercent" validate:"min=0.0,max=1.0"`
+
+	// Pool of entries.
+	EntryPool pool.ObjectPoolConfiguration `yaml:"entryPool"`
+
+	// Pool of counter elements.
+	CounterElemPool pool.ObjectPoolConfiguration `yaml:"counterElemPool"`
+
+	// Pool of timer elements.
+	TimerElemPool pool.ObjectPoolConfiguration `yaml:"timerElemPool"`
+
+	// Pool of gauge elements.
+	GaugeElemPool pool.ObjectPoolConfiguration `yaml:"gaugeElemPool"`
+
+	// Pool of buffered encoders.
+	BufferedEncoderPool pool.ObjectPoolConfiguration `yaml:"bufferedEncoderPool"`
+}
+
+// NewAggregatorOptions creates a new aggregator options.
+func (c *aggregatorConfiguration) NewAggregatorOptions(
+	instrumentOpts instrument.Options,
+) (aggregator.Options, error) {
+	opts := aggregator.NewOptions().SetInstrumentOptions(instrumentOpts)
+
+	// Set the prefix and suffix for metrics aggregations.
+	opts = setMetricPrefixOrSuffix(opts, c.MetricPrefix, opts.SetMetricPrefix)
+	opts = setMetricPrefixOrSuffix(opts, c.CounterPrefix, opts.SetCounterPrefix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerPrefix, opts.SetTimerPrefix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerSumSuffix, opts.SetTimerSumSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerSumSqSuffix, opts.SetTimerSumSqSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerMeanSuffix, opts.SetTimerMeanSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerLowerSuffix, opts.SetTimerLowerSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerUpperSuffix, opts.SetTimerUpperSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerCountSuffix, opts.SetTimerCountSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerStdevSuffix, opts.SetTimerStdevSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.TimerMedianSuffix, opts.SetTimerMedianSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.GaugePrefix, opts.SetGaugePrefix)
+
+	// Set timer quantile suffix function.
+	quantileSuffixFn, err := c.parseTimerQuantileSuffixFn()
+	if err != nil {
+		return nil, err
+	}
+	opts = opts.SetTimerQuantileSuffixFn(quantileSuffixFn)
+
+	// Set stream options.
+	iOpts := instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("stream"))
+	streamOpts, err := c.Stream.NewStreamOptions(iOpts)
+	if err != nil {
+		return nil, err
+	}
+	opts = opts.SetStreamOptions(streamOpts)
+
+	// Set flushing options.
+	if c.MinFlushInterval != 0 {
+		opts = opts.SetMinFlushInterval(c.MinFlushInterval)
+	}
+	if c.MaxFlushSize != 0 {
+		opts = opts.SetMaxFlushSize(c.MaxFlushSize)
+	}
+	flushFn, err := c.Flush.NewFlushFn()
+	if err != nil {
+		return nil, err
+	}
+	opts = opts.SetFlushFn(flushFn)
+
+	// Set entry options.
+	if c.EntryTTL != 0 {
+		opts = opts.SetEntryTTL(c.EntryTTL)
+	}
+	if c.EntryCheckInterval != 0 {
+		opts = opts.SetEntryCheckInterval(c.EntryCheckInterval)
+	}
+	if c.EntryCheckBatchPercent != 0.0 {
+		opts = opts.SetEntryCheckBatchPercent(c.EntryCheckBatchPercent)
+	}
+
+	// Set entry pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("entry-pool"))
+	entryPoolOpts := c.EntryPool.NewObjectPoolOptions(iOpts)
+	entryPool := aggregator.NewEntryPool(entryPoolOpts)
+	opts = opts.SetEntryPool(entryPool)
+	entryPool.Init(func() *aggregator.Entry { return aggregator.NewEntry(nil, opts) })
+
+	// Set counter elem pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("counter-elem-pool"))
+	counterElemPoolOpts := c.CounterElemPool.NewObjectPoolOptions(iOpts)
+	counterElemPool := aggregator.NewCounterElemPool(counterElemPoolOpts)
+	opts = opts.SetCounterElemPool(counterElemPool)
+	counterElemPool.Init(func() *aggregator.CounterElem { return aggregator.NewCounterElem(nil, emptyPolicy, opts) })
+
+	// Set timer elem pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("timer-elem-pool"))
+	timerElemPoolOpts := c.TimerElemPool.NewObjectPoolOptions(iOpts)
+	timerElemPool := aggregator.NewTimerElemPool(timerElemPoolOpts)
+	opts = opts.SetTimerElemPool(timerElemPool)
+	timerElemPool.Init(func() *aggregator.TimerElem { return aggregator.NewTimerElem(nil, emptyPolicy, opts) })
+
+	// Set gauge eleme pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("gauge-elem-pool"))
+	gaugeElemPoolOpts := c.GaugeElemPool.NewObjectPoolOptions(iOpts)
+	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
+	opts = opts.SetGaugeElemPool(gaugeElemPool)
+	gaugeElemPool.Init(func() *aggregator.GaugeElem { return aggregator.NewGaugeElem(nil, emptyPolicy, opts) })
+
+	// Set buffered encoder pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("buffered-encoder-pool"))
+	bufferedEncoderPoolOpts := c.BufferedEncoderPool.NewObjectPoolOptions(iOpts)
+	bufferedEncoderPool := msgpack.NewBufferedEncoderPool(bufferedEncoderPoolOpts)
+	opts = opts.SetBufferedEncoderPool(bufferedEncoderPool)
+	bufferedEncoderPool.Init(func() msgpack.BufferedEncoder { return msgpack.NewPooledBufferedEncoder(bufferedEncoderPool) })
+
+	return opts, nil
+}
+
+// parseTimerQuantileSuffixFn parses the quantile suffix function type.
+func (c *aggregatorConfiguration) parseTimerQuantileSuffixFn() (aggregator.QuantileSuffixFn, error) {
+	fnType := defaultQuantileSuffixType
+	if c.TimerQuantileSuffixFnType != "" {
+		fnType = timerQuantileSuffixFnType(c.TimerQuantileSuffixFnType)
+	}
+	switch fnType {
+	case defaultQuantileSuffixType:
+		return defaultTimerQuantileSuffixFn, nil
+	default:
+		return nil, errUnknownQuantileSuffixFnType
+	}
+}
+
+// streamConfiguration contains configuration for quantile-related metric streams.
+type streamConfiguration struct {
+	// Error epsilon for quantile computation.
+	Eps float64 `yaml:"eps"`
+
+	// Target quantiles to compute.
+	Quantiles []float64 `yaml:"quantiles"`
+
+	// Initial heap capacity for quantile computation.
+	Capacity int `yaml:"capacity"`
+
+	// Pool of streams.
+	StreamPool pool.ObjectPoolConfiguration `yaml:"streamPool"`
+
+	// Pool of metric samples.
+	SamplePool pool.ObjectPoolConfiguration `yaml:"samplePool"`
+
+	// Pool of float slices.
+	FloatsPool pool.BucketizedPoolConfiguration `yaml:"floatsPool"`
+}
+
+func (c *streamConfiguration) NewStreamOptions(instrumentOpts instrument.Options) (cm.Options, error) {
+	opts := cm.NewOptions().
+		SetEps(c.Eps).
+		SetQuantiles(c.Quantiles).
+		SetCapacity(c.Capacity)
+
+	iOpts := instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("sample-pool"))
+	samplePoolOpts := c.SamplePool.NewObjectPoolOptions(iOpts)
+	samplePool := cm.NewSamplePool(samplePoolOpts)
+	opts = opts.SetSamplePool(samplePool)
+	samplePool.Init()
+
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("floats-pool"))
+	floatsPoolOpts := c.FloatsPool.NewObjectPoolOptions(iOpts)
+	floatsPool := pool.NewFloatsPool(c.FloatsPool.NewBuckets(), floatsPoolOpts)
+	opts = opts.SetFloatsPool(floatsPool)
+	floatsPool.Init()
+
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("stream-pool"))
+	streamPoolOpts := c.StreamPool.NewObjectPoolOptions(iOpts)
+	streamPool := cm.NewStreamPool(streamPoolOpts)
+	opts = opts.SetStreamPool(streamPool)
+	streamPool.Init(func() cm.Stream { return cm.NewStream(opts) })
+
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+// flushConfiguration contains configuration for flushing metrics.
+type flushConfiguration struct {
+	// Flushing function type.
+	Type string `yaml:"type" validate:"regexp=(^blackhole$|^logging$|^forward$)"`
+
+	// Forward flush configuration.
+	Forward *forwardFlushConfiguration `yaml:"forward"`
+}
+
+func (c *flushConfiguration) NewFlushFn() (aggregator.FlushFn, error) {
+	switch flushFnType(c.Type) {
+	case blackholeFlushFnType:
+		return handler.NewBlackholeHandler().Handle, nil
+	case loggingFlushFnType:
+		return handler.NewLoggingHandler().Handle, nil
+	case forwardFlushFnType:
+		if c.Forward == nil {
+			return nil, errNoForwardFlushConfiguration
+		}
+		return c.Forward.NewFlushFn(), nil
+	default:
+		return nil, errUnknownFlushFnType
+	}
+}
+
+// forwardFlushConfiguration contains configuration for forward flushing function.
+type forwardFlushConfiguration struct {
+	// Server address list.
+	Servers []string `yaml:"servers"`
+}
+
+// TODO(xichen): implement this.
+func (c *forwardFlushConfiguration) NewFlushFn() aggregator.FlushFn {
+	return nil
+}
+
+// timerQuantileSuffixFnType is the timer quantile suffix function type.
+type timerQuantileSuffixFnType string
+
+// A list of supported timer quantile suffix function types.
+const (
+	defaultQuantileSuffixType timerQuantileSuffixFnType = "default"
+)
+
+func defaultTimerQuantileSuffixFn(quantile float64) []byte {
+	return []byte(fmt.Sprintf(".p%0.0f", quantile*100))
+}
+
+// flushFnType is the flushing function type.
+type flushFnType string
+
+// A list of supported flushing function types.
+const (
+	blackholeFlushFnType flushFnType = "blackhole"
+	loggingFlushFnType   flushFnType = "logging"
+	forwardFlushFnType   flushFnType = "forward"
+)
+
+type metricPrefixOrSuffixSetter func(prefixOrSuffix []byte) aggregator.Options
+
+func setMetricPrefixOrSuffix(
+	opts aggregator.Options,
+	str string,
+	fn metricPrefixOrSuffixSetter,
+) aggregator.Options {
+	if str == "" {
+		return opts
+	}
+	return fn([]byte(str))
+}

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -41,8 +41,8 @@ var (
 	emptyPolicy                    policy.Policy
 )
 
-// aggregatorConfiguration contains aggregator configuration.
-type aggregatorConfiguration struct {
+// AggregatorConfiguration contains aggregator configuration.
+type AggregatorConfiguration struct {
 	// Common metric prefix.
 	MetricPrefix string `yaml:"metricPrefix"`
 
@@ -119,8 +119,8 @@ type aggregatorConfiguration struct {
 	BufferedEncoderPool pool.ObjectPoolConfiguration `yaml:"bufferedEncoderPool"`
 }
 
-// NewAggregatorOptions creates a new aggregator options.
-func (c *aggregatorConfiguration) NewAggregatorOptions(
+// NewAggregatorOptions creates a new set of aggregator options.
+func (c *AggregatorConfiguration) NewAggregatorOptions(
 	instrumentOpts instrument.Options,
 ) (aggregator.Options, error) {
 	opts := aggregator.NewOptions().SetInstrumentOptions(instrumentOpts)
@@ -217,7 +217,7 @@ func (c *aggregatorConfiguration) NewAggregatorOptions(
 }
 
 // parseTimerQuantileSuffixFn parses the quantile suffix function type.
-func (c *aggregatorConfiguration) parseTimerQuantileSuffixFn() (aggregator.QuantileSuffixFn, error) {
+func (c *AggregatorConfiguration) parseTimerQuantileSuffixFn() (aggregator.QuantileSuffixFn, error) {
 	fnType := defaultQuantileSuffixType
 	if c.TimerQuantileSuffixFnType != "" {
 		fnType = timerQuantileSuffixFnType(c.TimerQuantileSuffixFnType)

--- a/services/m3aggregator/config/config.go
+++ b/services/m3aggregator/config/config.go
@@ -28,11 +28,11 @@ type Configuration struct {
 	Metrics instrument.MetricsConfiguration `yaml:"metrics"`
 
 	// Aggregator configuration.
-	Aggregator aggregatorConfiguration `yaml:"aggregator"`
+	Aggregator AggregatorConfiguration `yaml:"aggregator"`
 
 	// Msgpack server configuration.
-	Msgpack msgpackServerConfiguration `yaml:"msgpack"`
+	Msgpack MsgpackServerConfiguration `yaml:"msgpack"`
 
 	// HTTP server configuration.
-	HTTP httpServerConfiguration `yaml:"http"`
+	HTTP HTTPServerConfiguration `yaml:"http"`
 }

--- a/services/m3aggregator/config/config.go
+++ b/services/m3aggregator/config/config.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import "github.com/m3db/m3x/instrument"
+
+// Configuration contains top-level configuration.
+type Configuration struct {
+	// Metrics configuration.
+	Metrics instrument.MetricsConfiguration `yaml:"metrics"`
+
+	// Aggregator configuration.
+	Aggregator aggregatorConfiguration `yaml:"aggregator"`
+
+	// Msgpack server configuration.
+	Msgpack msgpackServerConfiguration `yaml:"msgpack"`
+
+	// HTTP server configuration.
+	HTTP httpServerConfiguration `yaml:"http"`
+}

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"time"
+
+	"github.com/m3db/m3aggregator/server/http"
+	"github.com/m3db/m3aggregator/server/msgpack"
+	"github.com/m3db/m3metrics/policy"
+	msgpackp "github.com/m3db/m3metrics/protocol/msgpack"
+	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
+	"github.com/m3db/m3x/retry"
+)
+
+// msgpackServerConfiguration contains msgpack server configuration.
+type msgpackServerConfiguration struct {
+	// Msgpack server listening address.
+	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
+
+	// Retry mechanism configuration.
+	Retry xretry.Configuration `yaml:"retry"`
+
+	// Iterator configuration.
+	Iterator unaggregatedIteratorConfiguration `yaml:"iterator"`
+}
+
+func (c *msgpackServerConfiguration) NewMsgpackServerOptions(
+	instrumentOpts instrument.Options,
+) msgpack.Options {
+	opts := msgpack.NewOptions().SetInstrumentOptions(instrumentOpts)
+
+	// Set retrier.
+	retrier := c.Retry.NewRetrier(instrumentOpts.MetricsScope())
+	opts = opts.SetRetrier(retrier)
+
+	// Set unaggregated iterator pool.
+	iteratorPool := c.Iterator.NewUnaggregatedIteratorPool(instrumentOpts)
+	opts = opts.SetIteratorPool(iteratorPool)
+
+	return opts
+}
+
+// unaggregatedIteratorConfiguration contains configuration for unaggregated iterator.
+type unaggregatedIteratorConfiguration struct {
+	// Whether to ignore encoded data streams whose version is higher than the current known version.
+	IgnoreHigherVersion bool `yaml:"ignoreHigherVersion"`
+
+	// Pool of float slices.
+	FloatsPool pool.BucketizedPoolConfiguration `yaml:"floatsPool"`
+
+	// Pool of policies.
+	PoliciesPool pool.BucketizedPoolConfiguration `yaml:"policiesPool"`
+
+	// Pool of unaggregated iterators.
+	IteratorPool pool.ObjectPoolConfiguration `yaml:"iteratorPool"`
+}
+
+func (c *unaggregatedIteratorConfiguration) NewUnaggregatedIteratorPool(
+	instrumentOpts instrument.Options,
+) msgpackp.UnaggregatedIteratorPool {
+	opts := msgpackp.NewUnaggregatedIteratorOptions().SetIgnoreHigherVersion(c.IgnoreHigherVersion)
+
+	// NB(xichen): intentionally not using the same floats pool used for computing
+	// timer quantiles to accommodate different usage patterns and reduce contention.
+	iOpts := instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("floats-pool"))
+	floatsPoolOpts := c.FloatsPool.NewObjectPoolOptions(iOpts)
+	floatsPool := pool.NewFloatsPool(c.FloatsPool.NewBuckets(), floatsPoolOpts)
+	opts = opts.SetFloatsPool(floatsPool)
+	floatsPool.Init()
+
+	// Set policies pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("policies-pool"))
+	policiesPoolOpts := c.PoliciesPool.NewObjectPoolOptions(iOpts)
+	policiesPool := policy.NewPoliciesPool(c.FloatsPool.NewBuckets(), policiesPoolOpts)
+	opts = opts.SetPoliciesPool(policiesPool)
+	policiesPool.Init()
+
+	// Set iterator pool.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("unaggreagted-iterator-pool"))
+	iteratorPoolOpts := c.IteratorPool.NewObjectPoolOptions(iOpts)
+	iteratorPool := msgpackp.NewUnaggregatedIteratorPool(iteratorPoolOpts)
+	opts = opts.SetIteratorPool(iteratorPool)
+	iteratorPool.Init(func() msgpackp.UnaggregatedIterator { return msgpackp.NewUnaggregatedIterator(nil, opts) })
+
+	return iteratorPool
+}
+
+// httpServerConfiguration contains http server configuration.
+type httpServerConfiguration struct {
+	// HTTP server listending address.
+	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
+
+	// HTTP server debug listening address.
+	DebugListenAddress string `yaml:"debugListenAddress"`
+
+	// HTTP server read timeout.
+	ReadTimeout time.Duration `yaml:"readTimeout"`
+
+	// HTTP server write timeout.
+	WriteTimeout time.Duration `yaml:"writeTimeout"`
+}
+
+func (c *httpServerConfiguration) NewHTTPServerOptions(
+	instrumentOpts instrument.Options,
+) http.Options {
+	opts := http.NewOptions()
+	if c.ReadTimeout != 0 {
+		opts = opts.SetReadTimeout(c.ReadTimeout)
+	}
+	if c.WriteTimeout != 0 {
+		opts = opts.SetWriteTimeout(c.WriteTimeout)
+	}
+	return opts
+}

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -32,8 +32,8 @@ import (
 	"github.com/m3db/m3x/retry"
 )
 
-// msgpackServerConfiguration contains msgpack server configuration.
-type msgpackServerConfiguration struct {
+// MsgpackServerConfiguration contains msgpack server configuration.
+type MsgpackServerConfiguration struct {
 	// Msgpack server listening address.
 	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
 
@@ -44,7 +44,8 @@ type msgpackServerConfiguration struct {
 	Iterator unaggregatedIteratorConfiguration `yaml:"iterator"`
 }
 
-func (c *msgpackServerConfiguration) NewMsgpackServerOptions(
+// NewMsgpackServerOptions create a new set of msgpack server options.
+func (c *MsgpackServerConfiguration) NewMsgpackServerOptions(
 	instrumentOpts instrument.Options,
 ) msgpack.Options {
 	opts := msgpack.NewOptions().SetInstrumentOptions(instrumentOpts)
@@ -105,8 +106,8 @@ func (c *unaggregatedIteratorConfiguration) NewUnaggregatedIteratorPool(
 	return iteratorPool
 }
 
-// httpServerConfiguration contains http server configuration.
-type httpServerConfiguration struct {
+// HTTPServerConfiguration contains http server configuration.
+type HTTPServerConfiguration struct {
 	// HTTP server listending address.
 	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
 
@@ -120,7 +121,8 @@ type httpServerConfiguration struct {
 	WriteTimeout time.Duration `yaml:"writeTimeout"`
 }
 
-func (c *httpServerConfiguration) NewHTTPServerOptions(
+// NewHTTPServerOptions create a new set of http server options.
+func (c *HTTPServerConfiguration) NewHTTPServerOptions(
 	instrumentOpts instrument.Options,
 ) http.Options {
 	opts := http.NewOptions()

--- a/services/m3aggregator/handler/blackhole.go
+++ b/services/m3aggregator/handler/blackhole.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package handler
+
+import "github.com/m3db/m3metrics/protocol/msgpack"
+
+type blackholeHandler struct{}
+
+// NewBlackholeHandler creates a new blackhole handler.
+func NewBlackholeHandler() Handler { return blackholeHandler{} }
+
+func (h blackholeHandler) Handle(buffer msgpack.Buffer) error {
+	buffer.Close()
+	return nil
+}

--- a/services/m3aggregator/handler/forward.go
+++ b/services/m3aggregator/handler/forward.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,32 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package cm
+package handler
 
-import (
-	"github.com/m3db/m3x/pool"
-)
-
-type floatsPool struct {
-	pool pool.BucketizedObjectPool
+// TODO(xichen)
+type forwardHandler struct {
 }
 
-// NewFloatsPool creates a new floats pool
-func NewFloatsPool(sizes []pool.Bucket, opts pool.ObjectPoolOptions) FloatsPool {
-	return &floatsPool{pool: pool.NewBucketizedObjectPool(sizes, opts)}
-}
-
-func (p *floatsPool) Init() {
-	p.pool.Init(func(capacity int) interface{} {
-		return make([]float64, 0, capacity)
-	})
-}
-
-func (p *floatsPool) Get(capacity int) []float64 {
-	return p.pool.Get(capacity).([]float64)
-}
-
-func (p *floatsPool) Put(value []float64) {
-	value = value[:0]
-	p.pool.Put(value, cap(value))
+// NewForwardHandler creates a new forwarding handler.
+func NewForwardHandler() Handler {
+	return nil
 }

--- a/services/m3aggregator/handler/handler.go
+++ b/services/m3aggregator/handler/handler.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package handler
+
+import "github.com/m3db/m3metrics/protocol/msgpack"
+
+// Handler handles encoded streams containing aggregated metrics alongside their policies.
+type Handler interface {
+	// Handle processes aggregated metrics and policies encoded in the buffer.
+	Handle(buffer msgpack.Buffer) error
+}

--- a/services/m3aggregator/handler/logging.go
+++ b/services/m3aggregator/handler/logging.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package handler
+
+import (
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/log"
+)
+
+var logger = xlog.NewLevelLogger(xlog.SimpleLogger, xlog.LogLevelInfo)
+
+func loggingHandler(metric aggregated.Metric, policy policy.Policy) error {
+	logger.WithFields(
+		xlog.NewLogField("metric", metric.String()),
+		xlog.NewLogField("policy", policy.String()),
+	).Info("aggregated metric")
+	return nil
+}
+
+// NewLoggingHandler creates a new logging handler.
+func NewLoggingHandler() Handler {
+	return NewDecodingHandler(loggingHandler)
+}


### PR DESCRIPTION
cc @martin-mao @cw9 @prateek  @jeromefroe  

This PR adds config structs and example yaml so we can build the service binary out of the open source repo.