### PR TITLE
Merge pprof and http ports

### DIFF
--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -94,6 +94,5 @@ msgpack:
 
 http:
   listenAddress: 0.0.0.0:6001
-  debugListenAddress: 0.0.0.0:16000
-  readTimeout: 10s
-  writeTimeout: 10s
+  readTimeout: 45s
+  writeTimeout: 45s

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3aggregator/aggregator"
 	networkserver "github.com/m3db/m3aggregator/server"
+	"github.com/m3db/m3x/pprof"
 )
 
 // server is an http server receiving incoming metrics traffic
@@ -50,6 +51,7 @@ func (s *server) ListenAndServe() error {
 	if err := registerHandlers(mux, s.aggregator); err != nil {
 		return err
 	}
+	xpprof.RegisterHandler(mux)
 	server := http.Server{
 		Handler:      mux,
 		ReadTimeout:  s.opts.ReadTimeout(),

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -109,11 +109,8 @@ func (c *unaggregatedIteratorConfiguration) NewUnaggregatedIteratorPool(
 
 // HTTPServerConfiguration contains http server configuration.
 type HTTPServerConfiguration struct {
-	// HTTP server listending address.
+	// HTTP server listening address.
 	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
-
-	// HTTP server debug listening address.
-	DebugListenAddress string `yaml:"debugListenAddress"`
 
 	// HTTP server read timeout.
 	ReadTimeout time.Duration `yaml:"readTimeout"`

--- a/services/m3aggregator/main/main.go
+++ b/services/m3aggregator/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,8 +34,6 @@ import (
 	"github.com/m3db/m3x/config"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/log"
-	"github.com/m3db/m3x/pprof"
-	"github.com/prometheus/common/log"
 )
 
 const (
@@ -90,17 +87,6 @@ func main() {
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("http-server"))
 	httpServerOpts := cfg.HTTP.NewHTTPServerOptions(iOpts)
 
-	// Start up the pprof goroutine.
-	if cfg.HTTP.DebugListenAddress != "" {
-		go func() {
-			mux := http.NewServeMux()
-			xpprof.RegisterHandler(mux)
-			if err := http.ListenAndServe(cfg.HTTP.DebugListenAddress, mux); err != nil {
-				logger.Errorf("debug server could not listen on %s: %v", cfg.HTTP.DebugListenAddress, err)
-			}
-		}()
-	}
-
 	doneCh := make(chan struct{})
 	closedCh := make(chan struct{})
 	go func() {
@@ -119,7 +105,7 @@ func main() {
 	}()
 
 	// Handle interrupts.
-	log.Warnf("interrupt: %v", interrupt())
+	logger.Warnf("interrupt: %v", interrupt())
 
 	close(doneCh)
 


### PR DESCRIPTION
cc @cw9 @jeromefroe @martin-mao 

This PR uses the same port for the http server (which is used for debugging only) and the pprof endpoint. It also increase the HTTP server timeout in order to be able to successfully retrieve a 30s profile without getting EOF errors.