### PR TITLE
Pull in m3metrics improvements for better perf and memory utilization

### DIFF
--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -59,6 +59,9 @@ type newMetricElemFn func() metricElem
 
 // metricElem is the common interface for metric elements
 type metricElem interface {
+	// ID returns the metric id.
+	ID() metric.ID
+
 	// ResetSetData resets the counter and sets data
 	ResetSetData(id metric.ID, policy policy.Policy)
 
@@ -125,7 +128,7 @@ type GaugeElem struct {
 	values []timedGauge // aggregated gauges sorted by time in ascending order
 }
 
-// ResetSetData resets the counter and sets data
+// ResetSetData resets the counter and sets data.
 func (e *elemBase) ResetSetData(id metric.ID, policy policy.Policy) {
 	e.id = id
 	e.policy = policy
@@ -133,8 +136,16 @@ func (e *elemBase) ResetSetData(id metric.ID, policy policy.Policy) {
 	e.closed = false
 }
 
+// ID returns the metric id.
+func (e *elemBase) ID() metric.ID {
+	e.Lock()
+	id := e.id
+	e.Unlock()
+	return id
+}
+
 // MarkAsTombstoned marks an element as tombstoned, which means this element
-// will be deleted once its aggregated values have been flushed
+// will be deleted once its aggregated values have been flushed.
 func (e *elemBase) MarkAsTombstoned() {
 	e.Lock()
 	if e.closed {

--- a/aggregator/elem_pool_test.go
+++ b/aggregator/elem_pool_test.go
@@ -35,18 +35,18 @@ func TestCounterElemPool(t *testing.T) {
 		return NewCounterElem(nil, policy.Policy{}, testOptions())
 	})
 
-	// Retrieve an element from the pool
+	// Retrieve an element from the pool.
 	element := p.Get()
-	element.ResetSetData(testID, testPolicy)
-	require.Equal(t, testID, element.id)
+	element.ResetSetData(testCounterID, testPolicy)
+	require.Equal(t, testCounterID, element.id)
 	require.Equal(t, testPolicy, element.policy)
 
-	// Put the element back to pool
+	// Put the element back to pool.
 	p.Put(element)
 
-	// Retrieve the element and assert it's the same element
+	// Retrieve the element and assert it's the same element.
 	element = p.Get()
-	require.Equal(t, testID, element.id)
+	require.Equal(t, testCounterID, element.id)
 	require.Equal(t, testPolicy, element.policy)
 }
 
@@ -56,18 +56,18 @@ func TestTimerElemPool(t *testing.T) {
 		return NewTimerElem(nil, policy.Policy{}, testOptions())
 	})
 
-	// Retrieve an element from the pool
+	// Retrieve an element from the pool.
 	element := p.Get()
-	element.ResetSetData(testID, testPolicy)
-	require.Equal(t, testID, element.id)
+	element.ResetSetData(testBatchTimerID, testPolicy)
+	require.Equal(t, testBatchTimerID, element.id)
 	require.Equal(t, testPolicy, element.policy)
 
-	// Put the element back to pool
+	// Put the element back to pool.
 	p.Put(element)
 
-	// Retrieve the element and assert it's the same element
+	// Retrieve the element and assert it's the same element.
 	element = p.Get()
-	require.Equal(t, testID, element.id)
+	require.Equal(t, testBatchTimerID, element.id)
 	require.Equal(t, testPolicy, element.policy)
 }
 
@@ -77,17 +77,17 @@ func TestGaugeElemPool(t *testing.T) {
 		return NewGaugeElem(nil, policy.Policy{}, testOptions())
 	})
 
-	// Retrieve an element from the pool
+	// Retrieve an element from the pool.
 	element := p.Get()
-	element.ResetSetData(testID, testPolicy)
-	require.Equal(t, testID, element.id)
+	element.ResetSetData(testGaugeID, testPolicy)
+	require.Equal(t, testGaugeID, element.id)
 	require.Equal(t, testPolicy, element.policy)
 
-	// Put the element back to pool
+	// Put the element back to pool.
 	p.Put(element)
 
-	// Retrieve the element and assert it's the same element
+	// Retrieve the element and assert it's the same element.
 	element = p.Get()
-	require.Equal(t, testID, element.id)
+	require.Equal(t, testGaugeID, element.id)
 	require.Equal(t, testPolicy, element.policy)
 }

--- a/aggregator/entry_pool_test.go
+++ b/aggregator/entry_pool_test.go
@@ -34,16 +34,16 @@ func TestEntryPool(t *testing.T) {
 		return NewEntry(nil, testOptions())
 	})
 
-	// Retrieve an entry from the pool
+	// Retrieve an entry from the pool.
 	entry := p.Get()
 	lists := &metricLists{}
 	entry.ResetSetData(&metricLists{})
 	require.Equal(t, lists, entry.lists)
 
-	// Put the entry back to pool
+	// Put the entry back to pool.
 	p.Put(entry)
 
-	// Retrieve the entry and assert it's the same entry
+	// Retrieve the entry and assert it's the same entry.
 	entry = p.Get()
 	require.Equal(t, lists, entry.lists)
 }

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -27,9 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/require"
@@ -48,62 +50,6 @@ var (
 		policy.NewPolicy(5*time.Minute, xtime.Minute, 7*24*time.Hour),
 	}
 )
