### PR TITLE
Support custom aggregation types

### DIFF
--- a/aggregation/common.go
+++ b/aggregation/common.go
@@ -20,13 +20,26 @@
 
 package aggregation
 
-import "math"
+import (
+	"math"
 
-func stdev(count, sumSq, sum float64) float64 {
+	"github.com/m3db/m3metrics/policy"
+)
+
+func stdev(count int64, sumSq, sum float64) float64 {
 	div := count * (count - 1)
 	if div == 0 {
 		return 0.0
 	}
-	num := count*sumSq - math.Pow(sum, 2)
+	num := float64(count)*sumSq - sum*sum
 	return math.Sqrt(num / float64(div))
+}
+
+func isExpensive(aggTypes policy.AggregationTypes) bool {
+	for _, aggType := range aggTypes {
+		if aggType == policy.SumSq || aggType == policy.Stdev {
+			return true
+		}
+	}
+	return false
 }

--- a/aggregation/common_test.go
+++ b/aggregation/common_test.go
@@ -23,9 +23,19 @@ package aggregation
 import (
 	"testing"
 
+	"github.com/m3db/m3metrics/policy"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestStdev(t *testing.T) {
 	require.InDelta(t, 29.01149, stdev(100, 338350, 5050), 0.001)
+}
+
+func TestIsExpensive(t *testing.T) {
+	require.False(t, isExpensive(policy.AggregationTypes{}))
+	require.True(t, isExpensive(policy.AggregationTypes{policy.Sum, policy.SumSq}))
+	require.True(t, isExpensive(policy.AggregationTypes{policy.Stdev}))
+	require.False(t, isExpensive(policy.AggregationTypes{policy.Sum}))
+	require.False(t, isExpensive(policy.AggregationTypes{policy.Count, policy.P999}))
 }

--- a/aggregation/common_test.go
+++ b/aggregation/common_test.go
@@ -18,49 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package handler
+package aggregation
 
 import (
-	"io"
+	"testing"
 
-	"github.com/m3db/m3aggregator/aggregator"
-	"github.com/m3db/m3metrics/metric/aggregated"
-	"github.com/m3db/m3metrics/policy"
-	"github.com/m3db/m3metrics/protocol/msgpack"
+	"github.com/stretchr/testify/require"
 )
 
-// HandleFunc handles an aggregated metric alongside the policy.
-type HandleFunc func(metric aggregated.Metric, policy policy.StoragePolicy) error
-
-type decodingHandler struct {
-	handle HandleFunc
+func TestStdev(t *testing.T) {
+	require.InDelta(t, 29.01149, stdev(100, 338350, 5050), 0.001)
 }
-
-// NewDecodingHandler creates a new decoding handler with a custom handle function.
-func NewDecodingHandler(handle HandleFunc) aggregator.Handler {
-	return decodingHandler{handle: handle}
-}
-
-func (h decodingHandler) Handle(buffer msgpack.Buffer) error {
-	defer buffer.Close()
-
-	iter := msgpack.NewAggregatedIterator(buffer.Buffer(), msgpack.NewAggregatedIteratorOptions())
-	defer iter.Close()
-
-	for iter.Next() {
-		rawMetric, sp := iter.Value()
-		metric, err := rawMetric.Metric()
-		if err != nil {
-			return err
-		}
-		if err := h.handle(metric, sp); err != nil {
-			return err
-		}
-	}
-	if err := iter.Err(); err != nil && err != io.EOF {
-		return err
-	}
-	return nil
-}
-
-func (h decodingHandler) Close() {}

--- a/aggregation/counter.go
+++ b/aggregation/counter.go
@@ -20,25 +20,106 @@
 
 package aggregation
 
-import "sync"
+import (
+	"math"
+	"sync"
 
-var (
-	emptyCounter Counter
+	"github.com/m3db/m3metrics/policy"
 )
 
 // Counter aggregates counter values.
 type Counter struct {
-	sum int64 // Sum of the values received
+	Options
+
+	sum   int64
+	sumSq int64
+	count int64
+	max   int64
+	min   int64
 }
 
 // NewCounter creates a new counter.
-func NewCounter() Counter { return emptyCounter }
+func NewCounter(opts Options) Counter {
+	return Counter{
+		Options: opts,
+		max:     math.MinInt64,
+		min:     math.MaxInt64,
+	}
+}
 
-// Add adds a counter value.
-func (c *Counter) Add(value int64) { c.sum += value }
+// Update updates the counter value.
+func (c *Counter) Update(value int64) {
+	c.sum += value
+	if c.IsDefault {
+		return
+	}
+
+	c.count++
+	if c.max < value {
+		c.max = value
+	}
+	if c.min > value {
+		c.min = value
+	}
+
+	if c.IsExpensive {
+		c.sumSq += value * value
+	}
+}
+
+// Count returns the number of values received.
+func (c *Counter) Count() int64 { return c.count }
 
 // Sum returns the sum of counter values.
 func (c *Counter) Sum() int64 { return c.sum }
+
+// SumSq returns the squared sum of counter values.
+func (c *Counter) SumSq() int64 { return c.sumSq }
+
+// Mean returns the mean counter value.
+func (c *Counter) Mean() float64 {
+	if c.count == 0 {
+		return 0
+	}
+	return float64(c.sum) / float64(c.count)
+}
+
+// Stdev returns the standard deviation counter value.
+func (c *Counter) Stdev() float64 {
+	return stdev(float64(c.count), float64(c.sumSq), float64(c.sum))
+}
+
+// Min returns the minimum counter value.
+func (c *Counter) Min() int64 {
+	return c.min
+}
+
+// Max returns the maximum counter value.
+func (c *Counter) Max() int64 {
+	return c.max
+}
+
+// ValueOf returns the value for the aggregation type.
+func (c *Counter) ValueOf(aggType policy.AggregationType) float64 {
+	switch aggType {
+	case policy.Lower:
+		return float64(c.Min())
+	case policy.Upper:
+		return float64(c.Max())
+	case policy.Mean:
+		return c.Mean()
+	case policy.Count:
+		return float64(c.Count())
+	case policy.Sum:
+		return float64(c.Sum())
+	case policy.SumSq:
+		return float64(c.SumSq())
+	case policy.Stdev:
+		return c.Stdev()
+	default:
+		return 0
+	}
+}
 
 // LockedCounter is a locked counter.
 type LockedCounter struct {
@@ -47,7 +128,7 @@ type LockedCounter struct {
 }
 
 // NewLockedCounter creates a new locked counter.
-func NewLockedCounter() *LockedCounter { return &LockedCounter{} }
+func NewLockedCounter(c Counter) *LockedCounter { return &LockedCounter{Counter: c} }
 
 // Reset resets the locked counter.
-func (lc *LockedCounter) Reset() { lc.Counter = emptyCounter }
+func (lc *LockedCounter) Reset(c Counter) { lc.Counter = c }

--- a/aggregation/counter.go
+++ b/aggregation/counter.go
@@ -50,7 +50,7 @@ func NewCounter(opts Options) Counter {
 // Update updates the counter value.
 func (c *Counter) Update(value int64) {
 	c.sum += value
-	if c.IsDefault {
+	if c.UseDefaultAggregation {
 		return
 	}
 
@@ -62,7 +62,7 @@ func (c *Counter) Update(value int64) {
 		c.min = value
 	}
 
-	if c.IsExpensive {
+	if c.HasExpensiveAggregations {
 		c.sumSq += value * value
 	}
 }
@@ -86,18 +86,14 @@ func (c *Counter) Mean() float64 {
 
 // Stdev returns the standard deviation counter value.
 func (c *Counter) Stdev() float64 {
-	return stdev(float64(c.count), float64(c.sumSq), float64(c.sum))
+	return stdev(c.count, float64(c.sumSq), float64(c.sum))
 }
 
 // Min returns the minimum counter value.
-func (c *Counter) Min() int64 {
-	return c.min
-}
+func (c *Counter) Min() int64 { return c.min }
 
 // Max returns the maximum counter value.
-func (c *Counter) Max() int64 {
-	return c.max
-}
+func (c *Counter) Max() int64 { return c.max }
 
 // ValueOf returns the value for the aggregation type.
 func (c *Counter) ValueOf(aggType policy.AggregationType) float64 {

--- a/aggregation/counter_test.go
+++ b/aggregation/counter_test.go
@@ -23,13 +23,52 @@ package aggregation
 import (
 	"testing"
 
+	"github.com/m3db/m3metrics/policy"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCounter(t *testing.T) {
-	var c Counter
+func TestCounterDefaultAggregationType(t *testing.T) {
+	c := NewCounter(NewOptions())
 	for i := 1; i <= 100; i++ {
-		c.Add(int64(i))
+		c.Update(int64(i))
 	}
 	require.Equal(t, int64(5050), c.Sum())
+	require.Equal(t, float64(5050), c.ValueOf(policy.Sum))
+	require.Equal(t, float64(0), c.ValueOf(policy.Count))
+	require.Equal(t, float64(0), c.ValueOf(policy.Mean))
+}
+
+func TestCounterCustomAggregationType(t *testing.T) {
+	opts := NewOptions()
+	opts.IsDefault = false
+	opts.IsExpensive = true
+
+	c := NewCounter(opts)
+
+	for i := 1; i <= 100; i++ {
+		c.Update(int64(i))
+	}
+	require.Equal(t, int64(5050), c.Sum())
+	for aggType := range policy.ValidAggregationTypes {
+		v := c.ValueOf(aggType)
+		switch aggType {
+		case policy.Lower:
+			require.Equal(t, float64(1), v)
+		case policy.Upper:
+			require.Equal(t, float64(100), v)
+		case policy.Mean:
+			require.Equal(t, 50.5, v)
+		case policy.Count:
+			require.Equal(t, float64(100), v)
+		case policy.Sum:
+			require.Equal(t, float64(5050), v)
+		case policy.SumSq:
+			require.Equal(t, float64(338350), v)
+		case policy.Stdev:
+			require.InDelta(t, 29.01149, v, 0.001)
+		default:
+			require.Equal(t, float64(0), v)
+			require.False(t, aggType.IsValidForCounter())
+		}
+	}
 }

--- a/aggregation/counter_test.go
+++ b/aggregation/counter_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3metrics/policy"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,8 +41,8 @@ func TestCounterDefaultAggregationType(t *testing.T) {
 
 func TestCounterCustomAggregationType(t *testing.T) {
 	opts := NewOptions()
-	opts.IsDefault = false
-	opts.IsExpensive = true
+	opts.UseDefaultAggregation = false
+	opts.HasExpensiveAggregations = true
 
 	c := NewCounter(opts)
 

--- a/aggregation/gauge.go
+++ b/aggregation/gauge.go
@@ -20,25 +20,117 @@
 
 package aggregation
 
-import "sync"
+import (
+	"math"
+	"sync"
 
-var (
-	emptyGauge Gauge
+	"github.com/m3db/m3metrics/policy"
+)
+
+const (
+	minFloat64 = -math.MaxFloat64
 )
 
 // Gauge aggregates gauge values.
 type Gauge struct {
-	value float64 // latest value received
+	Options
+
+	last  float64
+	sum   float64
+	sumSq float64
+	count int64
+	max   float64
+	min   float64
 }
 
 // NewGauge creates a new gauge.
-func NewGauge() Gauge { return emptyGauge }
+func NewGauge(opts Options) Gauge {
+	return Gauge{
+		Options: opts,
+		max:     minFloat64,
+		min:     math.MaxFloat64,
+	}
+}
 
-// Set sets the gauge value.
-func (g *Gauge) Set(value float64) { g.value = value }
+// Update updates the gauge value.
+func (g *Gauge) Update(value float64) {
+	g.last = value
+	if g.IsDefault {
+		return
+	}
 
-// Value returns the latest value.
-func (g *Gauge) Value() float64 { return g.value }
+	g.sum += value
+	g.count++
+	if g.max < value {
+		g.max = value
+	}
+	if g.min > value {
+		g.min = value
+	}
+
+	if g.IsExpensive {
+		g.sumSq += value * value
+	}
+}
+
+// Last returns the last value received.
+func (g *Gauge) Last() float64 { return g.last }
+
+// Count returns the number of values received.
+func (g *Gauge) Count() int64 { return g.count }
+
+// Sum returns the sum of gauge values.
+func (g *Gauge) Sum() float64 { return g.sum }
+
+// SumSq returns the squared sum of gauge values.
+func (g *Gauge) SumSq() float64 { return g.sumSq }
+
+// Mean returns the mean gauge value.
+func (g *Gauge) Mean() float64 {
+	if g.count == 0 {
+		return 0.0
+	}
+	return g.sum / float64(g.count)
+}
+
+// Stdev returns the standard deviation gauge value.
+func (g *Gauge) Stdev() float64 {
+	return stdev(float64(g.count), g.sumSq, g.sum)
+}
+
+// Min returns the minimum gauge value.
+func (g *Gauge) Min() float64 {
+	return g.min
+}
+
+// Max returns the maximum gauge value.
+func (g *Gauge) Max() float64 {
+	return g.max
+}
+
+// ValueOf returns the value for the aggregation type.
+func (g *Gauge) ValueOf(aggType policy.AggregationType) float64 {
+	switch aggType {
+	case policy.Last:
+		return g.Last()
+	case policy.Lower:
+		return g.Min()
+	case policy.Upper:
+		return g.Max()
+	case policy.Mean:
+		return g.Mean()
+	case policy.Count:
+		return float64(g.Count())
+	case policy.Sum:
+		return g.Sum()
+	case policy.SumSq:
+		return g.SumSq()
+	case policy.Stdev:
+		return g.Stdev()
+	default:
+		return 0
+	}
+}
 
 // LockedGauge is a locked gauge.
 type LockedGauge struct {
@@ -47,7 +139,7 @@ type LockedGauge struct {
 }
 
 // NewLockedGauge creates a new locked gauge.
-func NewLockedGauge() *LockedGauge { return &LockedGauge{} }
+func NewLockedGauge(g Gauge) *LockedGauge { return &LockedGauge{Gauge: g} }
 
 // Reset resets the locked gauge.
-func (lg *LockedGauge) Reset() { lg.Gauge = emptyGauge }
+func (lg *LockedGauge) Reset(g Gauge) { lg.Gauge = g }

--- a/aggregation/gauge.go
+++ b/aggregation/gauge.go
@@ -55,7 +55,7 @@ func NewGauge(opts Options) Gauge {
 // Update updates the gauge value.
 func (g *Gauge) Update(value float64) {
 	g.last = value
-	if g.IsDefault {
+	if g.UseDefaultAggregation {
 		return
 	}
 
@@ -68,7 +68,7 @@ func (g *Gauge) Update(value float64) {
 		g.min = value
 	}
 
-	if g.IsExpensive {
+	if g.HasExpensiveAggregations {
 		g.sumSq += value * value
 	}
 }
@@ -95,18 +95,14 @@ func (g *Gauge) Mean() float64 {
 
 // Stdev returns the standard deviation gauge value.
 func (g *Gauge) Stdev() float64 {
-	return stdev(float64(g.count), g.sumSq, g.sum)
+	return stdev(g.count, g.sumSq, g.sum)
 }
 
 // Min returns the minimum gauge value.
-func (g *Gauge) Min() float64 {
-	return g.min
-}
+func (g *Gauge) Min() float64 { return g.min }
 
 // Max returns the maximum gauge value.
-func (g *Gauge) Max() float64 {
-	return g.max
-}
+func (g *Gauge) Max() float64 { return g.max }
 
 // ValueOf returns the value for the aggregation type.
 func (g *Gauge) ValueOf(aggType policy.AggregationType) float64 {

--- a/aggregation/gauge_test.go
+++ b/aggregation/gauge_test.go
@@ -23,13 +23,55 @@ package aggregation
 import (
 	"testing"
 
+	"github.com/m3db/m3metrics/policy"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGauge(t *testing.T) {
-	var g Gauge
-	for i := 1; i <= 100; i++ {
-		g.Set(float64(i))
+func TestGaugeDefaultAggregationType(t *testing.T) {
+	g := NewGauge(NewOptions())
+	for i := 1.0; i <= 100.0; i++ {
+		g.Update(i)
 	}
-	require.Equal(t, 100.0, g.Value())
+	require.Equal(t, 100.0, g.Last())
+	require.Equal(t, 100.0, g.ValueOf(policy.Last))
+	require.Equal(t, 0.0, g.ValueOf(policy.Count))
+	require.Equal(t, 0.0, g.ValueOf(policy.Mean))
+}
+
+func TestGaugeCustomAggregationType(t *testing.T) {
+	opts := NewOptions()
+	opts.IsDefault = false
+	opts.IsExpensive = true
+
+	g := NewGauge(opts)
+
+	for i := 1; i <= 100; i++ {
+		g.Update(float64(i))
+	}
+
+	require.Equal(t, 100.0, g.Last())
+	for aggType := range policy.ValidAggregationTypes {
+		v := g.ValueOf(aggType)
+		switch aggType {
+		case policy.Last:
+			require.Equal(t, float64(100), v)
+		case policy.Lower:
+			require.Equal(t, float64(1), v)
+		case policy.Upper:
+			require.Equal(t, float64(100), v)
+		case policy.Mean:
+			require.Equal(t, float64(50.5), v)
+		case policy.Count:
+			require.Equal(t, float64(100), v)
+		case policy.Sum:
+			require.Equal(t, float64(5050), v)
+		case policy.SumSq:
+			require.Equal(t, float64(338350), v)
+		case policy.Stdev:
+			require.InDelta(t, 29.01149, v, 0.001)
+		default:
+			require.Equal(t, float64(0), v)
+			require.False(t, aggType.IsValidForGauge())
+		}
+	}
 }

--- a/aggregation/gauge_test.go
+++ b/aggregation/gauge_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3metrics/policy"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,8 +41,8 @@ func TestGaugeDefaultAggregationType(t *testing.T) {
 
 func TestGaugeCustomAggregationType(t *testing.T) {
 	opts := NewOptions()
-	opts.IsDefault = false
-	opts.IsExpensive = true
+	opts.UseDefaultAggregation = false
+	opts.HasExpensiveAggregations = true
 
 	g := NewGauge(opts)
 

--- a/aggregation/options.go
+++ b/aggregation/options.go
@@ -23,16 +23,16 @@ package aggregation
 import "github.com/m3db/m3metrics/policy"
 
 var (
-	defaultOptions = Options{IsDefault: true, IsExpensive: false}
+	defaultOptions = Options{UseDefaultAggregation: true, HasExpensiveAggregations: false}
 )
 
 // Options is the options for aggregations.
 type Options struct {
-	// IsDefault means only default aggregation types are enabled.
-	IsDefault bool
-	// IsExpensive means expensive (multiplication／division)
+	// UseDefaultAggregation means only default aggregation types are enabled.
+	UseDefaultAggregation bool
+	// HasExpensiveAggregations means expensive (multiplication／division)
 	// aggregation types are enabled.
-	IsExpensive bool
+	HasExpensiveAggregations bool
 }
 
 // NewOptions creates a new aggregation options.
@@ -42,15 +42,6 @@ func NewOptions() Options {
 
 // ResetSetData resets the aggregation options.
 func (o *Options) ResetSetData(aggTypes policy.AggregationTypes) {
-	o.IsDefault = aggTypes.IsDefault()
-	o.IsExpensive = isExpensive(aggTypes)
-}
-
-func isExpensive(aggTypes policy.AggregationTypes) bool {
-	for _, aggType := range aggTypes {
-		if aggType == policy.SumSq || aggType == policy.Stdev {
-			return true
-		}
-	}
-	return false
+	o.UseDefaultAggregation = aggTypes.IsDefault()
+	o.HasExpensiveAggregations = isExpensive(aggTypes)
 }

--- a/aggregation/options_test.go
+++ b/aggregation/options_test.go
@@ -24,31 +24,24 @@ import (
 	"testing"
 
 	"github.com/m3db/m3metrics/policy"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestOptions(t *testing.T) {
 	o := NewOptions()
-	require.True(t, o.IsDefault)
-	require.False(t, o.IsExpensive)
+	require.True(t, o.UseDefaultAggregation)
+	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(nil)
-	require.True(t, o.IsDefault)
-	require.False(t, o.IsExpensive)
+	require.True(t, o.UseDefaultAggregation)
+	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(policy.AggregationTypes{policy.Sum})
-	require.False(t, o.IsDefault)
-	require.False(t, o.IsExpensive)
+	require.False(t, o.UseDefaultAggregation)
+	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(policy.AggregationTypes{policy.Sum, policy.SumSq})
-	require.False(t, o.IsDefault)
-	require.True(t, o.IsExpensive)
-}
-
-func TestIsExpensive(t *testing.T) {
-	require.False(t, isExpensive(policy.AggregationTypes{}))
-	require.True(t, isExpensive(policy.AggregationTypes{policy.Sum, policy.SumSq}))
-	require.True(t, isExpensive(policy.AggregationTypes{policy.Stdev}))
-	require.False(t, isExpensive(policy.AggregationTypes{policy.Sum}))
-	require.False(t, isExpensive(policy.AggregationTypes{policy.Count, policy.P999}))
+	require.False(t, o.UseDefaultAggregation)
+	require.True(t, o.HasExpensiveAggregations)
 }

--- a/aggregation/options_test.go
+++ b/aggregation/options_test.go
@@ -18,49 +18,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package handler
+package aggregation
 
 import (
-	"io"
+	"testing"
 
-	"github.com/m3db/m3aggregator/aggregator"
-	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/policy"
-	"github.com/m3db/m3metrics/protocol/msgpack"
+	"github.com/stretchr/testify/require"
 )
 
-// HandleFunc handles an aggregated metric alongside the policy.
-type HandleFunc func(metric aggregated.Metric, policy policy.StoragePolicy) error
+func TestOptions(t *testing.T) {
+	o := NewOptions()
+	require.True(t, o.IsDefault)
+	require.False(t, o.IsExpensive)
 
-type decodingHandler struct {
-	handle HandleFunc
+	o.ResetSetData(nil)
+	require.True(t, o.IsDefault)
+	require.False(t, o.IsExpensive)
+
+	o.ResetSetData(policy.AggregationTypes{policy.Sum})
+	require.False(t, o.IsDefault)
+	require.False(t, o.IsExpensive)
+
+	o.ResetSetData(policy.AggregationTypes{policy.Sum, policy.SumSq})
+	require.False(t, o.IsDefault)
+	require.True(t, o.IsExpensive)
 }
 
-// NewDecodingHandler creates a new decoding handler with a custom handle function.
-func NewDecodingHandler(handle HandleFunc) aggregator.Handler {
-	return decodingHandler{handle: handle}
+func TestIsExpensive(t *testing.T) {
+	require.False(t, isExpensive(policy.AggregationTypes{}))
+	require.True(t, isExpensive(policy.AggregationTypes{policy.Sum, policy.SumSq}))
+	require.True(t, isExpensive(policy.AggregationTypes{policy.Stdev}))
+	require.False(t, isExpensive(policy.AggregationTypes{policy.Sum}))
+	require.False(t, isExpensive(policy.AggregationTypes{policy.Count, policy.P999}))
 }
-
-func (h decodingHandler) Handle(buffer msgpack.Buffer) error {
-	defer buffer.Close()
-
-	iter := msgpack.NewAggregatedIterator(buffer.Buffer(), msgpack.NewAggregatedIteratorOptions())
-	defer iter.Close()
-
-	for iter.Next() {
-		rawMetric, sp := iter.Value()
-		metric, err := rawMetric.Metric()
-		if err != nil {
-			return err
-		}
-		if err := h.handle(metric, sp); err != nil {
-			return err
-		}
-	}
-	if err := iter.Err(); err != nil && err != io.EOF {
-		return err
-	}
-	return nil
-}
-
-func (h decodingHandler) Close() {}

--- a/aggregation/timer.go
+++ b/aggregation/timer.go
@@ -53,7 +53,7 @@ func (t *Timer) Add(value float64) {
 	t.sum += value
 	t.stream.Add(value)
 
-	if t.IsDefault || t.IsExpensive {
+	if t.UseDefaultAggregation || t.HasExpensiveAggregations {
 		t.sumSq += value * value
 	}
 }
@@ -102,7 +102,7 @@ func (t *Timer) Mean() float64 {
 
 // Stdev returns the standard deviation timer value.
 func (t *Timer) Stdev() float64 {
-	return stdev(float64(t.count), t.sumSq, t.sum)
+	return stdev(t.count, t.sumSq, t.sum)
 }
 
 // ValueOf returns the value for the aggregation type.

--- a/aggregation/timer.go
+++ b/aggregation/timer.go
@@ -53,7 +53,7 @@ func (t *Timer) Add(value float64) {
 	t.sum += value
 	t.stream.Add(value)
 
-	if t.UseDefaultAggregation || t.HasExpensiveAggregations {
+	if t.HasExpensiveAggregations {
 		t.sumSq += value * value
 	}
 }

--- a/aggregation/timer.go
+++ b/aggregation/timer.go
@@ -21,70 +21,78 @@
 package aggregation
 
 import (
-	"math"
 	"sync"
 
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
+	"github.com/m3db/m3metrics/policy"
 )
 
-// Timer aggregates timer values. Timer APIs are not thread-safe
+// Timer aggregates timer values. Timer APIs are not thread-safe.
 type Timer struct {
-	count  int64     // number of values received
-	sum    float64   // sum of the values
-	sumSq  float64   // sum of squared values
-	stream cm.Stream // stream of values received
+	Options
+
+	count  int64     // Number of values received.
+	sum    float64   // Sum of the values.
+	sumSq  float64   // Sum of squared values.
+	stream cm.Stream // Stream of values received.
 }
 
 // NewTimer creates a new timer
-func NewTimer(quantiles []float64, opts cm.Options) Timer {
-	stream := opts.StreamPool().Get()
+func NewTimer(quantiles []float64, streamOpts cm.Options, opts Options) Timer {
+	stream := streamOpts.StreamPool().Get()
 	stream.ResetSetData(quantiles)
-	return Timer{stream: stream}
+	return Timer{
+		Options: opts,
+		stream:  stream,
+	}
 }
 
-// Add adds a timer value
+// Add adds a timer value.
 func (t *Timer) Add(value float64) {
 	t.count++
 	t.sum += value
-	t.sumSq += value * value
 	t.stream.Add(value)
+
+	if t.IsDefault || t.IsExpensive {
+		t.sumSq += value * value
+	}
 }
 
-// AddBatch adds a batch of timer values
+// AddBatch adds a batch of timer values.
 func (t *Timer) AddBatch(values []float64) {
 	for _, v := range values {
 		t.Add(v)
 	}
 }
 
-// Quantile returns the value at a given quantile
+// Quantile returns the value at a given quantile.
 func (t *Timer) Quantile(q float64) float64 {
 	t.stream.Flush()
 	return t.stream.Quantile(q)
 }
 
-// Count returns the number of values received
+// Count returns the number of values received.
 func (t *Timer) Count() int64 { return t.count }
 
-// Min returns the minimum timer value
+// Min returns the minimum timer value.
 func (t *Timer) Min() float64 {
 	t.stream.Flush()
 	return t.stream.Min()
 }
 
-// Max returns the maximum timer value
+// Max returns the maximum timer value.
 func (t *Timer) Max() float64 {
 	t.stream.Flush()
 	return t.stream.Max()
 }
 
-// Sum returns the sum of timer values
+// Sum returns the sum of timer values.
 func (t *Timer) Sum() float64 { return t.sum }
 
-// SumSq returns the squared sum of timer values
+// SumSq returns the squared sum of timer values.
 func (t *Timer) SumSq() float64 { return t.sumSq }
 
-// Mean returns the mean timer value
+// Mean returns the mean timer value.
 func (t *Timer) Mean() float64 {
 	if t.count == 0 {
 		return 0.0
@@ -92,14 +100,34 @@ func (t *Timer) Mean() float64 {
 	return t.sum / float64(t.count)
 }
 
-// Stdev returns the standard deviation timer value
+// Stdev returns the standard deviation timer value.
 func (t *Timer) Stdev() float64 {
-	num := float64(t.count)*t.sumSq - t.sum*t.sum
-	div := t.count * (t.count - 1)
-	if div == 0 {
-		return 0.0
+	return stdev(float64(t.count), t.sumSq, t.sum)
+}
+
+// ValueOf returns the value for the aggregation type.
+func (t *Timer) ValueOf(aggType policy.AggregationType) float64 {
+	if q, ok := aggType.Quantile(); ok {
+		return t.Quantile(q)
 	}
-	return math.Sqrt(num / float64(div))
+
+	switch aggType {
+	case policy.Lower:
+		return t.Min()
+	case policy.Upper:
+		return t.Max()
+	case policy.Mean:
+		return t.Mean()
+	case policy.Count:
+		return float64(t.Count())
+	case policy.Sum:
+		return t.Sum()
+	case policy.SumSq:
+		return t.SumSq()
+	case policy.Stdev:
+		return t.Stdev()
+	}
+	return 0
 }
 
 // Close closes the timer

--- a/aggregation/timer_test.go
+++ b/aggregation/timer_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
+	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
 
 	"github.com/stretchr/testify/require"
@@ -42,13 +43,13 @@ func TestCreateTimerResetStream(t *testing.T) {
 
 	// Add a value to the timer and close the timer, which returns the
 	// underlying stream to the pool.
-	timer := NewTimer(testQuantiles, streamOpts)
+	timer := NewTimer(testQuantiles, streamOpts, NewOptions())
 	timer.Add(1.0)
 	require.Equal(t, 1.0, timer.Min())
 	timer.Close()
 
 	// Create a new timer and assert the underlying stream has been closed.
-	timer = NewTimer(testQuantiles, streamOpts)
+	timer = NewTimer(testQuantiles, streamOpts, NewOptions())
 	timer.Add(1.0)
 	require.Equal(t, 1.0, timer.Min())
 	timer.Close()
@@ -56,7 +57,7 @@ func TestCreateTimerResetStream(t *testing.T) {
 }
 
 func TestTimerAggregations(t *testing.T) {
-	timer := Timer{stream: cm.NewStream(testQuantiles, cm.NewOptions())}
+	timer := NewTimer(testQuantiles, cm.NewOptions(), NewOptions())
 
 	// Assert the state of an empty timer
 	require.Equal(t, int64(0), timer.Count())
@@ -87,6 +88,35 @@ func TestTimerAggregations(t *testing.T) {
 	require.True(t, timer.Quantile(0.95) >= 94 && timer.Quantile(0.95) <= 96)
 	require.True(t, timer.Quantile(0.99) >= 98 && timer.Quantile(0.99) <= 100)
 
+	for aggType := range policy.ValidAggregationTypes {
+		v := timer.ValueOf(aggType)
+		switch aggType {
+		case policy.Last:
+			require.Equal(t, 0.0, v)
+		case policy.Lower:
+			require.Equal(t, 1.0, v)
+		case policy.Upper:
+			require.Equal(t, 100.0, v)
+		case policy.Mean:
+			require.Equal(t, 50.5, v)
+		case policy.Median:
+			require.Equal(t, 50.0, v)
+		case policy.Count:
+			require.Equal(t, 100.0, v)
+		case policy.Sum:
+			require.Equal(t, 5050.0, v)
+		case policy.SumSq:
+			require.Equal(t, 338350.0, v)
+		case policy.Stdev:
+			require.InDelta(t, 29.01149, v, 0.001)
+		case policy.P50:
+			require.Equal(t, 50.0, v)
+		case policy.P95:
+			require.Equal(t, 95.0, v)
+		case policy.P99:
+			require.True(t, v >= 99 && v <= 100)
+		}
+	}
 	// Closing the timer should close the underlying stream
 	timer.Close()
 	require.Equal(t, 0.0, timer.stream.Quantile(0.5))

--- a/aggregation/timer_test.go
+++ b/aggregation/timer_test.go
@@ -57,7 +57,22 @@ func TestCreateTimerResetStream(t *testing.T) {
 }
 
 func TestTimerAggregations(t *testing.T) {
-	timer := NewTimer(testQuantiles, cm.NewOptions(), NewOptions())
+	opts := NewOptions()
+	opts.ResetSetData(policy.AggregationTypes{
+		policy.Sum,
+		policy.SumSq,
+		policy.Mean,
+		policy.Lower,
+		policy.Upper,
+		policy.Count,
+		policy.Stdev,
+		policy.Median,
+		policy.P50,
+		policy.P95,
+		policy.P99,
+	})
+
+	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)
 
 	// Assert the state of an empty timer
 	require.Equal(t, int64(0), timer.Count())

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -58,8 +58,8 @@ var (
 	}
 	testPoliciesList = policy.PoliciesList{
 		policy.NewStagedPolicies(123, false, []policy.Policy{
-			policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
-			policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+			policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+			policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), policy.DefaultAggregationID),
 		}),
 		policy.NewStagedPolicies(456, true, nil),
 	}

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -349,7 +349,7 @@ func (e *CounterElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *CounterElem) processValue(timeNanos int64, agg aggregation.Counter, fn aggMetricFn) {
-	if e.aggOpts.IsDefault {
+	if e.aggOpts.UseDefaultAggregation {
 		// No suffix for default aggregations.
 		fn(e.opts.FullCounterPrefix(), e.id, nil, timeNanos, float64(agg.Sum()), e.sp)
 		return
@@ -540,7 +540,7 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 func (e *TimerElem) processValue(timeNanos int64, agg aggregation.Timer, fn aggMetricFn) {
 	fullTimerPrefix := e.opts.FullTimerPrefix()
-	if e.aggOpts.IsDefault {
+	if e.aggOpts.UseDefaultAggregation {
 		var (
 			quantiles        = e.opts.TimerQuantiles()
 			quantileSuffixes = e.opts.TimerQuantileSuffixes()
@@ -718,7 +718,7 @@ func (e *GaugeElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *GaugeElem) processValue(timeNanos int64, agg aggregation.Gauge, fn aggMetricFn) {
-	if e.aggOpts.IsDefault {
+	if e.aggOpts.UseDefaultAggregation {
 		// No suffix for default aggregations.
 		fn(e.opts.FullGaugePrefix(), e.id, nil, timeNanos, agg.Last(), e.sp)
 		return

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -336,8 +336,7 @@ func (e *CounterElem) processValue(timeNanos int64, agg aggregation.Counter, fn 
 }
 
 // NB(cw) suffix overrides default suffixes to not add
-// suffix of aggregation type: Sum for Counter metrics
-// for backward compatibility reasons.
+// suffix for default Counter metrics for backward compatibility reasons.
 func (e *CounterElem) suffix(aggType policy.AggregationType) []byte {
 	if aggType == policy.Sum {
 		return nil
@@ -359,7 +358,7 @@ func NewTimerElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggregat
 func (e *TimerElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
 	if aggTypes.IsDefault() {
 		aggTypes = e.opts.DefaultTimerAggregationTypes()
-		e.quantiles = e.opts.TimerQuantiles()
+		e.quantiles, e.pooledQuantiles = e.opts.TimerQuantiles(), false
 	} else {
 		e.quantiles, e.pooledQuantiles = aggTypes.PooledQuantiles(e.opts.QuantilesPool())
 	}
@@ -694,8 +693,7 @@ func (e *GaugeElem) processValue(timeNanos int64, agg aggregation.Gauge, fn aggM
 }
 
 // NB(cw) suffix overrides default suffixes to not add
-// suffix of aggregation type: Last for Gauge metrics
-// for backward compatibility reasons.
+// suffix for default Gauge metrics for backward compatibility reasons.
 func (e *GaugeElem) suffix(aggType policy.AggregationType) []byte {
 	if aggType == policy.Last {
 		return nil

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -380,7 +380,7 @@ func (e *TimerElem) quantilesFromAggTypes(aggTypes policy.AggregationTypes) []fl
 	if aggTypes.IsDefault() {
 		return e.opts.TimerQuantiles()
 	}
-	return aggTypes.Quantiles(e.opts.QuantileFloatsPool())
+	return aggTypes.PooledQuantiles(e.opts.QuantileFloatsPool())
 }
 
 // AddMetric adds a new batch of timer values.

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -328,6 +328,7 @@ func (e *CounterElem) processValue(timeNanos int64, agg aggregation.Counter, fn 
 	var fullCounterPrefix = e.opts.FullCounterPrefix()
 	if e.aggOpts.UseDefaultAggregation {
 		// No suffix for default aggregations.
+		// TODO(cw) Make aggregation types for Counter configurable.
 		fn(fullCounterPrefix, e.id, e.suffix(policy.Sum), timeNanos, float64(agg.Sum()), e.sp)
 		return
 	}
@@ -361,11 +362,9 @@ func (e *TimerElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes 
 	if aggTypes.IsDefault() {
 		aggTypes = e.opts.DefaultTimerAggregationTypes()
 		e.isAggTypesPooled = false
-
 		e.quantiles, e.isQuantilesPooled = e.opts.TimerQuantiles(), false
 	} else {
 		e.isAggTypesPooled = true
-
 		e.quantiles, e.isQuantilesPooled = aggTypes.PooledQuantiles(e.opts.QuantilesPool())
 	}
 
@@ -702,6 +701,7 @@ func (e *GaugeElem) processValue(timeNanos int64, agg aggregation.Gauge, fn aggM
 	var fullGaugePrefix = e.opts.FullGaugePrefix()
 	if e.aggOpts.UseDefaultAggregation {
 		// No suffix for default aggregations.
+		// TODO(cw) Make aggregation types for Gauge configurable.
 		fn(fullGaugePrefix, e.id, e.suffix(policy.Last), timeNanos, agg.Last(), e.sp)
 		return
 	}

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -51,7 +51,7 @@ type aggMetricFn func(
 	idSuffix []byte,
 	timeNanos int64,
 	value float64,
-	policy policy.Policy,
+	sp policy.StoragePolicy,
 )
 
 type newMetricElemFn func() metricElem
@@ -61,8 +61,8 @@ type metricElem interface {
 	// ID returns the metric id.
 	ID() id.RawID
 
-	// ResetSetData resets the counter and sets data
-	ResetSetData(id id.RawID, policy policy.Policy)
+	// ResetSetData resets the element and sets data
+	ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes)
 
 	// AddMetric adds a new metric value
 	// TODO(xichen): a value union would suffice here
@@ -101,7 +101,9 @@ type elemBase struct {
 
 	opts       Options
 	id         id.RawID
-	policy     policy.Policy
+	sp         policy.StoragePolicy
+	aggTypes   policy.AggregationTypes
+	aggOpts    aggregation.Options
 	tombstoned bool
 	closed     bool
 }
@@ -118,6 +120,7 @@ type CounterElem struct {
 type TimerElem struct {
 	elemBase
 
+	quantiles []float64    // quantiles used in this timer element
 	values    []timedTimer // aggregated timers sorted by time in ascending order
 	toConsume []timedTimer
 }
@@ -130,10 +133,19 @@ type GaugeElem struct {
 	toConsume []timedGauge
 }
 
+func newElemBase(opts Options) elemBase {
+	return elemBase{
+		opts:    opts,
+		aggOpts: aggregation.NewOptions(),
+	}
+}
+
 // ResetSetData resets the counter and sets data.
-func (e *elemBase) ResetSetData(id id.RawID, policy policy.Policy) {
+func (e *elemBase) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
 	e.id = id
-	e.policy = policy
+	e.sp = sp
+	e.aggTypes = aggTypes
+	e.aggOpts.ResetSetData(aggTypes)
 	e.tombstoned = false
 	e.closed = false
 }
@@ -158,23 +170,52 @@ func (e *elemBase) MarkAsTombstoned() {
 	e.Unlock()
 }
 
+func (e *elemBase) suffix(aggType policy.AggregationType) []byte {
+	switch aggType {
+	case policy.Last:
+		return e.opts.AggregationLastSuffix()
+	case policy.Lower:
+		return e.opts.AggregationLowerSuffix()
+	case policy.Upper:
+		return e.opts.AggregationUpperSuffix()
+	case policy.Mean:
+		return e.opts.AggregationMeanSuffix()
+	case policy.Median:
+		return e.opts.AggregationMedianSuffix()
+	case policy.Count:
+		return e.opts.AggregationCountSuffix()
+	case policy.Sum:
+		return e.opts.AggregationSumSuffix()
+	case policy.SumSq:
+		return e.opts.AggregationSumSqSuffix()
+	case policy.Stdev:
+		return e.opts.AggregationStdevSuffix()
+	}
+	if q, ok := aggType.Quantile(); ok {
+		return e.opts.TimerQuantileSuffixFn()(q)
+	}
+	return nil
+}
+
 // NewCounterElem creates a new counter element
-func NewCounterElem(id id.RawID, policy policy.Policy, opts Options) *CounterElem {
-	return &CounterElem{
-		elemBase: elemBase{opts: opts, id: id, policy: policy},
+func NewCounterElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes, opts Options) *CounterElem {
+	e := &CounterElem{
+		elemBase: newElemBase(opts),
 		values:   make([]timedCounter, 0, defaultNumValues), // in most cases values will have two entries
 	}
+	e.ResetSetData(id, sp, aggTypes)
+	return e
 }
 
 // AddMetric adds a new counter value
 func (e *CounterElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error {
-	alignedStart := timestamp.Truncate(e.policy.Resolution().Window).UnixNano()
+	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	counter, err := e.findOrCreate(alignedStart)
 	if err != nil {
 		return err
 	}
 	counter.Lock()
-	counter.Add(mu.CounterVal)
+	counter.Update(mu.CounterVal)
 	counter.Unlock()
 	return nil
 }
@@ -208,7 +249,7 @@ func (e *CounterElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 
 	// Process the counters.
 	for i := range e.toConsume {
-		endAtNanos := e.toConsume[i].timeNanos + int64(e.policy.Resolution().Window)
+		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
 		e.toConsume[i].counter.Lock()
 		e.processValue(endAtNanos, e.toConsume[i].counter.Counter, fn)
 		e.toConsume[i].counter.Unlock()
@@ -230,9 +271,11 @@ func (e *CounterElem) Close() {
 	e.values = e.values[:0]
 	e.toConsume = e.toConsume[:0]
 	pool := e.opts.CounterElemPool()
+	aggTypesPool := e.opts.AggregationTypesPool()
 	e.Unlock()
 
 	pool.Put(e)
+	aggTypesPool.Put(e.aggTypes)
 }
 
 // findOrCreate finds the counter for a given time, or creates one
@@ -269,7 +312,7 @@ func (e *CounterElem) findOrCreate(alignedStart int64) (*aggregation.LockedCount
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 	e.values[idx] = timedCounter{
 		timeNanos: alignedStart,
-		counter:   aggregation.NewLockedCounter(),
+		counter:   aggregation.NewLockedCounter(aggregation.NewCounter(e.aggOpts)),
 	}
 	counter := e.values[idx].counter
 	e.Unlock()
@@ -306,20 +349,43 @@ func (e *CounterElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *CounterElem) processValue(timeNanos int64, agg aggregation.Counter, fn aggMetricFn) {
-	fn(e.opts.FullCounterPrefix(), e.id, nil, timeNanos, float64(agg.Sum()), e.policy)
-}
+	if e.aggOpts.IsDefault {
+		// No suffix for default aggregations.
+		fn(e.opts.FullCounterPrefix(), e.id, nil, timeNanos, float64(agg.Sum()), e.sp)
+		return
+	}
 
-// NewTimerElem creates a new timer element
-func NewTimerElem(id id.RawID, policy policy.Policy, opts Options) *TimerElem {
-	return &TimerElem{
-		elemBase: elemBase{opts: opts, id: id, policy: policy},
-		values:   make([]timedTimer, 0, defaultNumValues), // in most cases values will have two entries
+	for _, aggType := range e.aggTypes {
+		fn(e.opts.FullCounterPrefix(), e.id, e.suffix(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
 	}
 }
 
-// AddMetric adds a new batch of timer values
+// NewTimerElem creates a new timer element.
+func NewTimerElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes, opts Options) *TimerElem {
+	e := &TimerElem{
+		elemBase: newElemBase(opts),
+		values:   make([]timedTimer, 0, defaultNumValues), // in most cases values will have two entries
+	}
+	e.ResetSetData(id, sp, aggTypes)
+	return e
+}
+
+// ResetSetData overrides elemBase.ResetData, to include quantile update for timer elements.
+func (e *TimerElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
+	e.elemBase.ResetSetData(id, sp, aggTypes)
+	e.quantiles = e.quantilesFromAggTypes(aggTypes)
+}
+
+func (e *TimerElem) quantilesFromAggTypes(aggTypes policy.AggregationTypes) []float64 {
+	if aggTypes.IsDefault() {
+		return e.opts.TimerQuantiles()
+	}
+	return aggTypes.Quantiles(e.opts.QuantileFloatsPool())
+}
+
+// AddMetric adds a new batch of timer values.
 func (e *TimerElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error {
-	alignedStart := timestamp.Truncate(e.policy.Resolution().Window).UnixNano()
+	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	timer, err := e.findOrCreate(alignedStart)
 	if err != nil {
 		return err
@@ -332,7 +398,7 @@ func (e *TimerElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 
 // Consume processes values before a given time and discards
 // them afterwards, returning whether the element can be collected
-// after discarding the values
+// after discarding the values.
 func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	e.Lock()
 	if e.closed {
@@ -341,7 +407,7 @@ func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	}
 	idx := 0
 	for range e.values {
-		// Bail as soon as the timestamp is no later than the target time
+		// Bail as soon as the timestamp is no later than the target time.
 		if e.values[idx].timeNanos >= earlierThanNanos {
 			break
 		}
@@ -349,10 +415,10 @@ func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	}
 	e.toConsume = e.toConsume[:0]
 	if idx > 0 {
-		// Shift remaining values to the left and shrink the values slice
+		// Shift remaining values to the left and shrink the values slice.
 		e.toConsume = append(e.toConsume, e.values[:idx]...)
 		n := copy(e.values[0:], e.values[idx:])
-		// Clear out the invalid timer items to avoid holding onto the underlying streams
+		// Clear out the invalid timer items to avoid holding onto the underlying streams.
 		for i := n; i < len(e.values); i++ {
 			e.values[i] = emptyTimedTimer
 		}
@@ -363,7 +429,7 @@ func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 
 	// Process the timers.
 	for i := range e.toConsume {
-		endAtNanos := e.toConsume[i].timeNanos + int64(e.policy.Resolution().Window)
+		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
 		e.toConsume[i].timer.Lock()
 		e.processValue(endAtNanos, e.toConsume[i].timer.Timer, fn)
 		e.toConsume[i].timer.Unlock()
@@ -375,7 +441,7 @@ func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	return canCollect
 }
 
-// Close closes the timer element
+// Close closes the timer element.
 func (e *TimerElem) Close() {
 	e.Lock()
 	if e.closed {
@@ -392,9 +458,13 @@ func (e *TimerElem) Close() {
 	e.values = e.values[:0]
 	e.toConsume = e.toConsume[:0]
 	pool := e.opts.TimerElemPool()
+	aggTypesPool := e.opts.AggregationTypesPool()
+	quantileFloatsPool := e.opts.QuantileFloatsPool()
 	e.Unlock()
 
 	pool.Put(e)
+	aggTypesPool.Put(e.aggTypes)
+	quantileFloatsPool.Put(e.quantiles)
 }
 
 // findOrCreate finds the timer for a given time, or creates one
@@ -429,7 +499,7 @@ func (e *TimerElem) findOrCreate(alignedStart int64) (*aggregation.LockedTimer, 
 	numValues := len(e.values)
 	e.values = append(e.values, emptyTimedTimer)
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
-	newTimer := aggregation.NewTimer(e.opts.TimerQuantiles(), e.opts.StreamOptions())
+	newTimer := aggregation.NewTimer(e.opts.TimerQuantiles(), e.opts.StreamOptions(), e.aggOpts)
 	e.values[idx] = timedTimer{
 		timeNanos: alignedStart,
 		timer:     aggregation.NewLockedTimer(newTimer),
@@ -469,52 +539,53 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *TimerElem) processValue(timeNanos int64, agg aggregation.Timer, fn aggMetricFn) {
-	var (
-		fullTimerPrefix   = e.opts.FullTimerPrefix()
-		timerSumSuffix    = e.opts.TimerSumSuffix()
-		timerSumSqSuffix  = e.opts.TimerSumSqSuffix()
-		timerMeanSuffix   = e.opts.TimerMeanSuffix()
-		timerLowerSuffix  = e.opts.TimerLowerSuffix()
-		timerUpperSuffix  = e.opts.TimerUpperSuffix()
-		timerCountSuffix  = e.opts.TimerCountSuffix()
-		timerStdevSuffix  = e.opts.TimerStdevSuffix()
-		timerMedianSuffix = e.opts.TimerMedianSuffix()
-		quantiles         = e.opts.TimerQuantiles()
-		quantileSuffixes  = e.opts.TimerQuantileSuffixes()
-	)
-	fn(fullTimerPrefix, e.id, timerSumSuffix, timeNanos, agg.Sum(), e.policy)
-	fn(fullTimerPrefix, e.id, timerSumSqSuffix, timeNanos, agg.SumSq(), e.policy)
-	fn(fullTimerPrefix, e.id, timerMeanSuffix, timeNanos, agg.Mean(), e.policy)
-	fn(fullTimerPrefix, e.id, timerLowerSuffix, timeNanos, agg.Min(), e.policy)
-	fn(fullTimerPrefix, e.id, timerUpperSuffix, timeNanos, agg.Max(), e.policy)
-	fn(fullTimerPrefix, e.id, timerCountSuffix, timeNanos, float64(agg.Count()), e.policy)
-	fn(fullTimerPrefix, e.id, timerStdevSuffix, timeNanos, agg.Stdev(), e.policy)
-	for idx, q := range quantiles {
-		v := agg.Quantile(q)
-		if q == 0.5 {
-			fn(fullTimerPrefix, e.id, timerMedianSuffix, timeNanos, v, e.policy)
+	fullTimerPrefix := e.opts.FullTimerPrefix()
+	if e.aggOpts.IsDefault {
+		var (
+			quantiles        = e.opts.TimerQuantiles()
+			quantileSuffixes = e.opts.TimerQuantileSuffixes()
+		)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationSumSuffix(), timeNanos, agg.Sum(), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationSumSqSuffix(), timeNanos, agg.SumSq(), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationMeanSuffix(), timeNanos, agg.Mean(), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationLowerSuffix(), timeNanos, agg.Min(), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationUpperSuffix(), timeNanos, agg.Max(), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationCountSuffix(), timeNanos, float64(agg.Count()), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.AggregationStdevSuffix(), timeNanos, agg.Stdev(), e.sp)
+		for idx, q := range quantiles {
+			v := agg.Quantile(q)
+			if q == 0.5 {
+				fn(fullTimerPrefix, e.id, e.opts.AggregationMedianSuffix(), timeNanos, v, e.sp)
+			}
+			fn(fullTimerPrefix, e.id, quantileSuffixes[idx], timeNanos, v, e.sp)
 		}
-		fn(fullTimerPrefix, e.id, quantileSuffixes[idx], timeNanos, v, e.policy)
+		return
+	}
+
+	for _, aggType := range e.aggTypes {
+		fn(fullTimerPrefix, e.id, e.suffix(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
 	}
 }
 
 // NewGaugeElem creates a new gauge element
-func NewGaugeElem(id id.RawID, policy policy.Policy, opts Options) *GaugeElem {
-	return &GaugeElem{
-		elemBase: elemBase{opts: opts, id: id, policy: policy},
+func NewGaugeElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes, opts Options) *GaugeElem {
+	e := &GaugeElem{
+		elemBase: newElemBase(opts),
 		values:   make([]timedGauge, 0, defaultNumValues), // in most cases values will have two entries
 	}
+	e.ResetSetData(id, sp, aggTypes)
+	return e
 }
 
 // AddMetric adds a new gauge value
 func (e *GaugeElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error {
-	alignedStart := timestamp.Truncate(e.policy.Resolution().Window).UnixNano()
+	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	gauge, err := e.findOrCreate(alignedStart)
 	if err != nil {
 		return err
 	}
 	gauge.Lock()
-	gauge.Set(mu.GaugeVal)
+	gauge.Update(mu.GaugeVal)
 	gauge.Unlock()
 	return nil
 }
@@ -547,7 +618,7 @@ func (e *GaugeElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	e.Unlock()
 
 	for i := range e.toConsume {
-		endAtNanos := e.toConsume[i].timeNanos + int64(e.policy.Resolution().Window)
+		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
 		e.toConsume[i].gauge.Lock()
 		e.processValue(endAtNanos, e.toConsume[i].gauge.Gauge, fn)
 		e.toConsume[i].gauge.Unlock()
@@ -569,9 +640,11 @@ func (e *GaugeElem) Close() {
 	e.values = e.values[:0]
 	e.toConsume = e.toConsume[:0]
 	pool := e.opts.GaugeElemPool()
+	aggTypesPool := e.opts.AggregationTypesPool()
 	e.Unlock()
 
 	pool.Put(e)
+	aggTypesPool.Put(e.aggTypes)
 }
 
 // findOrCreate finds the gauge for a given time, or creates one
@@ -608,7 +681,7 @@ func (e *GaugeElem) findOrCreate(alignedStart int64) (*aggregation.LockedGauge, 
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 	e.values[idx] = timedGauge{
 		timeNanos: alignedStart,
-		gauge:     aggregation.NewLockedGauge(),
+		gauge:     aggregation.NewLockedGauge(aggregation.NewGauge(e.aggOpts)),
 	}
 	gauge := e.values[idx].gauge
 	e.Unlock()
@@ -645,5 +718,13 @@ func (e *GaugeElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *GaugeElem) processValue(timeNanos int64, agg aggregation.Gauge, fn aggMetricFn) {
-	fn(e.opts.FullGaugePrefix(), e.id, nil, timeNanos, agg.Value(), e.policy)
+	if e.aggOpts.IsDefault {
+		// No suffix for default aggregations.
+		fn(e.opts.FullGaugePrefix(), e.id, nil, timeNanos, agg.Last(), e.sp)
+		return
+	}
+
+	for _, aggType := range e.aggTypes {
+		fn(e.opts.FullGaugePrefix(), e.id, e.suffix(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+	}
 }

--- a/aggregator/elem_pool_test.go
+++ b/aggregator/elem_pool_test.go
@@ -32,14 +32,14 @@ import (
 func TestCounterElemPool(t *testing.T) {
 	p := NewCounterElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *CounterElem {
-		return NewCounterElem(nil, policy.Policy{}, testOptions())
+		return NewCounterElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 	})
 
 	// Retrieve an element from the pool.
 	element := p.Get()
-	element.ResetSetData(testCounterID, testPolicy)
+	element.ResetSetData(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes)
 	require.Equal(t, testCounterID, element.id)
-	require.Equal(t, testPolicy, element.policy)
+	require.Equal(t, testStoragePolicy, element.sp)
 
 	// Put the element back to pool.
 	p.Put(element)
@@ -47,20 +47,20 @@ func TestCounterElemPool(t *testing.T) {
 	// Retrieve the element and assert it's the same element.
 	element = p.Get()
 	require.Equal(t, testCounterID, element.id)
-	require.Equal(t, testPolicy, element.policy)
+	require.Equal(t, testStoragePolicy, element.sp)
 }
 
 func TestTimerElemPool(t *testing.T) {
 	p := NewTimerElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *TimerElem {
-		return NewTimerElem(nil, policy.Policy{}, testOptions())
+		return NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 	})
 
 	// Retrieve an element from the pool.
 	element := p.Get()
-	element.ResetSetData(testBatchTimerID, testPolicy)
+	element.ResetSetData(testBatchTimerID, testStoragePolicy, policy.DefaultAggregationTypes)
 	require.Equal(t, testBatchTimerID, element.id)
-	require.Equal(t, testPolicy, element.policy)
+	require.Equal(t, testStoragePolicy, element.sp)
 
 	// Put the element back to pool.
 	p.Put(element)
@@ -68,20 +68,20 @@ func TestTimerElemPool(t *testing.T) {
 	// Retrieve the element and assert it's the same element.
 	element = p.Get()
 	require.Equal(t, testBatchTimerID, element.id)
-	require.Equal(t, testPolicy, element.policy)
+	require.Equal(t, testStoragePolicy, element.sp)
 }
 
 func TestGaugeElemPool(t *testing.T) {
 	p := NewGaugeElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *GaugeElem {
-		return NewGaugeElem(nil, policy.Policy{}, testOptions())
+		return NewGaugeElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 	})
 
 	// Retrieve an element from the pool.
 	element := p.Get()
-	element.ResetSetData(testGaugeID, testPolicy)
+	element.ResetSetData(testGaugeID, testStoragePolicy, policy.DefaultAggregationTypes)
 	require.Equal(t, testGaugeID, element.id)
-	require.Equal(t, testPolicy, element.policy)
+	require.Equal(t, testStoragePolicy, element.sp)
 
 	// Put the element back to pool.
 	p.Put(element)
@@ -89,5 +89,5 @@ func TestGaugeElemPool(t *testing.T) {
 	// Retrieve the element and assert it's the same element.
 	element = p.Get()
 	require.Equal(t, testGaugeID, element.id)
-	require.Equal(t, testPolicy, element.policy)
+	require.Equal(t, testStoragePolicy, element.sp)
 }

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -123,7 +123,7 @@ func TestCounterResetSetData(t *testing.T) {
 
 func TestTimerResetSetData(t *testing.T) {
 	te := NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, NewOptions())
-	require.False(t, te.pooledQuantiles)
+	require.False(t, te.isPooledQuantiles)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
 	te.ResetSetData(testBatchTimerID, sp, policy.AggregationTypes{policy.Upper, policy.P999})
@@ -136,7 +136,7 @@ func TestTimerResetSetData(t *testing.T) {
 	require.False(t, te.aggOpts.UseDefaultAggregation)
 	require.False(t, te.aggOpts.HasExpensiveAggregations)
 	require.Equal(t, []float64{0.999}, te.quantiles)
-	require.True(t, te.pooledQuantiles)
+	require.True(t, te.isPooledQuantiles)
 }
 
 func TestGaugeResetSetData(t *testing.T) {

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -36,11 +36,13 @@ import (
 )
 
 var (
-	testCounterID    = id.RawID("testCounter")
-	testBatchTimerID = id.RawID("testBatchTimer")
-	testGaugeID      = id.RawID("testGauge")
-	testPolicy       = policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour)
-	testTimestamps   = []time.Time{
+	testCounterID             = id.RawID("testCounter")
+	testBatchTimerID          = id.RawID("testBatchTimer")
+	testGaugeID               = id.RawID("testGauge")
+	testStoragePolicy         = policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour)
+	testAggregationTypes      = policy.AggregationTypes{policy.Mean, policy.Sum}
+	testTimerAggregationTypes = policy.AggregationTypes{policy.Mean, policy.P99}
+	testTimestamps            = []time.Time{
 		time.Unix(216, 0), time.Unix(217, 0), time.Unix(221, 0),
 	}
 	testAlignedStarts = []int64{
@@ -61,21 +63,100 @@ var (
 		ID:       testGaugeID,
 		GaugeVal: 123.456,
 	}
+	suffixMap = map[policy.AggregationType][]byte{
+		policy.Last:   []byte(".last"),
+		policy.Lower:  []byte(".lower"),
+		policy.Upper:  []byte(".upper"),
+		policy.Mean:   []byte(".mean"),
+		policy.Median: []byte(".median"),
+		policy.Count:  []byte(".count"),
+		policy.Sum:    []byte(".sum"),
+		policy.SumSq:  []byte(".sum_sq"),
+		policy.Stdev:  []byte(".stdev"),
+		policy.P10:    []byte(".p10"),
+		policy.P20:    []byte(".p20"),
+		policy.P30:    []byte(".p30"),
+		policy.P40:    []byte(".p40"),
+		policy.P50:    []byte(".p50"),
+		policy.P60:    []byte(".p60"),
+		policy.P70:    []byte(".p70"),
+		policy.P80:    []byte(".p80"),
+		policy.P90:    []byte(".p90"),
+		policy.P95:    []byte(".p95"),
+		policy.P99:    []byte(".p99"),
+		policy.P999:   []byte(".p999"),
+		policy.P9999:  []byte(".p9999"),
+	}
 )
+
+func TestElemSuffix(t *testing.T) {
+	e := newElemBase(NewOptions())
+	for aggType := range policy.ValidAggregationTypes {
+		require.Equal(t, expectSuffix(aggType), e.suffix(aggType))
+	}
+}
 
 func TestElemBaseID(t *testing.T) {
 	e := &elemBase{}
-	e.ResetSetData(testCounterID, testPolicy)
+	e.ResetSetData(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes)
 	require.Equal(t, testCounterID, e.ID())
 }
 
 func TestElemBaseResetSetData(t *testing.T) {
 	e := &elemBase{}
-	e.ResetSetData(testCounterID, testPolicy)
+	e.ResetSetData(testCounterID, testStoragePolicy, testAggregationTypes)
 	require.Equal(t, testCounterID, e.id)
-	require.Equal(t, testPolicy, e.policy)
+	require.Equal(t, testStoragePolicy, e.sp)
 	require.False(t, e.tombstoned)
 	require.False(t, e.closed)
+	require.False(t, e.aggOpts.IsDefault)
+	require.False(t, e.aggOpts.IsExpensive)
+}
+
+func TestCounterResetSetData(t *testing.T) {
+	ce := &CounterElem{}
+
+	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
+	ce.ResetSetData(testCounterID, sp, policy.AggregationTypes{policy.SumSq})
+
+	require.Equal(t, testCounterID, ce.id)
+	require.Equal(t, sp, ce.sp)
+	require.Equal(t, policy.AggregationTypes{policy.SumSq}, ce.aggTypes)
+	require.False(t, ce.tombstoned)
+	require.False(t, ce.closed)
+	require.False(t, ce.aggOpts.IsDefault)
+	require.True(t, ce.aggOpts.IsExpensive)
+}
+
+func TestTimerResetSetData(t *testing.T) {
+	te := NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, NewOptions())
+
+	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
+	te.ResetSetData(testBatchTimerID, sp, policy.AggregationTypes{policy.Upper, policy.P999})
+
+	require.Equal(t, testBatchTimerID, te.id)
+	require.Equal(t, sp, te.sp)
+	require.Equal(t, policy.AggregationTypes{policy.Upper, policy.P999}, te.aggTypes)
+	require.False(t, te.tombstoned)
+	require.False(t, te.closed)
+	require.False(t, te.aggOpts.IsDefault)
+	require.False(t, te.aggOpts.IsExpensive)
+	require.Equal(t, []float64{0.999}, te.quantiles)
+}
+
+func TestGaugeResetSetData(t *testing.T) {
+	ge := &GaugeElem{}
+
+	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
+	ge.ResetSetData(testGaugeID, sp, policy.DefaultAggregationTypes)
+
+	require.Equal(t, testGaugeID, ge.id)
+	require.Equal(t, sp, ge.sp)
+	require.Equal(t, policy.DefaultAggregationTypes, ge.aggTypes)
+	require.False(t, ge.tombstoned)
+	require.False(t, ge.closed)
+	require.True(t, ge.aggOpts.IsDefault)
+	require.False(t, ge.aggOpts.IsExpensive)
 }
 
 func TestElemBaseMarkAsTombStoned(t *testing.T) {
@@ -93,13 +174,14 @@ func TestElemBaseMarkAsTombStoned(t *testing.T) {
 }
 
 func TestCounterElemAddMetric(t *testing.T) {
-	e := NewCounterElem(testCounterID, testPolicy, testOptions())
+	e := NewCounterElem(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 
 	// Add a counter metric
 	require.NoError(t, e.AddMetric(testTimestamps[0], testCounter))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Sum())
+	require.Equal(t, int64(0), e.values[0].counter.Count())
 
 	// Add the counter metric at slightly different time
 	// but still within the same aggregation interval
@@ -107,6 +189,7 @@ func TestCounterElemAddMetric(t *testing.T) {
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, 2*testCounter.CounterVal, e.values[0].counter.Sum())
+	require.Equal(t, int64(0), e.values[0].counter.Count())
 
 	// Add the counter metric in the next aggregation interval
 	require.NoError(t, e.AddMetric(testTimestamps[2], testCounter))
@@ -115,14 +198,47 @@ func TestCounterElemAddMetric(t *testing.T) {
 		require.Equal(t, testAlignedStarts[i], e.values[i].timeNanos)
 	}
 	require.Equal(t, testCounter.CounterVal, e.values[1].counter.Sum())
+	require.Equal(t, int64(0), e.values[0].counter.Count())
 
 	// Adding the counter metric to a closed element results in an error
 	e.closed = true
 	require.Equal(t, errCounterElemClosed, e.AddMetric(testTimestamps[2], testCounter))
 }
 
-func TestCounterElemConsume(t *testing.T) {
-	e := testCounterElem()
+func TestCounterElemAddMetricWithCustomAggregation(t *testing.T) {
+	e := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypes, testOptions())
+
+	// Add a counter metric
+	require.NoError(t, e.AddMetric(testTimestamps[0], testCounter))
+	require.Equal(t, 1, len(e.values))
+	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
+	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Sum())
+	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Max())
+
+	// Add the counter metric at slightly different time
+	// but still within the same aggregation interval
+	require.NoError(t, e.AddMetric(testTimestamps[1], testCounter))
+	require.Equal(t, 1, len(e.values))
+	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
+	require.Equal(t, 2*testCounter.CounterVal, e.values[0].counter.Sum())
+	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Max())
+
+	// Add the counter metric in the next aggregation interval
+	require.NoError(t, e.AddMetric(testTimestamps[2], testCounter))
+	require.Equal(t, 2, len(e.values))
+	for i := 0; i < len(e.values); i++ {
+		require.Equal(t, testAlignedStarts[i], e.values[i].timeNanos)
+	}
+	require.Equal(t, testCounter.CounterVal, e.values[1].counter.Sum())
+	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Max())
+
+	// Adding the counter metric to a closed element results in an error
+	e.closed = true
+	require.Equal(t, errCounterElemClosed, e.AddMetric(testTimestamps[2], testCounter))
+}
+
+func TestCounterElemReadAndDiscard(t *testing.T) {
+	e := testCounterElem(policy.DefaultAggregationTypes)
 
 	// Read and discard values before an early-enough time
 	fn, res := testAggMetricFn()
@@ -133,13 +249,48 @@ func TestCounterElemConsume(t *testing.T) {
 	// Read and discard one value
 	fn, res = testAggMetricFn()
 	require.False(t, e.Consume(testAlignedStarts[1], fn))
-	require.Equal(t, expectedAggMetricsForCounter(testAlignedStarts[1], testPolicy), *res)
+	require.Equal(t, expectedAggMetricsForCounter(testAlignedStarts[1], testStoragePolicy, policy.DefaultAggregationTypes), *res)
 	require.Equal(t, 1, len(e.values))
 
 	// Read and discard all values
 	fn, res = testAggMetricFn()
 	require.False(t, e.Consume(testAlignedStarts[2], fn))
-	require.Equal(t, expectedAggMetricsForCounter(testAlignedStarts[2], testPolicy), *res)
+	require.Equal(t, expectedAggMetricsForCounter(testAlignedStarts[2], testStoragePolicy, policy.DefaultAggregationTypes), *res)
+	require.Equal(t, 0, len(e.values))
+
+	// Tombstone the element and discard all values
+	e.tombstoned = true
+	fn, res = testAggMetricFn()
+	require.True(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, 0, len(*res))
+	require.Equal(t, 0, len(e.values))
+
+	// Reading and discarding values from a closed element is no op
+	e.closed = true
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, 0, len(e.values))
+}
+
+func TestCounterElemReadAndDiscardWithCustomAggregation(t *testing.T) {
+	e := testCounterElem(testAggregationTypes)
+
+	// Read and discard values before an early-enough time
+	fn, res := testAggMetricFn()
+	require.False(t, e.Consume(0, fn))
+	require.Equal(t, 0, len(*res))
+	require.Equal(t, 2, len(e.values))
+
+	// Read and discard one value
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[1], fn))
+	require.Equal(t, expectedAggMetricsForCounter(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *res)
+	require.Equal(t, 1, len(e.values))
+
+	// Read and discard all values
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, expectedAggMetricsForCounter(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *res)
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values
@@ -157,7 +308,7 @@ func TestCounterElemConsume(t *testing.T) {
 }
 
 func TestCounterElemClose(t *testing.T) {
-	e := testCounterElem()
+	e := testCounterElem(policy.DefaultAggregationTypes)
 	require.False(t, e.closed)
 
 	// Closing the element
@@ -173,7 +324,7 @@ func TestCounterElemClose(t *testing.T) {
 }
 
 func TestCounterFindOrInsert(t *testing.T) {
-	e := NewCounterElem(testCounterID, testPolicy, testOptions())
+	e := NewCounterElem(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 	inputs := []int64{10, 10, 20, 10, 15}
 	expected := []testIndexData{
 		{index: 0, data: []int64{10}},
@@ -195,7 +346,7 @@ func TestCounterFindOrInsert(t *testing.T) {
 }
 
 func TestTimerElemAddMetric(t *testing.T) {
-	e := NewTimerElem(testBatchTimerID, testPolicy, testOptions())
+	e := NewTimerElem(testBatchTimerID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 
 	// Add a timer metric
 	require.NoError(t, e.AddMetric(testTimestamps[0], testBatchTimer))
@@ -244,7 +395,7 @@ func TestTimerElemConsume(t *testing.T) {
 
 	// Verify the pool is big enough to supply all the streams
 	opts := testOptions().SetStreamOptions(streamOpts)
-	e := testTimerElem(opts)
+	e := testTimerElem(policy.DefaultAggregationTypes, opts)
 	verifyStreamPoolSize(t, p, 0, numAlloc)
 
 	// Read and discard values before an early-enough time
@@ -256,13 +407,57 @@ func TestTimerElemConsume(t *testing.T) {
 	// Read and discard one value
 	fn, res = testAggMetricFn()
 	require.False(t, e.Consume(testAlignedStarts[1], fn))
-	require.Equal(t, expectedAggMetricsForTimer(testAlignedStarts[1], testPolicy), *res)
+	require.Equal(t, expectedAggMetricsForTimer(testAlignedStarts[1], testStoragePolicy, policy.DefaultAggregationTypes), *res)
 	require.Equal(t, 1, len(e.values))
 
 	// Read and discard all values
 	fn, res = testAggMetricFn()
 	require.False(t, e.Consume(testAlignedStarts[2], fn))
-	require.Equal(t, expectedAggMetricsForTimer(testAlignedStarts[2], testPolicy), *res)
+	require.Equal(t, expectedAggMetricsForTimer(testAlignedStarts[2], testStoragePolicy, policy.DefaultAggregationTypes), *res)
+	require.Equal(t, 0, len(e.values))
+
+	// Tombstone the element and discard all values
+	e.tombstoned = true
+	fn, res = testAggMetricFn()
+	require.True(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, 0, len(*res))
+	require.Equal(t, 0, len(e.values))
+
+	// Reading and discarding values from a closed element is no op
+	e.closed = true
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, 0, len(e.values))
+
+	// Verify the streams have been returned to pool
+	verifyStreamPoolSize(t, p, len(testAlignedStarts)-1, numAlloc)
+}
+
+func TestTimerElemReadAndDiscardWithCustomAggregation(t *testing.T) {
+	// Set up stream options
+	streamOpts, p, numAlloc := testStreamOptions(t, len(testAlignedStarts)-1)
+
+	// Verify the pool is big enough to supply all the streams
+	opts := testOptions().SetStreamOptions(streamOpts)
+	e := testTimerElem(testTimerAggregationTypes, opts)
+	verifyStreamPoolSize(t, p, 0, numAlloc)
+
+	// Read and discard values before an early-enough time
+	fn, res := testAggMetricFn()
+	require.False(t, e.Consume(0, fn))
+	require.Equal(t, 0, len(*res))
+	require.Equal(t, 2, len(e.values))
+
+	// Read and discard one value
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[1], fn))
+	require.Equal(t, expectedAggMetricsForTimer(testAlignedStarts[1], testStoragePolicy, testTimerAggregationTypes), *res)
+	require.Equal(t, 1, len(e.values))
+
+	// Read and discard all values
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, expectedAggMetricsForTimer(testAlignedStarts[2], testStoragePolicy, testTimerAggregationTypes), *res)
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values
@@ -288,7 +483,7 @@ func TestTimerElemClose(t *testing.T) {
 
 	// Verify the pool is big enough to supply all the streams
 	opts := testOptions().SetStreamOptions(streamOpts)
-	e := testTimerElem(opts)
+	e := testTimerElem(policy.DefaultAggregationTypes, opts)
 	verifyStreamPoolSize(t, p, 0, numAlloc)
 
 	require.False(t, e.closed)
@@ -309,7 +504,7 @@ func TestTimerElemClose(t *testing.T) {
 }
 
 func TestTimerFindOrInsert(t *testing.T) {
-	e := NewTimerElem(testBatchTimerID, testPolicy, testOptions())
+	e := NewTimerElem(testBatchTimerID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 	inputs := []int64{10, 10, 20, 10, 15}
 	expected := []testIndexData{
 		{index: 0, data: []int64{10}},
@@ -331,20 +526,22 @@ func TestTimerFindOrInsert(t *testing.T) {
 }
 
 func TestGaugeElemAddMetric(t *testing.T) {
-	e := NewGaugeElem(testGaugeID, testPolicy, testOptions())
+	e := NewGaugeElem(testGaugeID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 
 	// Add a gauge metric
 	require.NoError(t, e.AddMetric(testTimestamps[0], testGauge))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
-	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Value())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
+	require.Equal(t, 0.0, e.values[0].gauge.Mean())
 
 	// Add the gauge metric at slightly different time
 	// but still within the same aggregation interval
 	require.NoError(t, e.AddMetric(testTimestamps[1], testGauge))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
-	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Value())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
+	require.Equal(t, 0.0, e.values[0].gauge.Mean())
 
 	// Add the gauge metric in the next aggregation interval
 	require.NoError(t, e.AddMetric(testTimestamps[2], testGauge))
@@ -352,15 +549,49 @@ func TestGaugeElemAddMetric(t *testing.T) {
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].timeNanos)
 	}
-	require.Equal(t, testGauge.GaugeVal, e.values[1].gauge.Value())
+	require.Equal(t, testGauge.GaugeVal, e.values[1].gauge.Last())
+	require.Equal(t, 0.0, e.values[0].gauge.Mean())
 
 	// Adding the gauge metric to a closed element results in an error
 	e.closed = true
 	require.Equal(t, errGaugeElemClosed, e.AddMetric(testTimestamps[2], testGauge))
 }
 
-func TestGaugeElemConsume(t *testing.T) {
-	e := testGaugeElem()
+func TestGaugeElemAddMetricWithCustomAggregation(t *testing.T) {
+	e := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypes, testOptions())
+
+	// Add a gauge metric
+	require.NoError(t, e.AddMetric(testTimestamps[0], testGauge))
+	require.Equal(t, 1, len(e.values))
+	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Sum())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Mean())
+
+	// Add the gauge metric at slightly different time
+	// but still within the same aggregation interval
+	require.NoError(t, e.AddMetric(testTimestamps[1], testGauge))
+	require.Equal(t, 1, len(e.values))
+	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Max())
+
+	// Add the gauge metric in the next aggregation interval
+	require.NoError(t, e.AddMetric(testTimestamps[2], testGauge))
+	require.Equal(t, 2, len(e.values))
+	for i := 0; i < len(e.values); i++ {
+		require.Equal(t, testAlignedStarts[i], e.values[i].timeNanos)
+	}
+	require.Equal(t, testGauge.GaugeVal, e.values[1].gauge.Last())
+	require.Equal(t, testGauge.GaugeVal, e.values[1].gauge.Max())
+
+	// Adding the gauge metric to a closed element results in an error
+	e.closed = true
+	require.Equal(t, errGaugeElemClosed, e.AddMetric(testTimestamps[2], testGauge))
+}
+
+func TestGaugeElemReadAndDiscard(t *testing.T) {
+	e := testGaugeElem(policy.DefaultAggregationTypes)
 
 	// Read and discard values before an early-enough time
 	fn, res := testAggMetricFn()
@@ -371,13 +602,49 @@ func TestGaugeElemConsume(t *testing.T) {
 	// Read and discard one value
 	fn, res = testAggMetricFn()
 	require.False(t, e.Consume(testAlignedStarts[1], fn))
-	require.Equal(t, expectedAggMetricsForGauge(testAlignedStarts[1], testPolicy), *res)
+	require.Equal(t, expectedAggMetricsForGauge(testAlignedStarts[1], testStoragePolicy, policy.DefaultAggregationTypes), *res)
 	require.Equal(t, 1, len(e.values))
 
 	// Read and discard all values
 	fn, res = testAggMetricFn()
 	require.False(t, e.Consume(testAlignedStarts[2], fn))
-	require.Equal(t, expectedAggMetricsForGauge(testAlignedStarts[2], testPolicy), *res)
+	require.Equal(t, expectedAggMetricsForGauge(testAlignedStarts[2], testStoragePolicy, policy.DefaultAggregationTypes), *res)
+	require.Equal(t, 0, len(e.values))
+
+	// Tombstone the element and discard all values
+	e.tombstoned = true
+	fn, res = testAggMetricFn()
+	require.True(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, 0, len(*res))
+	require.Equal(t, 0, len(e.values))
+	require.Equal(t, 0, len(e.values))
+
+	// Reading and discarding values from a closed element is no op
+	e.closed = true
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, 0, len(e.values))
+}
+
+func TestGaugeElemReadAndDiscardWithCustomAggregation(t *testing.T) {
+	e := testGaugeElem(testAggregationTypes)
+
+	// Read and discard values before an early-enough time
+	fn, res := testAggMetricFn()
+	require.False(t, e.Consume(0, fn))
+	require.Equal(t, 0, len(*res))
+	require.Equal(t, 2, len(e.values))
+
+	// Read and discard one value
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[1], fn))
+	require.Equal(t, expectedAggMetricsForGauge(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *res)
+	require.Equal(t, 1, len(e.values))
+
+	// Read and discard all values
+	fn, res = testAggMetricFn()
+	require.False(t, e.Consume(testAlignedStarts[2], fn))
+	require.Equal(t, expectedAggMetricsForGauge(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *res)
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values
@@ -396,7 +663,7 @@ func TestGaugeElemConsume(t *testing.T) {
 }
 
 func TestGaugeElemClose(t *testing.T) {
-	e := testGaugeElem()
+	e := testGaugeElem(policy.DefaultAggregationTypes)
 	require.False(t, e.closed)
 
 	// Closing the element
@@ -412,7 +679,7 @@ func TestGaugeElemClose(t *testing.T) {
 }
 
 func TestGaugeFindOrInsert(t *testing.T) {
-	e := NewGaugeElem(testGaugeID, testPolicy, testOptions())
+	e := NewGaugeElem(testGaugeID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions())
 	inputs := []int64{10, 10, 20, 10, 15}
 	expected := []testIndexData{
 		{index: 0, data: []int64{10}},
@@ -439,8 +706,8 @@ type testIndexData struct {
 }
 
 type testSuffixAndValue struct {
-	suffix []byte
-	value  float64
+	aggType policy.AggregationType
+	value   float64
 }
 
 type testAggMetric struct {
@@ -449,7 +716,7 @@ type testAggMetric struct {
 	idSuffix  []byte
 	timeNanos int64
 	value     float64
-	policy    policy.Policy
+	sp        policy.StoragePolicy
 }
 
 type testAggMetricsByTimeAscending []testAggMetric
@@ -466,7 +733,7 @@ func testAggMetricFn() (aggMetricFn, *[]testAggMetric) {
 		idSuffix []byte,
 		timeNanos int64,
 		value float64,
-		policy policy.Policy,
+		sp policy.StoragePolicy,
 	) {
 		result = append(result, testAggMetric{
 			idPrefix:  idPrefix,
@@ -474,7 +741,7 @@ func testAggMetricFn() (aggMetricFn, *[]testAggMetric) {
 			idSuffix:  idSuffix,
 			timeNanos: timeNanos,
 			value:     value,
-			policy:    policy,
+			sp:        sp,
 		})
 	}, &result
 }
@@ -491,11 +758,11 @@ func testStreamOptions(t *testing.T, size int) (cm.Options, cm.StreamPool, *int)
 	return streamOpts, p, &numAlloc
 }
 
-func testCounterElem() *CounterElem {
-	e := NewCounterElem(testCounterID, testPolicy, testOptions())
+func testCounterElem(aggTypes policy.AggregationTypes) *CounterElem {
+	e := NewCounterElem(testCounterID, testStoragePolicy, aggTypes, testOptions())
 	for _, aligned := range testAlignedStarts[:len(testAlignedStarts)-1] {
-		counter := aggregation.NewLockedCounter()
-		counter.Add(testCounter.CounterVal)
+		counter := aggregation.NewLockedCounter(aggregation.NewCounter(e.aggOpts))
+		counter.Update(testCounter.CounterVal)
 		e.values = append(e.values, timedCounter{
 			timeNanos: aligned,
 			counter:   counter,
@@ -504,10 +771,10 @@ func testCounterElem() *CounterElem {
 	return e
 }
 
-func testTimerElem(opts Options) *TimerElem {
-	e := NewTimerElem(testBatchTimerID, testPolicy, opts)
+func testTimerElem(aggTypes policy.AggregationTypes, opts Options) *TimerElem {
+	e := NewTimerElem(testBatchTimerID, testStoragePolicy, aggTypes, opts)
 	for _, aligned := range testAlignedStarts[:len(testAlignedStarts)-1] {
-		newTimer := aggregation.NewTimer(opts.TimerQuantiles(), opts.StreamOptions())
+		newTimer := aggregation.NewTimer(opts.TimerQuantiles(), opts.StreamOptions(), e.aggOpts)
 		timer := aggregation.NewLockedTimer(newTimer)
 		timer.AddBatch(testBatchTimer.BatchTimerVal)
 		e.values = append(e.values, timedTimer{
@@ -518,11 +785,11 @@ func testTimerElem(opts Options) *TimerElem {
 	return e
 }
 
-func testGaugeElem() *GaugeElem {
-	e := NewGaugeElem(testGaugeID, testPolicy, testOptions())
+func testGaugeElem(aggTypes policy.AggregationTypes) *GaugeElem {
+	e := NewGaugeElem(testGaugeID, testStoragePolicy, aggTypes, testOptions())
 	for _, aligned := range testAlignedStarts[:len(testAlignedStarts)-1] {
-		gauge := aggregation.NewLockedGauge()
-		gauge.Set(testGauge.GaugeVal)
+		gauge := aggregation.NewLockedGauge(aggregation.NewGauge(e.aggOpts))
+		gauge.Update(testGauge.GaugeVal)
 		e.values = append(e.values, timedGauge{
 			timeNanos: aligned,
 			gauge:     gauge,
@@ -531,10 +798,29 @@ func testGaugeElem() *GaugeElem {
 	return e
 }
 
+func expectSuffix(aggType policy.AggregationType) []byte {
+	return suffixMap[aggType]
+}
+
 func expectedAggMetricsForCounter(
 	timeNanos int64,
-	policy policy.Policy,
+	sp policy.StoragePolicy,
+	aggTypes policy.AggregationTypes,
 ) []testAggMetric {
+	if !aggTypes.IsDefault() {
+		var res []testAggMetric
+		for _, aggType := range aggTypes {
+			res = append(res, testAggMetric{
+				idPrefix:  []byte("stats.counts."),
+				id:        testCounterID,
+				idSuffix:  expectSuffix(aggType),
+				timeNanos: timeNanos,
+				value:     float64(testCounter.CounterVal),
+				sp:        sp,
+			})
+		}
+		return res
+	}
 	return []testAggMetric{
 		{
 			idPrefix:  []byte("stats.counts."),
@@ -542,37 +828,57 @@ func expectedAggMetricsForCounter(
 			idSuffix:  nil,
 			timeNanos: timeNanos,
 			value:     float64(testCounter.CounterVal),
-			policy:    policy,
+			sp:        sp,
 		},
 	}
 }
 
 func expectedAggMetricsForTimer(
 	timeNanos int64,
-	policy policy.Policy,
+	sp policy.StoragePolicy,
+	aggTypes policy.AggregationTypes,
 ) []testAggMetric {
+	// this needs to be a list as the order of the result matters in some test
 	data := []testSuffixAndValue{
-		{[]byte(".sum"), 18.0},
-		{[]byte(".sum_sq"), 83.38},
-		{[]byte(".mean"), 3.6},
-		{[]byte(".lower"), 1.0},
-		{[]byte(".upper"), 6.5},
-		{[]byte(".count"), 5.0},
-		{[]byte(".stdev"), 2.15522620622523},
-		{[]byte(".median"), 3.5},
-		{[]byte(".p50"), 3.5},
-		{[]byte(".p95"), 6.5},
-		{[]byte(".p99"), 6.5},
+		{policy.Sum, 18.0},
+		{policy.SumSq, 83.38},
+		{policy.Mean, 3.6},
+		{policy.Lower, 1.0},
+		{policy.Upper, 6.5},
+		{policy.Count, 5.0},
+		{policy.Stdev, 2.15522620622523},
+		{policy.Median, 3.5},
+		{policy.P50, 3.5},
+		{policy.P95, 6.5},
+		{policy.P99, 6.5},
 	}
 	var expected []testAggMetric
+	if !aggTypes.IsDefault() {
+		for _, aggType := range aggTypes {
+			for _, d := range data {
+				if d.aggType == aggType {
+					expected = append(expected, testAggMetric{
+						idPrefix:  []byte("stats.timers."),
+						id:        testBatchTimerID,
+						idSuffix:  expectSuffix(aggType),
+						timeNanos: timeNanos,
+						value:     d.value,
+						sp:        sp,
+					})
+				}
+			}
+		}
+		return expected
+	}
+
 	for _, d := range data {
 		expected = append(expected, testAggMetric{
 			idPrefix:  []byte("stats.timers."),
 			id:        testBatchTimerID,
-			idSuffix:  d.suffix,
+			idSuffix:  expectSuffix(d.aggType),
 			timeNanos: timeNanos,
 			value:     d.value,
-			policy:    policy,
+			sp:        sp,
 		})
 	}
 	return expected
@@ -580,8 +886,23 @@ func expectedAggMetricsForTimer(
 
 func expectedAggMetricsForGauge(
 	timeNanos int64,
-	policy policy.Policy,
+	sp policy.StoragePolicy,
+	aggTypes policy.AggregationTypes,
 ) []testAggMetric {
+	if !aggTypes.IsDefault() {
+		var res []testAggMetric
+		for _, aggType := range aggTypes {
+			res = append(res, testAggMetric{
+				idPrefix:  []byte("stats.gauges."),
+				id:        testGaugeID,
+				idSuffix:  expectSuffix(aggType),
+				timeNanos: timeNanos,
+				value:     float64(testGauge.GaugeVal),
+				sp:        sp,
+			})
+		}
+		return res
+	}
 	return []testAggMetric{
 		{
 			idPrefix:  []byte("stats.gauges."),
@@ -589,7 +910,7 @@ func expectedAggMetricsForGauge(
 			idSuffix:  nil,
 			timeNanos: timeNanos,
 			value:     float64(testGauge.GaugeVal),
-			policy:    policy,
+			sp:        sp,
 		},
 	}
 }

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -123,7 +123,8 @@ func TestCounterResetSetData(t *testing.T) {
 
 func TestTimerResetSetData(t *testing.T) {
 	te := NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, NewOptions())
-	require.False(t, te.isPooledQuantiles)
+	require.False(t, te.isQuantilesPooled)
+	require.False(t, te.isAggTypesPooled)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
 	te.ResetSetData(testBatchTimerID, sp, policy.AggregationTypes{policy.Upper, policy.P999})
@@ -136,7 +137,8 @@ func TestTimerResetSetData(t *testing.T) {
 	require.False(t, te.aggOpts.UseDefaultAggregation)
 	require.False(t, te.aggOpts.HasExpensiveAggregations)
 	require.Equal(t, []float64{0.999}, te.quantiles)
-	require.True(t, te.isPooledQuantiles)
+	require.True(t, te.isQuantilesPooled)
+	require.True(t, te.isAggTypesPooled)
 }
 
 func TestGaugeResetSetData(t *testing.T) {

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -109,8 +109,8 @@ func TestElemBaseResetSetData(t *testing.T) {
 	require.Equal(t, testStoragePolicy, e.sp)
 	require.False(t, e.tombstoned)
 	require.False(t, e.closed)
-	require.False(t, e.aggOpts.IsDefault)
-	require.False(t, e.aggOpts.IsExpensive)
+	require.False(t, e.aggOpts.UseDefaultAggregation)
+	require.False(t, e.aggOpts.HasExpensiveAggregations)
 }
 
 func TestCounterResetSetData(t *testing.T) {
@@ -124,8 +124,8 @@ func TestCounterResetSetData(t *testing.T) {
 	require.Equal(t, policy.AggregationTypes{policy.SumSq}, ce.aggTypes)
 	require.False(t, ce.tombstoned)
 	require.False(t, ce.closed)
-	require.False(t, ce.aggOpts.IsDefault)
-	require.True(t, ce.aggOpts.IsExpensive)
+	require.False(t, ce.aggOpts.UseDefaultAggregation)
+	require.True(t, ce.aggOpts.HasExpensiveAggregations)
 }
 
 func TestTimerResetSetData(t *testing.T) {
@@ -139,8 +139,8 @@ func TestTimerResetSetData(t *testing.T) {
 	require.Equal(t, policy.AggregationTypes{policy.Upper, policy.P999}, te.aggTypes)
 	require.False(t, te.tombstoned)
 	require.False(t, te.closed)
-	require.False(t, te.aggOpts.IsDefault)
-	require.False(t, te.aggOpts.IsExpensive)
+	require.False(t, te.aggOpts.UseDefaultAggregation)
+	require.False(t, te.aggOpts.HasExpensiveAggregations)
 	require.Equal(t, []float64{0.999}, te.quantiles)
 }
 
@@ -155,8 +155,8 @@ func TestGaugeResetSetData(t *testing.T) {
 	require.Equal(t, policy.DefaultAggregationTypes, ge.aggTypes)
 	require.False(t, ge.tombstoned)
 	require.False(t, ge.closed)
-	require.True(t, ge.aggOpts.IsDefault)
-	require.False(t, ge.aggOpts.IsExpensive)
+	require.True(t, ge.aggOpts.UseDefaultAggregation)
+	require.False(t, ge.aggOpts.HasExpensiveAggregations)
 }
 
 func TestElemBaseMarkAsTombStoned(t *testing.T) {

--- a/aggregator/handler/logging.go
+++ b/aggregator/handler/logging.go
@@ -31,18 +31,18 @@ import (
 func logMetricAndPolicy(
 	logger xlog.Logger,
 	metric aggregated.Metric,
-	policy policy.Policy,
+	sp policy.StoragePolicy,
 ) error {
 	logger.WithFields(
 		xlog.NewLogField("metric", metric.String()),
-		xlog.NewLogField("policy", policy.String()),
+		xlog.NewLogField("policy", sp.String()),
 	).Info("aggregated metric")
 	return nil
 }
 
 func loggingHandler(logger xlog.Logger) HandleFunc {
-	return func(metric aggregated.Metric, policy policy.Policy) error {
-		return logMetricAndPolicy(logger, metric, policy)
+	return func(metric aggregated.Metric, sp policy.StoragePolicy) error {
+		return logMetricAndPolicy(logger, metric, sp)
 	}
 }
 

--- a/aggregator/map_test.go
+++ b/aggregator/map_test.go
@@ -42,9 +42,9 @@ var (
 			time.Now().UnixNano(),
 			false,
 			[]policy.Policy{
-				policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
-				policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
-				policy.NewPolicy(10*time.Minute, xtime.Minute, 30*24*time.Hour),
+				policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+				policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), policy.DefaultAggregationID),
+				policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 30*24*time.Hour), policy.DefaultAggregationID),
 			},
 		),
 	}

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -126,7 +126,7 @@ type options struct {
 	fullCounterPrefix []byte
 	fullTimerPrefix   []byte
 	fullGaugePrefix   []byte
-	suffixSlice       [][]byte
+	suffixes          [][]byte
 }
 
 // NewOptions create a new set of options.
@@ -581,7 +581,7 @@ func (o *options) DefaultTimerAggregationSuffixes() [][]byte {
 }
 
 func (o *options) Suffix(aggType policy.AggregationType) []byte {
-	return o.suffixSlice[aggType.ID()]
+	return o.suffixes[aggType.ID()]
 }
 
 func (o *options) initPools() {
@@ -637,32 +637,32 @@ func (o *options) computeQuantiles() {
 }
 
 func (o *options) computeSuffixes() {
-	o.suffixSlice = make([][]byte, policy.MaxAggregationTypeID+1)
+	o.suffixes = make([][]byte, policy.MaxAggregationTypeID+1)
 
 	for aggType := range policy.ValidAggregationTypes {
 		switch aggType {
 		case policy.Last:
-			o.suffixSlice[aggType.ID()] = o.AggregationLastSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationLastSuffix()
 		case policy.Lower:
-			o.suffixSlice[aggType.ID()] = o.AggregationLowerSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationLowerSuffix()
 		case policy.Upper:
-			o.suffixSlice[aggType.ID()] = o.AggregationUpperSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationUpperSuffix()
 		case policy.Mean:
-			o.suffixSlice[aggType.ID()] = o.AggregationMeanSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationMeanSuffix()
 		case policy.Median:
-			o.suffixSlice[aggType.ID()] = o.AggregationMedianSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationMedianSuffix()
 		case policy.Count:
-			o.suffixSlice[aggType.ID()] = o.AggregationCountSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationCountSuffix()
 		case policy.Sum:
-			o.suffixSlice[aggType.ID()] = o.AggregationSumSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationSumSuffix()
 		case policy.SumSq:
-			o.suffixSlice[aggType.ID()] = o.AggregationSumSqSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationSumSqSuffix()
 		case policy.Stdev:
-			o.suffixSlice[aggType.ID()] = o.AggregationStdevSuffix()
+			o.suffixes[aggType.ID()] = o.AggregationStdevSuffix()
 		default:
 			q, ok := aggType.Quantile()
 			if ok {
-				o.suffixSlice[aggType.ID()] = o.timerQuantileSuffixFn(q)
+				o.suffixes[aggType.ID()] = o.timerQuantileSuffixFn(q)
 			}
 		}
 	}

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -178,6 +178,7 @@ func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
 	o := NewOptions().SetDefaultTimerAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, []float64{0.99, 0.9999}, o.TimerQuantiles())
+	require.Equal(t, [][]byte{[]byte(".mean"), []byte(".sum_sq"), []byte(".p99"), []byte(".p9999")}, o.DefaultTimerAggregationSuffixes())
 }
 
 func TestOptionsSetTimerQuantileSuffixFn(t *testing.T) {
@@ -202,6 +203,7 @@ func TestOptionsNonQuantileSuffix(t *testing.T) {
 
 func TestOptionTimerQuantileSuffix(t *testing.T) {
 	o := NewOptions()
+	require.Equal(t, []byte(".p01"), o.TimerQuantileSuffixFn()(0.01))
 	require.Equal(t, []byte(".p10"), o.TimerQuantileSuffixFn()(0.1))
 	require.Equal(t, []byte(".p50"), o.TimerQuantileSuffixFn()(0.5))
 	require.Equal(t, []byte(".p90"), o.TimerQuantileSuffixFn()(0.9))
@@ -210,6 +212,7 @@ func TestOptionTimerQuantileSuffix(t *testing.T) {
 	require.Equal(t, []byte(".p999"), o.TimerQuantileSuffixFn()(0.999))
 	require.Equal(t, []byte(".p999"), o.TimerQuantileSuffixFn()(0.9990))
 	require.Equal(t, []byte(".p9999"), o.TimerQuantileSuffixFn()(0.9999))
+	require.Equal(t, []byte(".p00001"), o.TimerQuantileSuffixFn()(0.00001))
 	require.Equal(t, []byte(".p123456789"), o.TimerQuantileSuffixFn()(0.123456789))
 }
 

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -178,7 +178,7 @@ func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
 	o := NewOptions().SetDefaultTimerAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, []float64{0.99, 0.9999}, o.TimerQuantiles())
-	require.Equal(t, [][]byte{[]byte(".mean"), []byte(".sum_sq"), []byte(".p99"), []byte(".p9999")}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(".mean"), []byte(".sum_sq"), []byte(".p99"), []byte(".p99.99")}, o.DefaultTimerAggregationSuffixes())
 }
 
 func TestOptionsSetTimerQuantileSuffixFn(t *testing.T) {
@@ -203,17 +203,17 @@ func TestOptionsNonQuantileSuffix(t *testing.T) {
 
 func TestOptionTimerQuantileSuffix(t *testing.T) {
 	o := NewOptions()
-	require.Equal(t, []byte(".p01"), o.TimerQuantileSuffixFn()(0.01))
+	require.Equal(t, []byte(".p1"), o.TimerQuantileSuffixFn()(0.01))
 	require.Equal(t, []byte(".p10"), o.TimerQuantileSuffixFn()(0.1))
 	require.Equal(t, []byte(".p50"), o.TimerQuantileSuffixFn()(0.5))
 	require.Equal(t, []byte(".p90"), o.TimerQuantileSuffixFn()(0.9))
 	require.Equal(t, []byte(".p90"), o.TimerQuantileSuffixFn()(0.90))
-	require.Equal(t, []byte(".p909"), o.TimerQuantileSuffixFn()(0.909))
-	require.Equal(t, []byte(".p999"), o.TimerQuantileSuffixFn()(0.999))
-	require.Equal(t, []byte(".p999"), o.TimerQuantileSuffixFn()(0.9990))
-	require.Equal(t, []byte(".p9999"), o.TimerQuantileSuffixFn()(0.9999))
-	require.Equal(t, []byte(".p00001"), o.TimerQuantileSuffixFn()(0.00001))
-	require.Equal(t, []byte(".p123456789"), o.TimerQuantileSuffixFn()(0.123456789))
+	require.Equal(t, []byte(".p90.9"), o.TimerQuantileSuffixFn()(0.909))
+	require.Equal(t, []byte(".p99.9"), o.TimerQuantileSuffixFn()(0.999))
+	require.Equal(t, []byte(".p99.9"), o.TimerQuantileSuffixFn()(0.9990))
+	require.Equal(t, []byte(".p99.99"), o.TimerQuantileSuffixFn()(0.9999))
+	require.Equal(t, []byte(".p0.001"), o.TimerQuantileSuffixFn()(0.00001))
+	require.Equal(t, []byte(".p12.3456789"), o.TimerQuantileSuffixFn()(0.123456789))
 }
 
 func TestOptionsSetGaugePrefix(t *testing.T) {

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3metrics/protocol/msgpack"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
 
 	"github.com/stretchr/testify/require"
 )
@@ -73,14 +74,14 @@ func TestOptionsValidateDefault(t *testing.T) {
 	require.Equal(t, defaultMetricPrefix, o.MetricPrefix())
 	require.Equal(t, defaultCounterPrefix, o.CounterPrefix())
 	require.Equal(t, defaultTimerPrefix, o.TimerPrefix())
-	require.Equal(t, defaultTimerSumSuffix, o.TimerSumSuffix())
-	require.Equal(t, defaultTimerSumSqSuffix, o.TimerSumSqSuffix())
-	require.Equal(t, defaultTimerMeanSuffix, o.TimerMeanSuffix())
-	require.Equal(t, defaultTimerLowerSuffix, o.TimerLowerSuffix())
-	require.Equal(t, defaultTimerUpperSuffix, o.TimerUpperSuffix())
-	require.Equal(t, defaultTimerCountSuffix, o.TimerCountSuffix())
-	require.Equal(t, defaultTimerStdevSuffix, o.TimerStdevSuffix())
-	require.Equal(t, defaultTimerMedianSuffix, o.TimerMedianSuffix())
+	require.Equal(t, defaultAggregationSumSuffix, o.AggregationSumSuffix())
+	require.Equal(t, defaultAggregationSumSqSuffix, o.AggregationSumSqSuffix())
+	require.Equal(t, defaultAggregationMeanSuffix, o.AggregationMeanSuffix())
+	require.Equal(t, defaultAggregationLowerSuffix, o.AggregationLowerSuffix())
+	require.Equal(t, defaultAggregationUpperSuffix, o.AggregationUpperSuffix())
+	require.Equal(t, defaultAggregationCountSuffix, o.AggregationCountSuffix())
+	require.Equal(t, defaultAggregationStdevSuffix, o.AggregationStdevSuffix())
+	require.Equal(t, defaultAggregationMedianSuffix, o.AggregationMedianSuffix())
 	require.Equal(t, defaultGaugePrefix, o.GaugePrefix())
 	require.Equal(t, defaultMinFlushInterval, o.MinFlushInterval())
 	require.Equal(t, defaultMaxFlushSize, o.MaxFlushSize())
@@ -130,50 +131,50 @@ func TestOptionsSetTimerPrefix(t *testing.T) {
 
 func TestOptionsSetTimerSumSuffix(t *testing.T) {
 	newSumSuffix := []byte("testTimerSumSuffix")
-	o := NewOptions().SetTimerSumSuffix(newSumSuffix)
-	require.Equal(t, newSumSuffix, o.TimerSumSuffix())
+	o := NewOptions().SetAggregationSumSuffix(newSumSuffix)
+	require.Equal(t, newSumSuffix, o.AggregationSumSuffix())
 }
 
 func TestOptionsSetTimerSumSqSuffix(t *testing.T) {
 	newSumSqSuffix := []byte("testTimerSumSqSuffix")
-	o := NewOptions().SetTimerSumSqSuffix(newSumSqSuffix)
-	require.Equal(t, newSumSqSuffix, o.TimerSumSqSuffix())
+	o := NewOptions().SetAggregationSumSqSuffix(newSumSqSuffix)
+	require.Equal(t, newSumSqSuffix, o.AggregationSumSqSuffix())
 }
 
 func TestOptionsSetTimerMeanSuffix(t *testing.T) {
 	newMeanSuffix := []byte("testTimerMeanSuffix")
-	o := NewOptions().SetTimerMeanSuffix(newMeanSuffix)
-	require.Equal(t, newMeanSuffix, o.TimerMeanSuffix())
+	o := NewOptions().SetAggregationMeanSuffix(newMeanSuffix)
+	require.Equal(t, newMeanSuffix, o.AggregationMeanSuffix())
 }
 
 func TestOptionsSetTimerLowerSuffix(t *testing.T) {
 	newLowerSuffix := []byte("testTimerLowerSuffix")
-	o := NewOptions().SetTimerLowerSuffix(newLowerSuffix)
-	require.Equal(t, newLowerSuffix, o.TimerLowerSuffix())
+	o := NewOptions().SetAggregationLowerSuffix(newLowerSuffix)
+	require.Equal(t, newLowerSuffix, o.AggregationLowerSuffix())
 }
 
 func TestOptionsSetTimerUpperSuffix(t *testing.T) {
 	newUpperSuffix := []byte("testTimerUpperSuffix")
-	o := NewOptions().SetTimerUpperSuffix(newUpperSuffix)
-	require.Equal(t, newUpperSuffix, o.TimerUpperSuffix())
+	o := NewOptions().SetAggregationUpperSuffix(newUpperSuffix)
+	require.Equal(t, newUpperSuffix, o.AggregationUpperSuffix())
 }
 
 func TestOptionsSetTimerCountSuffix(t *testing.T) {
 	newCountSuffix := []byte("testTimerCountSuffix")
-	o := NewOptions().SetTimerCountSuffix(newCountSuffix)
-	require.Equal(t, newCountSuffix, o.TimerCountSuffix())
+	o := NewOptions().SetAggregationCountSuffix(newCountSuffix)
+	require.Equal(t, newCountSuffix, o.AggregationCountSuffix())
 }
 
 func TestOptionsSetTimerStdevSuffix(t *testing.T) {
 	newStdevSuffix := []byte("testTimerStdevSuffix")
-	o := NewOptions().SetTimerStdevSuffix(newStdevSuffix)
-	require.Equal(t, newStdevSuffix, o.TimerStdevSuffix())
+	o := NewOptions().SetAggregationStdevSuffix(newStdevSuffix)
+	require.Equal(t, newStdevSuffix, o.AggregationStdevSuffix())
 }
 
 func TestOptionsSetTimerMedianSuffix(t *testing.T) {
 	newMedianSuffix := []byte("testTimerMedianSuffix")
-	o := NewOptions().SetTimerMedianSuffix(newMedianSuffix)
-	require.Equal(t, newMedianSuffix, o.TimerMedianSuffix())
+	o := NewOptions().SetAggregationMedianSuffix(newMedianSuffix)
+	require.Equal(t, newMedianSuffix, o.AggregationMedianSuffix())
 }
 
 func TestOptionsSetTimerQuantile(t *testing.T) {
@@ -186,6 +187,19 @@ func TestOptionsSetTimerQuantileSuffixFn(t *testing.T) {
 	o := NewOptions().SetTimerQuantileSuffixFn(fn)
 	require.Equal(t, []byte("0.96"), o.TimerQuantileSuffixFn()(0.9582))
 	validateQuantiles(t, o)
+}
+
+func TestOptionTimerQuantileSuffix(t *testing.T) {
+	o := NewOptions()
+	require.Equal(t, []byte(".p50"), o.TimerQuantileSuffixFn()(0.5))
+	require.Equal(t, []byte(".p90"), o.TimerQuantileSuffixFn()(0.9))
+	require.Equal(t, []byte(".p90"), o.TimerQuantileSuffixFn()(0.90))
+	require.Equal(t, []byte(".p909"), o.TimerQuantileSuffixFn()(0.909))
+	require.Equal(t, []byte(".p999"), o.TimerQuantileSuffixFn()(0.999))
+	require.Equal(t, []byte(".p999"), o.TimerQuantileSuffixFn()(0.9990))
+	require.Equal(t, []byte(".p9999"), o.TimerQuantileSuffixFn()(0.9999))
+	require.Equal(t, []byte(".p100"), o.TimerQuantileSuffixFn()(0.99999))
+	require.Equal(t, []byte(".p100"), o.TimerQuantileSuffixFn()(1))
 }
 
 func TestOptionsSetGaugePrefix(t *testing.T) {
@@ -291,4 +305,10 @@ func TestSetBufferedEncoderPool(t *testing.T) {
 	value := msgpack.NewBufferedEncoderPool(nil)
 	o := NewOptions().SetBufferedEncoderPool(value)
 	require.Equal(t, value, o.BufferedEncoderPool())
+}
+
+func TestSetQuantilesPool(t *testing.T) {
+	p := pool.NewFloatsPool(nil, nil)
+	o := NewOptions().SetQuantileFloatsPool(p)
+	require.Equal(t, p, o.QuantileFloatsPool())
 }

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3metrics/protocol/msgpack"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
 )
 
 // Aggregator aggregates different types of metrics.
@@ -148,64 +149,70 @@ type Options interface {
 	// TimerPrefix returns the prefix for timers
 	TimerPrefix() []byte
 
-	// SetTimerSumSuffix sets the sum suffix for timers
-	SetTimerSumSuffix(value []byte) Options
+	// SetAggregationLastSuffix sets the suffix for aggregation type last.
+	SetAggregationLastSuffix(value []byte) Options
 
-	// TimerSumSuffix returns the sum suffix for timers
-	TimerSumSuffix() []byte
+	// AggregationLastSuffix returns the suffix for aggregation type last.
+	AggregationLastSuffix() []byte
 
-	// SetTimerSumSqSuffix sets the sum square suffix for timers
-	SetTimerSumSqSuffix(value []byte) Options
+	// SetAggregationLowerSuffix sets the suffix for aggregation type lower.
+	SetAggregationLowerSuffix(value []byte) Options
 
-	// TimerSumSqSuffix returns the sum square suffix for timers
-	TimerSumSqSuffix() []byte
+	// AggregationLowerSuffix returns the suffix for aggregation type lower.
+	AggregationLowerSuffix() []byte
 
-	// SetTimerMeanSuffix sets the mean suffix for timers
-	SetTimerMeanSuffix(value []byte) Options
+	// SetAggregationUpperSuffix sets the suffix for aggregation type upper.
+	SetAggregationUpperSuffix(value []byte) Options
 
-	// TimerMeanSuffix returns the mean suffix for timers
-	TimerMeanSuffix() []byte
+	// AggregationUpperSuffix returns the suffix for aggregation type upper.
+	AggregationUpperSuffix() []byte
 
-	// SetTimerLowerSuffix sets the lower suffix for timers
-	SetTimerLowerSuffix(value []byte) Options
+	// SetAggregationMeanSuffix sets the suffix for aggregation type mean.
+	SetAggregationMeanSuffix(value []byte) Options
 
-	// TimerLowerSuffix returns the lower suffix for timers
-	TimerLowerSuffix() []byte
+	// AggregationMeanSuffix returns the suffix for aggregation type mean.
+	AggregationMeanSuffix() []byte
 
-	// SetTimerUpperSuffix sets the upper suffix for timers
-	SetTimerUpperSuffix(value []byte) Options
+	// SetAggregationMedianSuffix sets the suffix for aggregation type median.
+	SetAggregationMedianSuffix(value []byte) Options
 
-	// TimerUpperSuffix returns the upper suffix for timers
-	TimerUpperSuffix() []byte
+	// AggregationMedianSuffix returns the suffix for aggregation type median.
+	AggregationMedianSuffix() []byte
 
-	// SetTimerCountSuffix sets the count suffix for timers
-	SetTimerCountSuffix(value []byte) Options
+	// SetAggregationCountSuffix sets the suffix for aggregation type count.
+	SetAggregationCountSuffix(value []byte) Options
 
-	// TimerCountSuffix returns the count suffix for timers
-	TimerCountSuffix() []byte
+	// AggregationCountSuffix returns the suffix for aggregation type count.
+	AggregationCountSuffix() []byte
 
-	// SetTimerStdevSuffix sets the standard deviation suffix for timers
-	SetTimerStdevSuffix(value []byte) Options
+	// SetAggregationSumSuffix sets the suffix for aggregation type sum.
+	SetAggregationSumSuffix(value []byte) Options
 
-	// TimerStdevSuffix returns the standard deviation suffix for timers
-	TimerStdevSuffix() []byte
+	// AggregationSumSuffix returns the suffix for aggregation type sum.
+	AggregationSumSuffix() []byte
 
-	// SetTimerMedianSuffix sets the median suffix for timers
-	SetTimerMedianSuffix(value []byte) Options
+	// SetAggregationSumSqSuffix sets the suffix for aggregation type sum square.
+	SetAggregationSumSqSuffix(value []byte) Options
 
-	// TimerMedianSuffix returns the median suffix for timers
-	TimerMedianSuffix() []byte
+	// AggregationSumSqSuffix returns the suffix for aggregation type sum square.
+	AggregationSumSqSuffix() []byte
 
-	// SetTimerQuantiles sets the timer quantiles
+	// SetAggregationStdevSuffix sets the suffix for aggregation type standard deviation.
+	SetAggregationStdevSuffix(value []byte) Options
+
+	// AggregationStdevSuffix returns the suffix for aggregation type standard deviation.
+	AggregationStdevSuffix() []byte
+
+	// SetTimerQuantiles sets the timer quantiles.
 	SetTimerQuantiles(quantiles []float64) Options
 
-	// TimerQuantiles returns the quantiles for timers
+	// TimerQuantiles returns the quantiles for timers.
 	TimerQuantiles() []float64
 
-	// SetTimerQuantileSuffixFn sets the quantile suffix function for timers
+	// SetTimerQuantileSuffixFn sets the quantile suffix function for timers.
 	SetTimerQuantileSuffixFn(value QuantileSuffixFn) Options
 
-	// TimerQuantileSuffixFn returns the quantile suffix function for timers
+	// TimerQuantileSuffixFn returns the quantile suffix function for timers.
 	TimerQuantileSuffixFn() QuantileSuffixFn
 
 	// SetGaugePrefix sets the prefix for gauges
@@ -316,29 +323,41 @@ type Options interface {
 	// EntryPool returns the entry pool
 	EntryPool() EntryPool
 
-	// SetCounterElemPool sets the counter element pool
+	// SetCounterElemPool sets the counter element pool.
 	SetCounterElemPool(value CounterElemPool) Options
 
-	// CounterElemPool returns the counter element pool
+	// CounterElemPool returns the counter element pool.
 	CounterElemPool() CounterElemPool
 
-	// SetTimerElemPool sets the timer element pool
+	// SetTimerElemPool sets the timer element pool.
 	SetTimerElemPool(value TimerElemPool) Options
 
-	// TimerElemPool returns the timer element pool
+	// TimerElemPool returns the timer element pool.
 	TimerElemPool() TimerElemPool
 
-	// SetGaugeElemPool sets the gauge element pool
+	// SetGaugeElemPool sets the gauge element pool.
 	SetGaugeElemPool(value GaugeElemPool) Options
 
-	// GaugeElemPool returns the gauge element pool
+	// GaugeElemPool returns the gauge element pool.
 	GaugeElemPool() GaugeElemPool
 
-	// SetBufferedEncoderPool sets the buffered encoder pool
+	// SetBufferedEncoderPool sets the buffered encoder pool.
 	SetBufferedEncoderPool(value msgpack.BufferedEncoderPool) Options
 
-	// BufferedEncoderPool returns the buffered encoder pool
+	// BufferedEncoderPool returns the buffered encoder pool.
 	BufferedEncoderPool() msgpack.BufferedEncoderPool
+
+	// SetAggregationTypesPool sets the aggregation types pool.
+	SetAggregationTypesPool(pool policy.AggregationTypesPool) Options
+
+	// AggregationTypesPool returns the aggregation types pool.
+	AggregationTypesPool() policy.AggregationTypesPool
+
+	// SetQuantileFloatsPool sets the timer quantiles pool.
+	SetQuantileFloatsPool(pool pool.FloatsPool) Options
+
+	// QuantileFloatsPool returns the timer quantiles pool.
+	QuantileFloatsPool() pool.FloatsPool
 
 	/// Read-only derived options
 

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -126,9 +126,6 @@ type Handler interface {
 
 // Options provide a set of base and derived options for the aggregator
 type Options interface {
-	// Validate validates the options
-	Validate() error
-
 	/// Read-write base options
 
 	// SetMetricPrefix sets the common prefix for all metric types
@@ -203,11 +200,11 @@ type Options interface {
 	// AggregationStdevSuffix returns the suffix for aggregation type standard deviation.
 	AggregationStdevSuffix() []byte
 
-	// SetTimerQuantiles sets the timer quantiles.
-	SetTimerQuantiles(quantiles []float64) Options
+	// SetDefaultTimerAggregationTypes sets the timer aggregation types.
+	SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options
 
-	// TimerQuantiles returns the quantiles for timers.
-	TimerQuantiles() []float64
+	// DefaultTimerAggregationTypes returns the aggregation types for timers.
+	DefaultTimerAggregationTypes() policy.AggregationTypes
 
 	// SetTimerQuantileSuffixFn sets the quantile suffix function for timers.
 	SetTimerQuantileSuffixFn(value QuantileSuffixFn) Options
@@ -353,11 +350,11 @@ type Options interface {
 	// AggregationTypesPool returns the aggregation types pool.
 	AggregationTypesPool() policy.AggregationTypesPool
 
-	// SetQuantileFloatsPool sets the timer quantiles pool.
-	SetQuantileFloatsPool(pool pool.FloatsPool) Options
+	// SetQuantilesPool sets the timer quantiles pool.
+	SetQuantilesPool(pool pool.FloatsPool) Options
 
-	// QuantileFloatsPool returns the timer quantiles pool.
-	QuantileFloatsPool() pool.FloatsPool
+	// QuantilesPool returns the timer quantiles pool.
+	QuantilesPool() pool.FloatsPool
 
 	/// Read-only derived options
 
@@ -370,6 +367,9 @@ type Options interface {
 	// FullGaugePrefix returns the full prefix for gauges
 	FullGaugePrefix() []byte
 
-	// TimerQuantileSuffixes returns the quantile suffixes for timers
-	TimerQuantileSuffixes() [][]byte
+	// TimerQuantiles returns the quantiles for timers.
+	TimerQuantiles() []float64
+
+	// Suffix returns the suffix for the aggregation type
+	Suffix(aggtype policy.AggregationType) []byte
 }

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -370,6 +370,10 @@ type Options interface {
 	// TimerQuantiles returns the quantiles for timers.
 	TimerQuantiles() []float64
 
+	// DefaultTimerAggregationSuffixes returns the suffix for
+	// default timer aggregation types.
+	DefaultTimerAggregationSuffixes() [][]byte
+
 	// Suffix returns the suffix for the aggregation type
-	Suffix(aggtype policy.AggregationType) []byte
+	Suffix(aggType policy.AggregationType) []byte
 }

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -109,7 +109,7 @@ aggregator:
     size: 4096
   bufferedEncoderPool:
     size: 4096
-  quantilesFloatsPool:
+  quantilesPool:
     buckets:
       - count: 256
         capacity: 4

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -75,7 +75,7 @@ aggregator:
         - count: 2048
           capacity: 32
         - count: 1024
-          capacity: 16
+          capacity: 64
   timerQuantiles:
     - 0.5
     - 0.95
@@ -97,6 +97,8 @@ aggregator:
   defaultPolicies:
     - 10s:2d
     - 1m:40d
+  aggregationTypesPool:
+    size: 1024
   counterElemPool:
     size: 4096
   timerElemPool:
@@ -107,3 +109,9 @@ aggregator:
     size: 4096
   bufferedEncoderPool:
     size: 4096
+  quantilesFloatsPool:
+    buckets:
+      - count: 256
+        capacity: 4
+      - count: 128
+        capacity: 8

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1bc243c51945e6f29b54f7c9c95c0480947492a17efddad4b015217e24ac7918
-updated: 2017-06-06T15:24:39.60121022-04:00
+hash: 1aeb7193a078df4b55612db13510b1cfe39a237c82e5bec7a103c45ac2a99c9a
+updated: 2017-06-08T17:38:01.526064597-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 3609ade2272ee3ab0dfad0e6c68a46b9164a8499
+  version: 27933961dba78cb60caf44c5a1bf83cd9fe6c75b
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8f0487e4b6c8022f6dbf2a0bb4c20c7000a91162e5fb32014dee6cad8b5853fc
-updated: 2017-06-12T16:02:58.669595098-04:00
+hash: a94c0cdad9218489653503407c1c21907c1f5200ca0c55cfa53e92518a034d0d
+updated: 2017-06-13T14:50:04.13721398-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 59739da1f4d405930f3df91b0d1fb9097196c2e9
+  version: 45037302bdeb70797fde141e228d7c639adac708
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1aeb7193a078df4b55612db13510b1cfe39a237c82e5bec7a103c45ac2a99c9a
-updated: 2017-06-08T17:38:01.526064597-04:00
+hash: 0b5ddbdb917b61fe9221f33f5b49e4bd26303cc884723773d18f9a6a834eaa8b
+updated: 2017-06-10T08:47:36.426705623-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 27933961dba78cb60caf44c5a1bf83cd9fe6c75b
+  version: 36c2d6edf2ca9f5e6208b339f42e3782baf19907
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0b5ddbdb917b61fe9221f33f5b49e4bd26303cc884723773d18f9a6a834eaa8b
-updated: 2017-06-10T08:47:36.426705623-04:00
+hash: 15060119e009eb2a43fb3ca80d6ec3a4ca502b110b061d5ae94abb4ea783374e
+updated: 2017-06-10T17:57:16.144288164-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 36c2d6edf2ca9f5e6208b339f42e3782baf19907
+  version: a8d3dcef9a53e53b588e72908de07a691eae8286
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 15060119e009eb2a43fb3ca80d6ec3a4ca502b110b061d5ae94abb4ea783374e
-updated: 2017-06-10T17:57:16.144288164-04:00
+hash: 8f0487e4b6c8022f6dbf2a0bb4c20c7000a91162e5fb32014dee6cad8b5853fc
+updated: 2017-06-12T16:02:58.669595098-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: a8d3dcef9a53e53b588e72908de07a691eae8286
+  version: 59739da1f4d405930f3df91b0d1fb9097196c2e9
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8684f0f57cb932b0e6f3772a625acf2dd317dd6715e280ddf080f7e0f0960a14
-updated: 2017-06-05T16:54:23.653931756-04:00
+hash: 1bc243c51945e6f29b54f7c9c95c0480947492a17efddad4b015217e24ac7918
+updated: 2017-06-06T15:24:39.60121022-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 18bc01a7057d55b78e528236e0e9db297bcd4fa3
+  version: 3609ade2272ee3ab0dfad0e6c68a46b9164a8499
   subpackages:
   - generated/proto/schema
   - metric/aggregated
@@ -151,6 +151,8 @@ imports:
   - m3/customtransports
   - m3/thrift
   - m3/thriftudp
+- name: github.com/willf/bitset
+  version: 988f4f24992fc745de53c42df0da6581e42a6686
 - name: golang.org/x/net
   version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: 27933961dba78cb60caf44c5a1bf83cd9fe6c75b
+  version: 36c2d6edf2ca9f5e6208b339f42e3782baf19907
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x
@@ -61,5 +61,7 @@ import:
   version: 1878d9fbb537119d24b21ca07effd591627cd160
 - package: github.com/spaolacci/murmur3
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
+- package: github.com/willf/bitset
+  version: 988f4f24992fc745de53c42df0da6581e42a6686
 - package: google.golang.org/grpc
   version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: 3609ade2272ee3ab0dfad0e6c68a46b9164a8499
+  version: 27933961dba78cb60caf44c5a1bf83cd9fe6c75b
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: 36c2d6edf2ca9f5e6208b339f42e3782baf19907
+  version: a8d3dcef9a53e53b588e72908de07a691eae8286
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: 18bc01a7057d55b78e528236e0e9db297bcd4fa3
+  version: 3609ade2272ee3ab0dfad0e6c68a46b9164a8499
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: a8d3dcef9a53e53b588e72908de07a691eae8286
+  version: 59739da1f4d405930f3df91b0d1fb9097196c2e9
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: 59739da1f4d405930f3df91b0d1fb9097196c2e9
+  version: 45037302bdeb70797fde141e228d7c639adac708
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/integration/custom_aggregation_test.go
+++ b/integration/custom_aggregation_test.go
@@ -1,0 +1,132 @@
+// +build integration
+
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	compressor                             = policy.NewAggregationIDCompressor()
+	compressedLower, _                     = compressor.Compress(policy.AggregationTypes{policy.Lower})
+	compressedLowerAndUpper, _             = compressor.Compress(policy.AggregationTypes{policy.Lower, policy.Upper})
+	testPoliciesListWithCustomAggregation1 = policy.PoliciesList{
+		policy.NewStagedPolicies(
+			0,
+			false,
+			[]policy.Policy{
+				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), compressedLower),
+				policy.NewPolicy(policy.NewStoragePolicy(2*time.Second, xtime.Second, 6*time.Hour), compressedLower),
+			},
+		),
+	}
+
+	testPoliciesListWithCustomAggregation2 = policy.PoliciesList{
+		policy.NewStagedPolicies(
+			0,
+			false,
+			[]policy.Policy{
+				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), compressedLowerAndUpper),
+				policy.NewPolicy(policy.NewStoragePolicy(3*time.Second, xtime.Second, 24*time.Hour), compressedLowerAndUpper),
+			},
+		),
+	}
+)
+
+func TestCustomAggregation(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Test setup
+	testSetup, err := newTestSetup(newTestOptions())
+	require.NoError(t, err)
+	defer testSetup.close()
+
+	testSetup.aggregatorOpts =
+		testSetup.aggregatorOpts.
+			SetEntryCheckInterval(time.Second).
+			SetMinFlushInterval(0)
+
+	// Start the server
+	log := testSetup.aggregatorOpts.InstrumentOptions().Logger()
+	log.Info("test policy change")
+	require.NoError(t, testSetup.startServer())
+	log.Info("server is now up")
+
+	var (
+		idPrefix = "foo"
+		numIDs   = 3
+		start    = testSetup.getNowFn()
+		t1       = start.Add(2 * time.Second)
+		t2       = start.Add(4 * time.Second)
+		t3       = start.Add(6 * time.Second)
+		end      = start.Add(8 * time.Second)
+		interval = time.Second
+	)
+	client := testSetup.newClient()
+	require.NoError(t, client.connect())
+	defer client.close()
+
+	ids := generateTestIDs(idPrefix, numIDs)
+	input1 := generateTestData(t, start, t1, interval, ids, roundRobinMetricTypeFn, testPoliciesList)
+	input2 := generateTestData(t, t1, t2, interval, ids, roundRobinMetricTypeFn, testPoliciesListWithCustomAggregation1)
+	input3 := generateTestData(t, t2, t3, interval, ids, roundRobinMetricTypeFn, testPoliciesListWithCustomAggregation2)
+	input4 := generateTestData(t, t3, end, interval, ids, roundRobinMetricTypeFn, testPoliciesList)
+	for _, input := range []testDatasetWithPoliciesList{input1, input2, input3, input4} {
+		for _, data := range input.dataset {
+			testSetup.setNowFn(data.timestamp)
+			for _, mu := range data.metrics {
+				require.NoError(t, client.write(mu, input.policiesList))
+			}
+			require.NoError(t, client.flush())
+
+			// Give server some time to process the incoming packets
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Move time forward and wait for ticking to happen. The sleep time
+	// must be the longer than the lowest resolution across all policies.
+	finalTime := end.Add(time.Second)
+	testSetup.setNowFn(finalTime)
+	time.Sleep(6 * time.Second)
+
+	// Stop the server
+	require.NoError(t, testSetup.stopServer())
+	log.Info("server is now down")
+
+	// Validate results
+	expected := toExpectedResults(t, finalTime, input1, testSetup.aggregatorOpts)
+	expected = append(expected, toExpectedResults(t, finalTime, input2, testSetup.aggregatorOpts)...)
+	expected = append(expected, toExpectedResults(t, finalTime, input3, testSetup.aggregatorOpts)...)
+	expected = append(expected, toExpectedResults(t, finalTime, input4, testSetup.aggregatorOpts)...)
+	actual := testSetup.sortedResults()
+	require.Equal(t, expected, actual)
+}

--- a/integration/data.go
+++ b/integration/data.go
@@ -301,24 +301,9 @@ func toAggregatedMetrics(
 	case aggregation.Counter:
 		fn(opts.FullCounterPrefix(), id, nil, timeNanos, float64(values.Sum()), p)
 	case aggregation.Timer:
-		var (
-			fullTimerPrefix  = opts.FullTimerPrefix()
-			quantiles        = opts.TimerQuantiles()
-			quantileSuffixes = opts.TimerQuantileSuffixes()
-		)
-		fn(fullTimerPrefix, id, opts.AggregationSumSuffix(), timeNanos, values.Sum(), p)
-		fn(fullTimerPrefix, id, opts.AggregationSumSqSuffix(), timeNanos, values.SumSq(), p)
-		fn(fullTimerPrefix, id, opts.AggregationMeanSuffix(), timeNanos, values.Mean(), p)
-		fn(fullTimerPrefix, id, opts.AggregationLowerSuffix(), timeNanos, values.Min(), p)
-		fn(fullTimerPrefix, id, opts.AggregationUpperSuffix(), timeNanos, values.Max(), p)
-		fn(fullTimerPrefix, id, opts.AggregationCountSuffix(), timeNanos, float64(values.Count()), p)
-		fn(fullTimerPrefix, id, opts.AggregationStdevSuffix(), timeNanos, values.Stdev(), p)
-		for idx, q := range quantiles {
-			v := values.Quantile(q)
-			if q == 0.5 {
-				fn(fullTimerPrefix, id, opts.AggregationMedianSuffix(), timeNanos, v, p)
-			}
-			fn(fullTimerPrefix, id, quantileSuffixes[idx], timeNanos, v, p)
+		var fullTimerPrefix = opts.FullTimerPrefix()
+		for _, aggType := range opts.DefaultTimerAggregationTypes() {
+			fn(fullTimerPrefix, id, opts.Suffix(aggType), timeNanos, values.ValueOf(aggType), p)
 		}
 	case aggregation.Gauge:
 		fn(opts.FullGaugePrefix(), id, nil, timeNanos, values.Last(), p)

--- a/integration/data.go
+++ b/integration/data.go
@@ -250,29 +250,24 @@ func toExpectedResults(
 				aggTypes, err := decompressor.Decompress(policy.AggregationID)
 				require.NoError(t, err)
 
-				if aggTypes.IsDefault() {
-					switch mu.Type {
-					case unaggregated.CounterType:
-						// TODO(cw) use default aggregation types for Counter
-					case unaggregated.BatchTimerType:
-						aggTypes = testDefaultTimerAggregationTypes
-					case unaggregated.GaugeType:
-						// TODO(cw) use default aggregation types for Gauge
-					default:
-						require.Fail(t, fmt.Sprintf("unrecognized metric type %v", mu.Type))
-					}
-				}
 				metrics.aggTypes = aggTypes
 				aggregationOpts := aggregation.NewOptions()
-				aggregationOpts.ResetSetData(aggTypes)
 
 				if !exists {
 					switch mu.Type {
 					case unaggregated.CounterType:
+						// TODO(cw) Get default aggregation types for Counter.
+						aggregationOpts.ResetSetData(aggTypes)
 						values = aggregation.NewCounter(aggregationOpts)
 					case unaggregated.BatchTimerType:
+						if aggTypes.IsDefault() {
+							aggTypes = opts.DefaultTimerAggregationTypes()
+						}
+						aggregationOpts.ResetSetData(aggTypes)
 						values = aggregation.NewTimer(opts.TimerQuantiles(), opts.StreamOptions(), aggregationOpts)
 					case unaggregated.GaugeType:
+						// TODO(cw) Get default aggregation types for Gauge.
+						aggregationOpts.ResetSetData(aggTypes)
 						values = aggregation.NewGauge(aggregationOpts)
 					default:
 						require.Fail(t, fmt.Sprintf("unrecognized metric type %v", mu.Type))

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -65,7 +65,7 @@ type testSetup struct {
 	getNowFn          clock.NowFn
 	setNowFn          nowSetterFn
 	workerPool        xsync.WorkerPool
-	results           *[]aggregated.MetricWithPolicy
+	results           *[]aggregated.MetricWithStoragePolicy
 	resultLock        *sync.Mutex
 
 	// Signals.
@@ -158,14 +158,14 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 
 	// Set up the handler.
 	var (
-		results    []aggregated.MetricWithPolicy
+		results    []aggregated.MetricWithStoragePolicy
 		resultLock sync.Mutex
 	)
-	handleFn := func(metric aggregated.Metric, policy policy.Policy) error {
+	handleFn := func(metric aggregated.Metric, sp policy.StoragePolicy) error {
 		resultLock.Lock()
-		results = append(results, aggregated.MetricWithPolicy{
-			Metric: metric,
-			Policy: policy,
+		results = append(results, aggregated.MetricWithStoragePolicy{
+			Metric:        metric,
+			StoragePolicy: sp,
 		})
 		resultLock.Unlock()
 		return nil
@@ -242,7 +242,7 @@ func (ts *testSetup) startServer() error {
 	return <-errCh
 }
 
-func (ts *testSetup) sortedResults() []aggregated.MetricWithPolicy {
+func (ts *testSetup) sortedResults() []aggregated.MetricWithStoragePolicy {
 	sort.Sort(byTimeIDPolicyAscending(*ts.results))
 	return *ts.results
 }

--- a/server/msgpack/server_test.go
+++ b/server/msgpack/server_test.go
@@ -63,9 +63,9 @@ var (
 			time.Now().UnixNano(),
 			false,
 			[]policy.Policy{
-				policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
-				policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
-				policy.NewPolicy(10*time.Minute, xtime.Minute, 30*24*time.Hour),
+				policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+				policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), policy.DefaultAggregationID),
+				policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 30*24*time.Hour), policy.DefaultAggregationID),
 			},
 		),
 	}

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -162,7 +162,7 @@ type AggregatorConfiguration struct {
 	AggregationTypesPool pool.ObjectPoolConfiguration `yaml:"aggregationTypesPool"`
 
 	// Pool of quantile slices.
-	QuantilesFloatsPool pool.BucketizedPoolConfiguration `yaml:"quantilesFloatsPool"`
+	QuantilesPool pool.BucketizedPoolConfiguration `yaml:"quantilesPool"`
 }
 
 // NewAggregatorOptions creates a new set of aggregator options.
@@ -331,14 +331,14 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		return make(policy.AggregationTypes, 0, len(policy.ValidAggregationTypes))
 	})
 
-	// Set quantile floats pool.
-	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("quantile-floats-pool"))
-	quantileFloatsPool := pool.NewFloatsPool(
-		c.QuantilesFloatsPool.NewBuckets(),
-		c.QuantilesFloatsPool.NewObjectPoolOptions(iOpts),
+	// Set quantiles pool.
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("quantile-pool"))
+	quantilePool := pool.NewFloatsPool(
+		c.QuantilesPool.NewBuckets(),
+		c.QuantilesPool.NewObjectPoolOptions(iOpts),
 	)
-	opts = opts.SetQuantilesPool(quantileFloatsPool)
-	quantileFloatsPool.Init()
+	opts = opts.SetQuantilesPool(quantilePool)
+	quantilePool.Init()
 
 	return opts, nil
 }

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -333,12 +333,12 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 
 	// Set quantiles pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("quantile-pool"))
-	quantilePool := pool.NewFloatsPool(
+	quantilesPool := pool.NewFloatsPool(
 		c.QuantilesPool.NewBuckets(),
 		c.QuantilesPool.NewObjectPoolOptions(iOpts),
 	)
-	opts = opts.SetQuantilesPool(quantilePool)
-	quantilePool.Init()
+	opts = opts.SetQuantilesPool(quantilesPool)
+	quantilesPool.Init()
 
 	return opts, nil
 }

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -55,7 +55,6 @@ var (
 	errUnknownFlushHandlerType       = errors.New("unknown flush handler type")
 	errNoKVClientConfiguration       = errors.New("no kv client configuration")
 	errNoForwardHandlerConfiguration = errors.New("no forward flush configuration")
-	emptyPolicy                      policy.Policy
 )
 
 // AggregatorConfiguration contains aggregator configuration.
@@ -69,29 +68,32 @@ type AggregatorConfiguration struct {
 	// Timer metric prefix.
 	TimerPrefix string `yaml:"timerPrefix"`
 
-	// Timer sum metric suffix.
-	TimerSumSuffix string `yaml:"timerSumSuffix"`
+	// Metric suffix for aggregation type last.
+	AggregationLastSuffix string `yaml:"aggregationLastSuffix"`
 
-	// Timer sum square metric suffix.
-	TimerSumSqSuffix string `yaml:"timerSumSqSuffix"`
+	// Metric suffix for aggregation type sum.
+	AggregationSumSuffix string `yaml:"aggregationSumSuffix"`
 
-	// Timer sum mean metric suffix.
-	TimerMeanSuffix string `yaml:"timerMeanSuffix"`
+	// Metric suffix for aggregation type sum square.
+	AggregationSumSqSuffix string `yaml:"aggregationSumSqSuffix"`
 
-	// Timer lower metric suffix.
-	TimerLowerSuffix string `yaml:"timerLowerSuffix"`
+	// Metric suffix for aggregation type mean.
+	AggregationMeanSuffix string `yaml:"aggregationMeanSuffix"`
 
-	// Timer upper metric suffix.
-	TimerUpperSuffix string `yaml:"timerUpperSuffix"`
+	// Metric suffix for aggregation type lower.
+	AggregationLowerSuffix string `yaml:"aggregationLowerSuffix"`
 
-	// Timer count metric suffix.
-	TimerCountSuffix string `yaml:"timerCountSuffix"`
+	// Metric suffix for aggregation type upper.
+	AggregationUpperSuffix string `yaml:"aggregationUpperSuffix"`
 
-	// Timer standard deviation metric suffix.
-	TimerStdevSuffix string `yaml:"timerStdevSuffix"`
+	// Metric suffix for aggregation type count.
+	AggregationCountSuffix string `yaml:"aggregationCountSuffix"`
 
-	// Timer median metric suffix.
-	TimerMedianSuffix string `yaml:"timerMedianSuffix"`
+	// Metric suffix for aggregation type standard deviation.
+	AggregationStdevSuffix string `yaml:"aggregationStdevSuffix"`
+
+	// Metric suffix for aggregation type median.
+	AggregationMedianSuffix string `yaml:"aggregationMedianSuffix"`
 
 	// Target quantiles to compute.
 	TimerQuantiles []float64 `yaml:"timerQuantiles"`
@@ -155,6 +157,12 @@ type AggregatorConfiguration struct {
 
 	// Pool of buffered encoders.
 	BufferedEncoderPool pool.ObjectPoolConfiguration `yaml:"bufferedEncoderPool"`
+
+	// Pool of aggregation types.
+	AggregationTypesPool pool.ObjectPoolConfiguration `yaml:"aggregationTypesPool"`
+
+	// Pool of quantile slices.
+	QuantilesFloatsPool pool.BucketizedPoolConfiguration `yaml:"quantilesFloatsPool"`
 }
 
 // NewAggregatorOptions creates a new set of aggregator options.
@@ -169,19 +177,20 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	opts = setMetricPrefixOrSuffix(opts, c.MetricPrefix, opts.SetMetricPrefix)
 	opts = setMetricPrefixOrSuffix(opts, c.CounterPrefix, opts.SetCounterPrefix)
 	opts = setMetricPrefixOrSuffix(opts, c.TimerPrefix, opts.SetTimerPrefix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerSumSuffix, opts.SetTimerSumSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerSumSqSuffix, opts.SetTimerSumSqSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerMeanSuffix, opts.SetTimerMeanSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerLowerSuffix, opts.SetTimerLowerSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerUpperSuffix, opts.SetTimerUpperSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerCountSuffix, opts.SetTimerCountSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerStdevSuffix, opts.SetTimerStdevSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.TimerMedianSuffix, opts.SetTimerMedianSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationLastSuffix, opts.SetAggregationLastSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationSumSuffix, opts.SetAggregationSumSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationSumSqSuffix, opts.SetAggregationSumSqSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationMeanSuffix, opts.SetAggregationMeanSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationLowerSuffix, opts.SetAggregationLowerSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationUpperSuffix, opts.SetAggregationUpperSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationCountSuffix, opts.SetAggregationCountSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationStdevSuffix, opts.SetAggregationStdevSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationMedianSuffix, opts.SetAggregationMedianSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.GaugePrefix, opts.SetGaugePrefix)
 
 	// Set timer quantiles and quantile suffix function.
 	opts = opts.SetTimerQuantiles(c.TimerQuantiles)
-	quantileSuffixFn, err := c.parseTimerQuantileSuffixFn()
+	quantileSuffixFn, err := c.parseTimerQuantileSuffixFn(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -272,21 +281,27 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	counterElemPoolOpts := c.CounterElemPool.NewObjectPoolOptions(iOpts)
 	counterElemPool := aggregator.NewCounterElemPool(counterElemPoolOpts)
 	opts = opts.SetCounterElemPool(counterElemPool)
-	counterElemPool.Init(func() *aggregator.CounterElem { return aggregator.NewCounterElem(nil, emptyPolicy, opts) })
+	counterElemPool.Init(func() *aggregator.CounterElem {
+		return aggregator.NewCounterElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
+	})
 
 	// Set timer elem pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("timer-elem-pool"))
 	timerElemPoolOpts := c.TimerElemPool.NewObjectPoolOptions(iOpts)
 	timerElemPool := aggregator.NewTimerElemPool(timerElemPoolOpts)
 	opts = opts.SetTimerElemPool(timerElemPool)
-	timerElemPool.Init(func() *aggregator.TimerElem { return aggregator.NewTimerElem(nil, emptyPolicy, opts) })
+	timerElemPool.Init(func() *aggregator.TimerElem {
+		return aggregator.NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
+	})
 
 	// Set gauge elem pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("gauge-elem-pool"))
 	gaugeElemPoolOpts := c.GaugeElemPool.NewObjectPoolOptions(iOpts)
 	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
 	opts = opts.SetGaugeElemPool(gaugeElemPool)
-	gaugeElemPool.Init(func() *aggregator.GaugeElem { return aggregator.NewGaugeElem(nil, emptyPolicy, opts) })
+	gaugeElemPool.Init(func() *aggregator.GaugeElem {
+		return aggregator.NewGaugeElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
+	})
 
 	// Set entry pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("entry-pool"))
@@ -307,6 +322,24 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		return msgpack.NewPooledBufferedEncoderSize(bufferedEncoderPool, initialBufferSize)
 	})
 
+	// Set aggregation types pool.
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("aggregation-types-pool"))
+	aggTypesPoolOpts := c.AggregationTypesPool.NewObjectPoolOptions(iOpts)
+	aggTypesPool := policy.NewAggregationTypesPool(aggTypesPoolOpts)
+	opts = opts.SetAggregationTypesPool(aggTypesPool)
+	aggTypesPool.Init(func() policy.AggregationTypes {
+		return make(policy.AggregationTypes, 0, len(policy.ValidAggregationTypes))
+	})
+
+	// Set quantile floats pool.
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("quantile-floats-pool"))
+	quantileFloatsPool := pool.NewFloatsPool(
+		c.QuantilesFloatsPool.NewBuckets(),
+		c.QuantilesFloatsPool.NewObjectPoolOptions(iOpts),
+	)
+	opts = opts.SetQuantileFloatsPool(quantileFloatsPool)
+	quantileFloatsPool.Init()
+
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
@@ -315,14 +348,14 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 }
 
 // parseTimerQuantileSuffixFn parses the quantile suffix function type.
-func (c *AggregatorConfiguration) parseTimerQuantileSuffixFn() (aggregator.QuantileSuffixFn, error) {
+func (c *AggregatorConfiguration) parseTimerQuantileSuffixFn(opts aggregator.Options) (aggregator.QuantileSuffixFn, error) {
 	fnType := defaultQuantileSuffixType
 	if c.TimerQuantileSuffixFnType != "" {
 		fnType = timerQuantileSuffixFnType(c.TimerQuantileSuffixFnType)
 	}
 	switch fnType {
 	case defaultQuantileSuffixType:
-		return defaultTimerQuantileSuffixFn, nil
+		return opts.TimerQuantileSuffixFn(), nil
 	default:
 		return nil, errUnknownQuantileSuffixFnType
 	}
@@ -587,10 +620,6 @@ type timerQuantileSuffixFnType string
 const (
 	defaultQuantileSuffixType timerQuantileSuffixFnType = "default"
 )
-
-func defaultTimerQuantileSuffixFn(quantile float64) []byte {
-	return []byte(fmt.Sprintf(".p%0.0f", quantile*100))
-}
 
 type metricPrefixOrSuffixSetter func(prefixOrSuffix []byte) aggregator.Options
 

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -96,7 +96,7 @@ type AggregatorConfiguration struct {
 	AggregationMedianSuffix string `yaml:"aggregationMedianSuffix"`
 
 	// Target quantiles to compute.
-	TimerQuantiles []float64 `yaml:"timerQuantiles"`
+	TimerAggregationTypes policy.AggregationTypes `yaml:"timerAggregationTypes"`
 
 	// Timer quantile suffix function type.
 	TimerQuantileSuffixFnType string `yaml:"timerQuantileSuffixFnType"`
@@ -189,7 +189,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	opts = setMetricPrefixOrSuffix(opts, c.GaugePrefix, opts.SetGaugePrefix)
 
 	// Set timer quantiles and quantile suffix function.
-	opts = opts.SetTimerQuantiles(c.TimerQuantiles)
+	opts = opts.SetDefaultTimerAggregationTypes(c.TimerAggregationTypes)
 	quantileSuffixFn, err := c.parseTimerQuantileSuffixFn(opts)
 	if err != nil {
 		return nil, err
@@ -337,12 +337,8 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		c.QuantilesFloatsPool.NewBuckets(),
 		c.QuantilesFloatsPool.NewObjectPoolOptions(iOpts),
 	)
-	opts = opts.SetQuantileFloatsPool(quantileFloatsPool)
+	opts = opts.SetQuantilesPool(quantileFloatsPool)
 	quantileFloatsPool.Init()
-
-	if err := opts.Validate(); err != nil {
-		return nil, err
-	}
 
 	return opts, nil
 }


### PR DESCRIPTION
This diff picks up the change made in m3metrics to support custom aggregation types, we decode the policies with compressed aggregation types and use as is, only decompress the aggregation types when changes were noticed in the policies to save CPU.

@xichen2020 @prateek @jeromefroe 