-
-type testPreProcessFn func(e *Entry)
-type testElemValidateFn func(t *testing.T, elem *list.Element, alignedStart time.Time)
-type testPostProcessFn func(t *testing.T)
-
-type testEntryData struct {
-	mu unaggregated.MetricUnion
-	fn testElemValidateFn
-}
-
-func testEntry() (*Entry, *metricLists, time.Time) {
-	now := time.Now()
-	clockOpts := clock.NewOptions().SetNowFn(func() time.Time {
-		return now
-	})
-	opts := testOptions().
-		SetClockOptions(clockOpts).
-		SetMinFlushInterval(0)
-
-	lists := newMetricLists(opts)
-	// This effectively disable flushing.
-	lists.newMetricListFn = func(res time.Duration, opts Options) *metricList {
-		return newMetricList(0, opts)
-	}
-
-	e := NewEntry(nil, opts)
-	e.ResetSetData(lists)
-
-	return e, lists, now
-}
-
-func populateTestAggregations(
-	t *testing.T,
-	e *Entry,
-	typ unaggregated.Type,
-) {
-	for _, policy := range testPolicies {
-		var newElem metricElem
-		switch typ {
-		case unaggregated.CounterType:
-			newElem = e.opts.CounterElemPool().Get()
-		case unaggregated.BatchTimerType:
-			newElem = e.opts.TimerElemPool().Get()
-		case unaggregated.GaugeType:
-			newElem = e.opts.GaugeElemPool().Get()
-		default:
-			require.Fail(t, fmt.Sprintf("unrecognized metric type: %v", typ))
-		}
-		newElem.ResetSetData(testID, policy)
-		list, err := e.lists.FindOrCreate(policy.Resolution().Window)
-		require.NoError(t, err)
-		newListElem, err := list.PushBack(newElem)
-		require.NoError(t, err)
-		e.aggregations[policy] = newListElem
-	}
-}
 
 func TestEntryIncDecWriter(t *testing.T) {
 	e := NewEntry(nil, testOptions())
@@ -145,6 +91,289 @@ func TestEntryResetSetData(t *testing.T) {
 	require.Equal(t, now.UnixNano(), e.lastAccessInNs)
 }
 
+func TestEntryAddBatchTimerWithPoolAlloc(t *testing.T) {
+	timerValPool := pool.NewFloatsPool([]pool.Bucket{
+		{Capacity: 16, Count: 1},
+	}, nil)
+	timerValPool.Init()
+
+	// Consume the element in the pool.
+	input := timerValPool.Get(10)
+	input = append(input, []float64{1.0, 3.5, 2.2, 6.5, 4.8}...)
+	bt := unaggregated.MetricUnion{
+		Type:          unaggregated.BatchTimerType,
+		ID:            testBatchTimerID,
+		BatchTimerVal: input,
+		TimerValPool:  timerValPool,
+	}
+	e, _, now := testEntry()
+	require.NoError(t, e.addMetricWithLock(now, bt))
+
+	// Assert the timer values have been returned to pool.
+	vals := timerValPool.Get(10)
+	require.Equal(t, []float64{1.0, 3.5, 2.2, 6.5, 4.8}, vals[:5])
+}
+
+func TestEntryHasPolicyChangesWithLockDifferentLength(t *testing.T) {
+	e, _, _ := testEntry()
+	require.True(t, e.hasPolicyChangesWithLock(testPolicies))
+}
+
+func TestEntryHasPolicyChangesWithLockSameLengthDifferentPolicies(t *testing.T) {
+	e, _, _ := testEntry()
+	for i, p := range testPolicies {
+		if i == len(testPolicies)-1 {
+			resolution := p.Resolution()
+			retention := p.Retention()
+			newRetention := time.Duration(retention) - time.Second
+			p = policy.NewPolicy(resolution.Window, resolution.Precision, newRetention)
+		}
+		e.aggregations[p] = &list.Element{}
+	}
+	require.True(t, e.hasPolicyChangesWithLock(testPolicies))
+}
+
+func TestEntryHasPolicyChangesWithLockSameLengthSamePolicies(t *testing.T) {
+	e, _, _ := testEntry()
+	for _, p := range testPolicies {
+		e.aggregations[p] = &list.Element{}
+	}
+	require.False(t, e.hasPolicyChangesWithLock(testPolicies))
+}
+
+func TestEntryAddMetricWithPoliciesNoPolicyUpdate(t *testing.T) {
+	var lists *metricLists
+	preAddFn := func(e *Entry) { lists = e.lists }
+	postAddFn := func(t *testing.T) {
+		require.Equal(t, 3, len(lists.lists))
+		for _, p := range testPolicies {
+			list, exists := lists.lists[p.Resolution().Window]
+			require.True(t, exists)
+			require.Equal(t, 1, list.aggregations.Len())
+			checkElemTombstoned(t, list.aggregations.Front().Value.(metricElem), nil)
+		}
+	}
+	testEntryAddMetricWithPolicies(t, testPoliciesVersion, true, false, preAddFn, postAddFn, testPolicies)
+}
+
+func TestEntryAddMetricWithPoliciesWithPolicyUpdateNoPolicyChanges(t *testing.T) {
+	var lists *metricLists
+	preAddFn := func(e *Entry) { lists = e.lists }
+	postAddFn := func(t *testing.T) {
+		require.Equal(t, 3, len(lists.lists))
+		for _, p := range testPolicies {
+			list, exists := lists.lists[p.Resolution().Window]
+			require.True(t, exists)
+			require.Equal(t, 1, list.aggregations.Len())
+			checkElemTombstoned(t, list.aggregations.Front().Value.(metricElem), nil)
+		}
+	}
+	testEntryAddMetricWithPolicies(t, testPoliciesVersion+1, true, false, preAddFn, postAddFn, testPolicies)
+}
+
+func TestEntryAddMetricWithPoliciesWithPolicyUpdateIDNotOwnedReuseElemID(t *testing.T) {
+	var lists *metricLists
+	deletedPolicies := make(map[policy.Policy]struct{})
+	deletedPolicies[testPolicies[1]] = struct{}{}
+	deletedPolicies[testPolicies[2]] = struct{}{}
+
+	preAddFn := func(e *Entry) { lists = e.lists }
+	postAddFn := func(t *testing.T) {
+		require.Equal(t, 4, len(lists.lists))
+		expectedLengths := []int{1, 2, 1}
+		for _, policies := range [][]policy.Policy{testPolicies, testNewPolicies} {
+			for i := range policies {
+				list, exists := lists.lists[policies[i].Resolution().Window]
+				require.True(t, exists)
+				require.Equal(t, expectedLengths[i], list.aggregations.Len())
+				for elem := list.aggregations.Front(); elem != nil; elem = elem.Next() {
+					checkElemTombstoned(t, elem.Value.(metricElem), deletedPolicies)
+				}
+			}
+		}
+	}
+	testEntryAddMetricWithPolicies(t, testPoliciesVersion+1, true, false, preAddFn, postAddFn, testNewPolicies)
+}
+
+func TestEntryAddMetricWithPoliciesWithPolicyUpdateIDNotOwnedCopyID(t *testing.T) {
+	var lists *metricLists
+	preAddFn := func(e *Entry) { lists = e.lists }
+	postAddFn := func(t *testing.T) {
+		require.Equal(t, 3, len(lists.lists))
+		expectedLengths := []int{1, 1, 1}
+		for i, policy := range testPolicies {
+			list, exists := lists.lists[policy.Resolution().Window]
+			require.True(t, exists)
+			require.Equal(t, expectedLengths[i], list.aggregations.Len())
+			for elem := list.aggregations.Front(); elem != nil; elem = elem.Next() {
+				checkElemTombstoned(t, elem.Value.(metricElem), nil)
+			}
+		}
+	}
+	testEntryAddMetricWithPolicies(t, testPoliciesVersion+1, false, false, preAddFn, postAddFn, testPolicies)
+}
+
+func TestEntryAddMetricWithPoliciesWithPolicyUpdateIDOwnsID(t *testing.T) {
+	var lists *metricLists
+	preAddFn := func(e *Entry) { lists = e.lists }
+	postAddFn := func(t *testing.T) {
+		require.Equal(t, 3, len(lists.lists))
+		expectedLengths := []int{1, 1, 1}
+		for i, policy := range testPolicies {
+			list, exists := lists.lists[policy.Resolution().Window]
+			require.True(t, exists)
+			require.Equal(t, expectedLengths[i], list.aggregations.Len())
+			for elem := list.aggregations.Front(); elem != nil; elem = elem.Next() {
+				checkElemTombstoned(t, elem.Value.(metricElem), nil)
+			}
+		}
+	}
+	testEntryAddMetricWithPolicies(t, testPoliciesVersion+1, false, true, preAddFn, postAddFn, testPolicies)
+}
+
+func TestEntryAddMetricsWithPolicyError(t *testing.T) {
+	e, lists, now := testEntry()
+	e.version = testPoliciesVersion
+	versionedPolicies := policy.CustomVersionedPolicies(
+		testPoliciesVersion+1,
+		now.Add(-time.Second),
+		testNewPolicies,
+	)
+
+	// Add an invalid metric should result in an error.
+	require.Error(t, e.AddMetricWithPolicies(
+		testInvalidMetric,
+		versionedPolicies,
+	))
+
+	// Add a metric to a closed entry should result in an error.
+	e.closed = true
+	require.Equal(t, errEntryClosed, e.AddMetricWithPolicies(
+		testCounter,
+		versionedPolicies,
+	))
+
+	// Add a metric with closed lists should result in an error.
+	e.closed = false
+	lists.closed = true
+	require.Error(t, e.AddMetricWithPolicies(
+		testCounter,
+		versionedPolicies,
+	))
+}
+
+func TestEntryMaybeExpireNoExpiry(t *testing.T) {
+	e, _, now := testEntry()
+
+	// If we are still within entry TTL, should not expire.
+	require.False(t, e.ShouldExpire(now.Add(e.opts.EntryTTL()).Add(-time.Second)))
+
+	// If the entry is closed, should not expire.
+	e.closed = true
+	require.False(t, e.ShouldExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
+
+	// If there are still active writers, should not expire.
+	e.closed = false
+	e.numWriters = 1
+	require.False(t, e.ShouldExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
+}
+
+func TestEntryMaybeExpireWithExpiry(t *testing.T) {
+	e, _, now := testEntry()
+	populateTestAggregations(t, e, unaggregated.CounterType)
+
+	var elems []*CounterElem
+	for _, elem := range e.aggregations {
+		elems = append(elems, elem.Value.(*CounterElem))
+	}
+
+	// Try expiring this entry and assert it's not expired.
+	require.False(t, e.TryExpire(now))
+
+	// Try expiring the entry with time in the future and
+	// assert it's expired.
+	require.True(t, e.TryExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
+
+	// Assert elements have been tombstoned
+	require.Equal(t, 0, len(e.aggregations))
+	require.NotNil(t, e.aggregations)
+	require.Nil(t, e.lists)
+	for _, elem := range elems {
+		require.True(t, elem.tombstoned)
+	}
+}
+
+func TestShouldUpdatePoliciesWithLock(t *testing.T) {
+	e := NewEntry(nil, testOptions())
+
+	// If entry version is the init version, we should update.
+	currTime := time.Now()
+	cutover := currTime.Add(-time.Second)
+	require.True(t, e.shouldUpdatePoliciesWithLock(currTime, -100, cutover))
+
+	// If the current version is older than the incoming version,
+	// and we've surpassed the cutover, we should update the policies.
+	e.version = 2
+	require.True(t, e.shouldUpdatePoliciesWithLock(currTime, 3, cutover))
+
+	// Otherwise we shouldn't update.
+	require.False(t, e.shouldUpdatePoliciesWithLock(currTime, 2, cutover))
+	require.False(t, e.shouldUpdatePoliciesWithLock(currTime, 3, currTime.Add(time.Second)))
+}
+
+func testEntry() (*Entry, *metricLists, time.Time) {
+	now := time.Now()
+	clockOpts := clock.NewOptions().SetNowFn(func() time.Time {
+		return now
+	})
+	opts := testOptions().
+		SetClockOptions(clockOpts).
+		SetMinFlushInterval(0)
+
+	lists := newMetricLists(opts)
+	// This effectively disable flushing.
+	lists.newMetricListFn = func(res time.Duration, opts Options) *metricList {
+		return newMetricList(0, opts)
+	}
+
+	e := NewEntry(nil, opts)
+	e.ResetSetData(lists)
+
+	return e, lists, now
+}
+
+func populateTestAggregations(
+	t *testing.T,
+	e *Entry,
+	typ unaggregated.Type,
+) {
+	for _, policy := range testPolicies {
+		var (
+			newElem metricElem
+			testID  metric.ID
+		)
+		switch typ {
+		case unaggregated.CounterType:
+			newElem = e.opts.CounterElemPool().Get()
+			testID = testCounterID
+		case unaggregated.BatchTimerType:
+			newElem = e.opts.TimerElemPool().Get()
+			testID = testBatchTimerID
+		case unaggregated.GaugeType:
+			newElem = e.opts.GaugeElemPool().Get()
+			testID = testGaugeID
+		default:
+			require.Fail(t, fmt.Sprintf("unrecognized metric type: %v", typ))
+		}
+		newElem.ResetSetData(testID, policy)
+		list, err := e.lists.FindOrCreate(policy.Resolution().Window)
+		require.NoError(t, err)
+		newListElem, err := list.PushBack(newElem)
+		require.NoError(t, err)
+		e.aggregations[policy] = newListElem
+	}
+}
+
 func checkElemTombstoned(t *testing.T, elem metricElem, deleted map[policy.Policy]struct{}) {
 	switch elem := elem.(type) {
 	case *CounterElem:
@@ -173,6 +402,8 @@ func checkElemTombstoned(t *testing.T, elem metricElem, deleted map[policy.Polic
 func testEntryAddMetricWithPolicies(
 	t *testing.T,
 	newPoliciesVersion int,
+	withPrePopulation bool,
+	ownsID bool,
 	preAddFn testPreProcessFn,
 	postAddFn testPostProcessFn,
 	expectedPolicies []policy.Policy,
@@ -181,6 +412,8 @@ func testEntryAddMetricWithPolicies(
 		{
 			mu: testCounter,
 			fn: func(t *testing.T, elem *list.Element, alignedStart time.Time) {
+				id := elem.Value.(*CounterElem).ID()
+				require.Equal(t, testCounterID, id)
 				aggregations := elem.Value.(*CounterElem).values
 				require.Equal(t, 1, len(aggregations))
 				require.Equal(t, alignedStart.UnixNano(), aggregations[0].timeNs)
@@ -190,6 +423,8 @@ func testEntryAddMetricWithPolicies(
 		{
 			mu: testBatchTimer,
 			fn: func(t *testing.T, elem *list.Element, alignedStart time.Time) {
+				id := elem.Value.(*TimerElem).ID()
+				require.Equal(t, testBatchTimerID, id)
 				aggregations := elem.Value.(*TimerElem).values
 				require.Equal(t, 1, len(aggregations))
 				require.Equal(t, alignedStart.UnixNano(), aggregations[0].timeNs)
@@ -199,6 +434,8 @@ func testEntryAddMetricWithPolicies(
 		{
 			mu: testGauge,
 			fn: func(t *testing.T, elem *list.Element, alignedStart time.Time) {
+				id := elem.Value.(*GaugeElem).ID()
+				require.Equal(t, testGaugeID, id)
 				aggregations := elem.Value.(*GaugeElem).values
 				require.Equal(t, 1, len(aggregations))
 				require.Equal(t, alignedStart.UnixNano(), aggregations[0].timeNs)
@@ -208,9 +445,14 @@ func testEntryAddMetricWithPolicies(
 	}
 
 	for _, input := range inputs {
+		input.mu.OwnsID = ownsID
+
 		e, _, now := testEntry()
 		e.version = testPoliciesVersion
-		populateTestAggregations(t, e, input.mu.Type)
+
+		if withPrePopulation {
+			populateTestAggregations(t, e, input.mu.Type)
+		}
 
 		preAddFn(e)
 
@@ -236,131 +478,11 @@ func testEntryAddMetricWithPolicies(
 	}
 }
 
-func TestEntryAddMetricWithPoliciesNoPolicyUpdate(t *testing.T) {
-	var lists *metricLists
-	preAddFn := func(e *Entry) { lists = e.lists }
-	postAddFn := func(t *testing.T) {
-		require.Equal(t, 3, len(lists.lists))
-		for _, p := range testPolicies {
-			list, exists := lists.lists[p.Resolution().Window]
-			require.True(t, exists)
-			require.Equal(t, 1, list.aggregations.Len())
-			checkElemTombstoned(t, list.aggregations.Front().Value.(metricElem), nil)
-		}
-	}
-	testEntryAddMetricWithPolicies(t, testPoliciesVersion, preAddFn, postAddFn, testPolicies)
-}
+type testPreProcessFn func(e *Entry)
+type testElemValidateFn func(t *testing.T, elem *list.Element, alignedStart time.Time)
+type testPostProcessFn func(t *testing.T)
 
-func TestEntryAddMetricWithPoliciesWithPolicyUpdate(t *testing.T) {
-	var lists *metricLists
-	deletedPolicies := make(map[policy.Policy]struct{})
-	deletedPolicies[testPolicies[1]] = struct{}{}
-	deletedPolicies[testPolicies[2]] = struct{}{}
-
-	preAddFn := func(e *Entry) { lists = e.lists }
-	postAddFn := func(t *testing.T) {
-		require.Equal(t, 4, len(lists.lists))
-		expectedLengths := []int{1, 2, 1}
-		for _, policies := range [][]policy.Policy{testPolicies, testNewPolicies} {
-			for i := range policies {
-				list, exists := lists.lists[policies[i].Resolution().Window]
-				require.True(t, exists)
-				require.Equal(t, expectedLengths[i], list.aggregations.Len())
-				for elem := list.aggregations.Front(); elem != nil; elem = elem.Next() {
-					checkElemTombstoned(t, elem.Value.(metricElem), deletedPolicies)
-				}
-			}
-		}
-	}
-	testEntryAddMetricWithPolicies(t, testPoliciesVersion+1, preAddFn, postAddFn, testNewPolicies)
-}
-
-func TestEntryAddMetricsWithPolicyError(t *testing.T) {
-	e, lists, now := testEntry()
-	e.version = testPoliciesVersion
-	versionedPolicies := policy.CustomVersionedPolicies(
-		testPoliciesVersion+1,
-		now.Add(-time.Second),
-		testNewPolicies,
-	)
-
-	// Add an invalid metric should result in an error
-	require.Error(t, e.AddMetricWithPolicies(
-		testInvalidMetric,
-		versionedPolicies,
-	))
-
-	// Add a metric to a closed entry should result in an error
-	e.closed = true
-	require.Equal(t, errEntryClosed, e.AddMetricWithPolicies(
-		testCounter,
-		versionedPolicies,
-	))
-
-	// Add a metric with closed lists should result in an error
-	e.closed = false
-	lists.closed = true
-	require.Error(t, e.AddMetricWithPolicies(
-		testCounter,
-		versionedPolicies,
-	))
-}
-
-func TestEntryMaybeExpireNoExpiry(t *testing.T) {
-	e, _, now := testEntry()
-
-	// If we are still within entry TTL, should not expire
-	require.False(t, e.ShouldExpire(now.Add(e.opts.EntryTTL()).Add(-time.Second)))
-
-	// If the entry is closed, should not expire
-	e.closed = true
-	require.False(t, e.ShouldExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
-
-	// If there are still active writers, should not expire
-	e.closed = false
-	e.numWriters = 1
-	require.False(t, e.ShouldExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
-}
-
-func TestEntryMaybeExpireWithExpiry(t *testing.T) {
-	e, _, now := testEntry()
-	populateTestAggregations(t, e, unaggregated.CounterType)
-
-	var elems []*CounterElem
-	for _, elem := range e.aggregations {
-		elems = append(elems, elem.Value.(*CounterElem))
-	}
-
-	// Try expiring this entry and assert it's not expired
-	require.False(t, e.TryExpire(now))
-
-	// Try expiring the entry with time in the future and
-	// assert it's expired
-	require.True(t, e.TryExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
-
-	// Assert elements have been tombstoned
-	require.Equal(t, 0, len(e.aggregations))
-	require.NotNil(t, e.aggregations)
-	require.Nil(t, e.lists)
-	for _, elem := range elems {
-		require.True(t, elem.tombstoned)
-	}
-}
-
-func TestShouldUpdatePoliciesWithLock(t *testing.T) {
-	e := NewEntry(nil, testOptions())
-
-	// If entry version is the init version, we should update
-	currTime := time.Now()
-	cutover := currTime.Add(-time.Second)
-	require.True(t, e.shouldUpdatePoliciesWithLock(currTime, -100, cutover))
-
-	// If the current version is older than the incoming version,
-	// and we've surpassed the cutover, we should update the policies
-	e.version = 2
-	require.True(t, e.shouldUpdatePoliciesWithLock(currTime, 3, cutover))
-
-	// Otherwise we shouldn't update
-	require.False(t, e.shouldUpdatePoliciesWithLock(currTime, 2, cutover))
-	require.False(t, e.shouldUpdatePoliciesWithLock(currTime, 3, currTime.Add(time.Second)))
+type testEntryData struct {
+	mu unaggregated.MetricUnion
+	fn testElemValidateFn
 }

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -37,6 +37,188 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMetricListPushBack(t *testing.T) {
+	l := newMetricList(time.Second, testOptions())
+	elem := NewCounterElem(nil, policy.Policy{}, l.opts)
+
+	// Push a counter to the list
+	e, err := l.PushBack(elem)
+	require.NoError(t, err)
+	require.Equal(t, 1, l.aggregations.Len())
+	require.Equal(t, elem, e.Value.(*CounterElem))
+
+	// Push a counter to a closed list should result in an error.
+	l.Lock()
+	l.closed = true
+	l.Unlock()
+
+	_, err = l.PushBack(elem)
+	require.Equal(t, err, errListClosed)
+}
+
+func TestMetricListClose(t *testing.T) {
+	l := newMetricList(time.Second, testOptions())
+	l.RLock()
+	require.False(t, l.closed)
+	l.RUnlock()
+
+	l.Close()
+	require.True(t, l.closed)
+
+	// Close for a second time should have no impact.
+	l.Close()
+	require.True(t, l.closed)
+}
+
+func TestMetricListTick(t *testing.T) {
+	var (
+		bufferLock sync.Mutex
+		buffers    []msgpack.Buffer
+	)
+	flushFn := func(buffer msgpack.Buffer) error {
+		bufferLock.Lock()
+		buffers = append(buffers, buffer)
+		bufferLock.Unlock()
+		return nil
+	}
+	handler := &mockHandler{handleFn: flushFn}
+
+	var now = time.Unix(216, 0).UnixNano()
+	nowTs := time.Unix(0, now)
+	clockOpts := clock.NewOptions().SetNowFn(func() time.Time {
+		return time.Unix(0, atomic.LoadInt64(&now))
+	})
+	opts := testOptions().
+		SetClockOptions(clockOpts).
+		SetMinFlushInterval(0).
+		SetMaxFlushSize(100).
+		SetFlushHandler(handler)
+	l := newMetricList(0, opts)
+	l.resolution = testPolicy.Resolution().Window
+	l.waitForFn = func(time.Duration) <-chan time.Time {
+		c := make(chan time.Time)
+		close(c)
+		return c
+	}
+
+	// Intentionally cause a one-time error during encoding.
+	var count int
+	l.encodeFn = func(mp aggregated.ChunkedMetricWithPolicy) error {
+		if count == 0 {
+			count++
+			return errors.New("foo")
+		}
+		return l.encoder.EncodeChunkedMetricWithPolicy(mp)
+	}
+
+	elemPairs := []testElemPair{
+		{
+			elem:   NewCounterElem(testCounterID, testPolicy, opts),
+			metric: testCounter,
+		},
+		{
+			elem:   NewTimerElem(testBatchTimerID, testPolicy, opts),
+			metric: testBatchTimer,
+		},
+		{
+			elem:   NewGaugeElem(testGaugeID, testPolicy, opts),
+			metric: testGauge,
+		},
+	}
+	for _, ep := range elemPairs {
+		require.NoError(t, ep.elem.AddMetric(nowTs, ep.metric))
+		require.NoError(t, ep.elem.AddMetric(nowTs.Add(testPolicy.Resolution().Window), ep.metric))
+		_, err := l.PushBack(ep.elem)
+		require.NoError(t, err)
+	}
+
+	// Force a tick.
+	l.tickInternal()
+
+	// Assert nothing has been collected.
+	bufferLock.Lock()
+	require.Equal(t, 0, len(buffers))
+	bufferLock.Unlock()
+
+	for i := 0; i < 2; i++ {
+		// Move the time forward by one aggregation interval.
+		nowTs = nowTs.Add(testPolicy.Resolution().Window)
+		atomic.StoreInt64(&now, nowTs.UnixNano())
+
+		// Force a tick.
+		l.tickInternal()
+
+		var expected []testAggMetric
+		alignedStart := nowTs.Truncate(testPolicy.Resolution().Window)
+		expected = append(expected, expectedAggMetricsForCounter(alignedStart, testPolicy)...)
+		expected = append(expected, expectedAggMetricsForTimer(alignedStart, testPolicy)...)
+		expected = append(expected, expectedAggMetricsForGauge(alignedStart, testPolicy)...)
+
+		// Skip the first item because we intentionally triggered
+		// an encoder error when encoding the first item.
+		if i == 0 {
+			expected = expected[1:]
+		}
+
+		bufferLock.Lock()
+		require.NotNil(t, buffers)
+		validateBuffers(t, expected, buffers)
+		buffers = buffers[:0]
+		bufferLock.Unlock()
+	}
+
+	// Move the time forward by one aggregation interval.
+	nowTs = nowTs.Add(testPolicy.Resolution().Window)
+	atomic.StoreInt64(&now, nowTs.UnixNano())
+
+	// Force a tick.
+	l.tickInternal()
+
+	// Assert nothing has been collected.
+	bufferLock.Lock()
+	require.Equal(t, 0, len(buffers))
+	bufferLock.Unlock()
+	require.Equal(t, 3, l.aggregations.Len())
+
+	// Mark all elements as tombstoned.
+	for e := l.aggregations.Front(); e != nil; e = e.Next() {
+		e.Value.(metricElem).MarkAsTombstoned()
+	}
+
+	// Force a tick.
+	l.tickInternal()
+
+	// Assert all elements have been collected.
+	require.Equal(t, 0, l.aggregations.Len())
+}
+
+func TestMetricLists(t *testing.T) {
+	lists := newMetricLists(testOptions())
+	require.False(t, lists.closed)
+
+	// Create a new list.
+	l, err := lists.FindOrCreate(time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, l)
+	require.Equal(t, 1, lists.Len())
+
+	// Find the same list.
+	l2, err := lists.FindOrCreate(time.Second)
+	require.NoError(t, err)
+	require.Equal(t, l, l2)
+	require.Equal(t, 1, lists.Len())
+
+	// Finding or creating in a closed list should result in an error.
+	lists.Close()
+	_, err = lists.FindOrCreate(time.Second)
+	require.Equal(t, errListsClosed, err)
+	require.True(t, lists.closed)
+
+	// Closing a second time should have no impact.
+	lists.Close()
+	require.True(t, lists.closed)
+}
+
 type testElemPair struct {
 	elem   metricElem
 	metric unaggregated.MetricUnion
@@ -75,188 +257,6 @@ func validateBuffers(
 		require.Equal(t, expected[i].value, decoded[i].Value)
 		require.Equal(t, expected[i].policy, decoded[i].Policy)
 	}
-}
-
-func TestMetricListPushBack(t *testing.T) {
-	l := newMetricList(time.Second, testOptions())
-	elem := NewCounterElem(nil, policy.Policy{}, l.opts)
-
-	// Push a counter to the list
-	e, err := l.PushBack(elem)
-	require.NoError(t, err)
-	require.Equal(t, 1, l.aggregations.Len())
-	require.Equal(t, elem, e.Value.(*CounterElem))
-
-	// Push a counter to a closed list should result in an error
-	l.Lock()
-	l.closed = true
-	l.Unlock()
-
-	_, err = l.PushBack(elem)
-	require.Equal(t, err, errListClosed)
-}
-
-func TestMetricListClose(t *testing.T) {
-	l := newMetricList(time.Second, testOptions())
-	l.RLock()
-	require.False(t, l.closed)
-	l.RUnlock()
-
-	l.Close()
-	require.True(t, l.closed)
-
-	// Close for a second time should have no impact
-	l.Close()
-	require.True(t, l.closed)
-}
-
-func TestMetricListTick(t *testing.T) {
-	var (
-		bufferLock sync.Mutex
-		buffers    []msgpack.Buffer
-	)
-	flushFn := func(buffer msgpack.Buffer) error {
-		bufferLock.Lock()
-		buffers = append(buffers, buffer)
-		bufferLock.Unlock()
-		return nil
-	}
-	handler := &mockHandler{handleFn: flushFn}
-
-	var now = time.Unix(216, 0).UnixNano()
-	nowTs := time.Unix(0, now)
-	clockOpts := clock.NewOptions().SetNowFn(func() time.Time {
-		return time.Unix(0, atomic.LoadInt64(&now))
-	})
-	opts := testOptions().
-		SetClockOptions(clockOpts).
-		SetMinFlushInterval(0).
-		SetMaxFlushSize(100).
-		SetFlushHandler(handler)
-	l := newMetricList(0, opts)
-	l.resolution = testPolicy.Resolution().Window
-	l.waitForFn = func(time.Duration) <-chan time.Time {
-		c := make(chan time.Time)
-		close(c)
-		return c
-	}
-
-	// Intentionally cause a one-time error during encoding
-	var count int
-	l.encodeFn = func(mp aggregated.ChunkedMetricWithPolicy) error {
-		if count == 0 {
-			count++
-			return errors.New("foo")
-		}
-		return l.encoder.EncodeChunkedMetricWithPolicy(mp)
-	}
-
-	elemPairs := []testElemPair{
-		{
-			elem:   NewCounterElem(testID, testPolicy, opts),
-			metric: testCounter,
-		},
-		{
-			elem:   NewTimerElem(testID, testPolicy, opts),
-			metric: testBatchTimer,
-		},
-		{
-			elem:   NewGaugeElem(testID, testPolicy, opts),
-			metric: testGauge,
-		},
-	}
-	for _, ep := range elemPairs {
-		require.NoError(t, ep.elem.AddMetric(nowTs, ep.metric))
-		require.NoError(t, ep.elem.AddMetric(nowTs.Add(testPolicy.Resolution().Window), ep.metric))
-		_, err := l.PushBack(ep.elem)
-		require.NoError(t, err)
-	}
-
-	// Force a tick
-	l.tickInternal()
-
-	// Assert nothing has been collected
-	bufferLock.Lock()
-	require.Equal(t, 0, len(buffers))
-	bufferLock.Unlock()
-
-	for i := 0; i < 2; i++ {
-		// Move the time forward by one aggregation interval
-		nowTs = nowTs.Add(testPolicy.Resolution().Window)
-		atomic.StoreInt64(&now, nowTs.UnixNano())
-
-		// Force a tick
-		l.tickInternal()
-
-		var expected []testAggMetric
-		alignedStart := nowTs.Truncate(testPolicy.Resolution().Window)
-		expected = append(expected, expectedAggMetricsForCounter(alignedStart, testPolicy)...)
-		expected = append(expected, expectedAggMetricsForTimer(alignedStart, testPolicy)...)
-		expected = append(expected, expectedAggMetricsForGauge(alignedStart, testPolicy)...)
-
-		// Skip the first item because we intentionally triggered
-		// an encoder error when encoding the first item
-		if i == 0 {
-			expected = expected[1:]
-		}
-
-		bufferLock.Lock()
-		require.NotNil(t, buffers)
-		validateBuffers(t, expected, buffers)
-		buffers = buffers[:0]
-		bufferLock.Unlock()
-	}
-
-	// Move the time forward by one aggregation interval
-	nowTs = nowTs.Add(testPolicy.Resolution().Window)
-	atomic.StoreInt64(&now, nowTs.UnixNano())
-
-	// Force a tick
-	l.tickInternal()
-
-	// Assert nothing has been collected
-	bufferLock.Lock()
-	require.Equal(t, 0, len(buffers))
-	bufferLock.Unlock()
-	require.Equal(t, 3, l.aggregations.Len())
-
-	// Mark all elements as tombstoned
-	for e := l.aggregations.Front(); e != nil; e = e.Next() {
-		e.Value.(metricElem).MarkAsTombstoned()
-	}
-
-	// Force a tick
-	l.tickInternal()
-
-	// Assert all elements have been collected
-	require.Equal(t, 0, l.aggregations.Len())
-}
-
-func TestMetricLists(t *testing.T) {
-	lists := newMetricLists(testOptions())
-	require.False(t, lists.closed)
-
-	// Create a new list
-	l, err := lists.FindOrCreate(time.Second)
-	require.NoError(t, err)
-	require.NotNil(t, l)
-	require.Equal(t, 1, lists.Len())
-
-	// Find the same list
-	l2, err := lists.FindOrCreate(time.Second)
-	require.NoError(t, err)
-	require.Equal(t, l, l2)
-	require.Equal(t, 1, lists.Len())
-
-	// Finding or creating in a closed list should result in an error
-	lists.Close()
-	_, err = lists.FindOrCreate(time.Second)
-	require.Equal(t, errListsClosed, err)
-	require.True(t, lists.closed)
-
-	// Closing a second time should have no impact
-	lists.Close()
-	require.True(t, lists.closed)
 }
 
 type handleFn func(buffer msgpack.Buffer) error

--- a/aggregator/map_test.go
+++ b/aggregator/map_test.go
@@ -51,11 +51,11 @@ func TestMetricMapAddMetricWithPolicies(t *testing.T) {
 	m := newMetricMap(opts)
 	policies := testDefaultVersionedPolicies
 
-	// Add a counter metric and assert there is one entry afterwards
+	// Add a counter metric and assert there is one entry afterwards.
 	require.NoError(t, m.AddMetricWithPolicies(testCounter, policies))
 	require.Equal(t, 1, len(m.entries))
 	require.Equal(t, 1, m.entryList.Len())
-	idHash := id.HashFn(testID)
+	idHash := id.HashFn(testCounterID)
 	elem, exists := m.entries[idHash]
 	require.True(t, exists)
 	entry := elem.Value.(hashedEntry)
@@ -63,7 +63,7 @@ func TestMetricMapAddMetricWithPolicies(t *testing.T) {
 	require.Equal(t, idHash, entry.idHash)
 	require.Equal(t, 2, m.metricLists.Len())
 
-	// Add the same counter and assert there is still one entry
+	// Add the same counter and assert there is still one entry.
 	require.NoError(t, m.AddMetricWithPolicies(testCounter, policies))
 	require.Equal(t, 1, len(m.entries))
 	require.Equal(t, 1, m.entryList.Len())
@@ -74,7 +74,7 @@ func TestMetricMapAddMetricWithPolicies(t *testing.T) {
 	require.Equal(t, int32(0), atomic.LoadInt32(&entry2.entry.numWriters))
 	require.Equal(t, 2, m.metricLists.Len())
 
-	// Add a different metric and assert there are now two entries
+	// Add a different metric and assert there are now two entries.
 	require.NoError(t, m.AddMetricWithPolicies(
 		unaggregated.MetricUnion{
 			Type:     unaggregated.GaugeType,
@@ -119,7 +119,7 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 		return c
 	}
 
-	// Insert some live entries and some expired entries
+	// Insert some live entries and some expired entries.
 	numEntries := 100
 	for i := 0; i < numEntries; i++ {
 		idHash := id.HashFn([]byte(fmt.Sprintf("%d", i)))
@@ -136,10 +136,10 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 		}
 	}
 
-	// Delete expired entries
+	// Delete expired entries.
 	m.DeleteExpired(opts.EntryCheckInterval())
 
-	// Assert there should be only half of the entries left
+	// Assert there should be only half of the entries left.
 	require.Equal(t, numEntries/2, len(m.entries))
 	require.Equal(t, numEntries/2, m.entryList.Len())
 	require.True(t, len(waitIntervals) > 0)

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -73,22 +73,22 @@ msgpack:
     jitter: true
   iterator:
     ignoreHigherVersion: false
-    floatsPool:
+    readerBufferSize: 1440
+    largeFloatsSize: 1024
+    largeFloatsPool:
       buckets:
-        - count: 4096
-          capacity: 16
-        - count: 2048
-          capacity: 32
         - count: 1024
-          capacity: 16
-    policiesPool:
-      buckets:
-        - count: 8192
-          capacity: 2
-        - count: 4096
-          capacity: 4
-        - count: 1024
-          capacity: 8
+          capacity: 2048
+        - count: 512
+          capacity: 4096
+        - count: 256
+          capacity: 8192
+        - count: 128
+          capacity: 16384
+        - count: 64
+          capacity: 32768
+        - count: 32
+          capacity: 65536
     iteratorPool:
       size: 4096
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0fa87d980a617b0a4ac56ba5f9d880721b03e22e372c68b4029515216b7f6326
-updated: 2017-04-17T22:07:47.457248347-04:00
+hash: c41119bda665040ceed0ec9d96e5d7b0a0717a7af4b86e74d75353c032db5a59
+updated: 2017-04-23T10:14:53.339976301-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -16,7 +16,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/m3db/m3metrics
-  version: 27d28ef612e44438df96be220a466877797e9cc4
+  version: 98f9078734910857f6735191e5a850092cf2e57d
   subpackages:
   - generated/proto/schema
   - metric
@@ -45,8 +45,6 @@ imports:
   - difflib
 - name: github.com/prometheus/common
   version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
-  subpackages:
-  - log
 - name: github.com/Sirupsen/logrus
   version: cd7d1bbe41066b6c1f19780f895901052150a575
 - name: github.com/stretchr/testify
@@ -69,11 +67,6 @@ imports:
   - context
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
-  subpackages:
-  - unix
-  - windows
-  - windows/registry
-  - windows/svc/eventlog
 - name: google.golang.org/appengine
   version: 8758a385849434ba5eac8aeedcf5192c5a0f5f10
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c41119bda665040ceed0ec9d96e5d7b0a0717a7af4b86e74d75353c032db5a59
-updated: 2017-04-23T10:14:53.339976301-04:00
+hash: bef683ad41184b52605dfa3332b984ef902a1b44a833a79c8caf9c9f2eba1f08
+updated: 2017-04-23T19:14:33.40297527-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -16,7 +16,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/m3db/m3metrics
-  version: 98f9078734910857f6735191e5a850092cf2e57d
+  version: 053503305e8d1c46ea828d758bcde4b8b165558a
   subpackages:
   - generated/proto/schema
   - metric

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
 
 - package: github.com/m3db/m3metrics
-  version: 27d28ef612e44438df96be220a466877797e9cc4
+  version: 98f9078734910857f6735191e5a850092cf2e57d
 
 - package: github.com/m3db/m3x
   version: 0983ae8a74b716e37edd2675638dff80bf723e88

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
 
 - package: github.com/m3db/m3metrics
-  version: 98f9078734910857f6735191e5a850092cf2e57d
+  version: 053503305e8d1c46ea828d758bcde4b8b165558a
 
 - package: github.com/m3db/m3x
   version: 0983ae8a74b716e37edd2675638dff80bf723e88

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -21,7 +21,6 @@
 package msgpack
 
 import (
-	"bufio"
 	"io"
 	"net"
 	"sync"
@@ -186,7 +185,7 @@ func (s *server) handleConnection(conn net.Conn) {
 	}()
 
 	it := s.iteratorPool.Get()
-	it.Reset(bufio.NewReader(conn))
+	it.Reset(conn)
 	defer it.Close()
 
 	// Iterate over the incoming metrics stream and queue up metrics


### PR DESCRIPTION
cc @jeromefroe @cw9 @martin-mao 

This PR pulls in latest m3metrics PR (https://github.com/m3db/m3metrics/pull/35) and makes necessary changes to improve perf and memory utilization. The notable changes are:
* In normal cases when there are no policy changes, we reuse the same []byte in the unaggregated iterator for the metric id, therefore makes zero []byte allocation for ids. The only time when we need to create a new id is when there is a policy change, in which case we only make a copy if the id is not owned, and there are no existing reusable ids. 
* The policy slices are cached internally in the unaggregated iterator and are reused across metrics.
* The timer value []float64 slices are reused for non-large value slices (slices with no more than 1024 elements are considered non-large, the threshold is configurable). For large value slices, the unaggregated iterator will allocate it from the large floats pool, and the aggregator returns it to pool after adding all the values. 