### PR TITLE
Shard metrics within aggregation server

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -22,10 +22,14 @@ package aggregator
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/services/placement"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
@@ -34,77 +38,168 @@ import (
 	"github.com/uber-go/tally"
 )
 
-var (
-	errAggregatorClosed  = errors.New("aggregator is closed")
-	errInvalidMetricType = errors.New("invalid metric type")
+const (
+	uninitializedCutoverNanos = math.MinInt64
 )
 
+var (
+	errAggregatorIsOpenOrClosed    = errors.New("aggregator is already open or closed")
+	errAggregatorIsNotOpenOrClosed = errors.New("aggregator is not open or closed")
+	errInvalidMetricType           = errors.New("invalid metric type")
+	errActivePlacementChanged      = errors.New("active placement has changed")
+)
+
+type aggregatorTickMetrics struct {
+	scope          tally.Scope
+	duration       tally.Timer
+	activeEntries  tally.Gauge
+	expiredEntries tally.Counter
+	activeElems    map[time.Duration]tally.Gauge
+}
+
+func newAggregatorTickMetrics(scope tally.Scope) aggregatorTickMetrics {
+	return aggregatorTickMetrics{
+		scope:          scope,
+		duration:       scope.Timer("duration"),
+		activeEntries:  scope.Gauge("active-entries"),
+		expiredEntries: scope.Counter("expired-entries"),
+		activeElems:    make(map[time.Duration]tally.Gauge),
+	}
+}
+
+func (m aggregatorTickMetrics) Report(tickResult tickResult, duration time.Duration) {
+	m.duration.Record(duration)
+	m.activeEntries.Update(float64(tickResult.ActiveEntries))
+	m.expiredEntries.Inc(int64(tickResult.ExpiredEntries))
+	for dur, val := range tickResult.ActiveElems {
+		gauge, exists := m.activeElems[dur]
+		if !exists {
+			gauge = m.scope.Tagged(
+				map[string]string{"resolution": dur.String()},
+			).Gauge("active-elems")
+			m.activeElems[dur] = gauge
+		}
+		gauge.Update(float64(val))
+	}
+}
+
+type aggregatorShardMetrics struct {
+	add   tally.Counter
+	close tally.Counter
+}
+
+func newAggregatorShardMetrics(scope tally.Scope) aggregatorShardMetrics {
+	return aggregatorShardMetrics{
+		add:   scope.Counter("add"),
+		close: scope.Counter("close"),
+	}
+}
+
 type aggregatorMetrics struct {
-	tickDuration              tally.Timer
-	tickExpired               tally.Counter
 	counters                  tally.Counter
 	timers                    tally.Counter
 	gauges                    tally.Counter
 	invalidMetricTypes        tally.Counter
 	addMetricWithPoliciesList instrument.MethodMetrics
+	shards                    aggregatorShardMetrics
+	tick                      aggregatorTickMetrics
 }
 
 func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMetrics {
+	shardsScope := scope.SubScope("shards")
 	tickScope := scope.SubScope("tick")
 	return aggregatorMetrics{
-		tickDuration:              tickScope.Timer("duration"),
-		tickExpired:               tickScope.Counter("expired"),
 		counters:                  scope.Counter("counters"),
 		timers:                    scope.Counter("timers"),
 		gauges:                    scope.Counter("gauges"),
 		invalidMetricTypes:        scope.Counter("invalid-metric-types"),
 		addMetricWithPoliciesList: instrument.NewMethodMetrics(scope, "addMetricWithPoliciesList", samplingRate),
+		shards: newAggregatorShardMetrics(shardsScope),
+		tick:   newAggregatorTickMetrics(tickScope),
 	}
 }
 
-type addMetricWithPoliciesListFn func(mu unaggregated.MetricUnion, pl policy.PoliciesList) error
+type updateShardsType int
 
-type waitForFn func(d time.Duration) <-chan time.Time
+const (
+	noUpdateShards updateShardsType = iota
+	updateShards
+)
+
+type aggregatorState int
+
+const (
+	aggregatorNotOpen aggregatorState = iota
+	aggregatorOpen
+	aggregatorClosed
+)
+
+type sleepFn func(d time.Duration)
 
 // aggregator stores aggregations of different types of metrics (e.g., counter,
 // timer, gauges) and periodically flushes them out.
 type aggregator struct {
-	opts                        Options
-	nowFn                       clock.NowFn
-	checkInterval               time.Duration
-	closed                      int32
-	doneCh                      chan struct{}
-	wg                          sync.WaitGroup
-	metricMap                   *metricMap
-	addMetricWithPoliciesListFn addMetricWithPoliciesListFn
-	waitForFn                   waitForFn
-	metrics                     aggregatorMetrics
+	sync.RWMutex
+
+	opts          Options
+	nowFn         clock.NowFn
+	instanceID    string
+	shardFn       ShardFn
+	checkInterval time.Duration
+	handler       Handler
+
+	shardIDs              []uint32
+	shards                []*aggregatorShard
+	placementWatcher      services.StagedPlacementWatcher
+	placementCutoverNanos int64
+	state                 aggregatorState
+	metrics               aggregatorMetrics
+	doneCh                chan struct{}
+	wg                    sync.WaitGroup
+	sleepFn               sleepFn
 }
 
 // NewAggregator creates a new aggregator.
 func NewAggregator(opts Options) Aggregator {
-	doneCh := make(chan struct{})
+	placementWatcherOpts := opts.StagedPlacementWatcherOptions()
+	placementWatcher := placement.NewStagedPlacementWatcher(placementWatcherOpts)
 	iOpts := opts.InstrumentOptions()
-	agg := &aggregator{
-		opts:          opts,
-		nowFn:         opts.ClockOptions().NowFn(),
-		checkInterval: opts.EntryCheckInterval(),
-		doneCh:        doneCh,
-		metricMap:     newMetricMap(opts),
-		metrics:       newAggregatorMetrics(iOpts.MetricsScope(), iOpts.MetricsSamplingRate()),
-	}
-	agg.addMetricWithPoliciesListFn = agg.metricMap.AddMetricWithPoliciesList
-	agg.waitForFn = time.After
+	metrics := newAggregatorMetrics(iOpts.MetricsScope(), iOpts.MetricsSamplingRate())
 
+	return &aggregator{
+		opts:                  opts,
+		nowFn:                 opts.ClockOptions().NowFn(),
+		instanceID:            opts.InstanceID(),
+		shardFn:               opts.ShardFn(),
+		checkInterval:         opts.EntryCheckInterval(),
+		handler:               opts.FlushHandler(),
+		placementWatcher:      placementWatcher,
+		placementCutoverNanos: uninitializedCutoverNanos,
+		metrics:               metrics,
+		doneCh:                make(chan struct{}),
+		sleepFn:               time.Sleep,
+	}
+}
+
+func (agg *aggregator) Open() error {
+	agg.Lock()
+	defer agg.Unlock()
+
+	if agg.state != aggregatorNotOpen {
+		return errAggregatorIsOpenOrClosed
+	}
+	if err := agg.placementWatcher.Watch(); err != nil {
+		return err
+	}
+	if err := agg.initShardsWithLock(); err != nil {
+		return err
+	}
 	if agg.checkInterval > 0 {
 		agg.wg.Add(1)
 		go agg.tick()
 	}
-
-	agg.wg.Add(1)
-	go agg.reportMetrics()
-
-	return agg
+	agg.state = aggregatorOpen
+	return nil
 }
 
 func (agg *aggregator) AddMetricWithPoliciesList(
@@ -112,38 +207,193 @@ func (agg *aggregator) AddMetricWithPoliciesList(
 	pl policy.PoliciesList,
 ) error {
 	callStart := agg.nowFn()
-	if atomic.LoadInt32(&agg.closed) == 1 {
+	if err := agg.checkMetricType(mu.Type); err != nil {
 		agg.metrics.addMetricWithPoliciesList.ReportError(agg.nowFn().Sub(callStart))
-		return errAggregatorClosed
+		return err
 	}
-	switch mu.Type {
-	case unaggregated.CounterType:
-		agg.metrics.counters.Inc(1)
-	case unaggregated.BatchTimerType:
-		agg.metrics.timers.Inc(1)
-	case unaggregated.GaugeType:
-		agg.metrics.gauges.Inc(1)
-	default:
-		agg.metrics.invalidMetricTypes.Inc(1)
+	shard, err := agg.shardFor(mu.ID)
+	if err != nil {
 		agg.metrics.addMetricWithPoliciesList.ReportError(agg.nowFn().Sub(callStart))
-		return errInvalidMetricType
+		return err
 	}
-	err := agg.addMetricWithPoliciesListFn(mu, pl)
+	err = shard.AddMetricWithPoliciesList(mu, pl)
 	agg.metrics.addMetricWithPoliciesList.ReportSuccessOrError(err, agg.nowFn().Sub(callStart))
 	return err
 }
 
-func (agg *aggregator) Close() {
-	if !atomic.CompareAndSwapInt32(&agg.closed, 0, 1) {
-		return
+func (agg *aggregator) Close() error {
+	agg.Lock()
+	defer agg.Unlock()
+
+	if agg.state != aggregatorOpen {
+		return errAggregatorIsNotOpenOrClosed
+	}
+	agg.state = aggregatorClosed
+	close(agg.doneCh)
+	for _, shardID := range agg.shardIDs {
+		agg.shards[shardID].Close()
+	}
+	agg.handler.Close()
+	return nil
+}
+
+func (agg *aggregator) shardFor(id id.RawID) (*aggregatorShard, error) {
+	agg.RLock()
+	shard, err := agg.shardForWithLock(id, noUpdateShards)
+	if err == nil || err != errActivePlacementChanged {
+		agg.RUnlock()
+		return shard, err
+	}
+	agg.RUnlock()
+
+	agg.Lock()
+	shard, err = agg.shardForWithLock(id, updateShards)
+	agg.Unlock()
+
+	return shard, err
+}
+
+func (agg *aggregator) shardForWithLock(id id.RawID, updateShardsType updateShardsType) (*aggregatorShard, error) {
+	if agg.state != aggregatorOpen {
+		return nil, errAggregatorIsNotOpenOrClosed
+	}
+	stagedPlacement, onStagedPlacementDoneFn, err := agg.placementWatcher.ActiveStagedPlacement()
+	if err != nil {
+		return nil, err
+	}
+	placement, onPlacementDoneFn, err := stagedPlacement.ActivePlacement()
+	if err != nil {
+		onStagedPlacementDoneFn()
+		return nil, err
+	}
+	shard, err := agg.findOrUpdateShardWithLock(id, placement, updateShardsType)
+	onPlacementDoneFn()
+	onStagedPlacementDoneFn()
+	return shard, err
+}
+
+func (agg *aggregator) findOrUpdateShardWithLock(
+	id id.RawID,
+	placement services.Placement,
+	updateShardsType updateShardsType,
+) (*aggregatorShard, error) {
+	if agg.shouldUpdateShardsWithLock(placement) {
+		if updateShardsType == noUpdateShards {
+			return nil, errActivePlacementChanged
+		}
+		if err := agg.updateShardsWithLock(placement); err != nil {
+			return nil, err
+		}
+	}
+	numShards := placement.NumShards()
+	shardID := agg.shardFn([]byte(id), numShards)
+	if int(shardID) >= len(agg.shards) || agg.shards[shardID] == nil {
+		return nil, fmt.Errorf("not responsible for shard %d", shardID)
+	}
+	return agg.shards[shardID], nil
+}
+
+func (agg *aggregator) initShardsWithLock() error {
+	stagedPlacement, onStagedPlacementDoneFn, err := agg.placementWatcher.ActiveStagedPlacement()
+	if err != nil {
+		return err
+	}
+	defer onStagedPlacementDoneFn()
+
+	placement, onPlacementDoneFn, err := stagedPlacement.ActivePlacement()
+	if err != nil {
+		return err
+	}
+	defer onPlacementDoneFn()
+
+	return agg.updateShardsWithLock(placement)
+}
+
+func (agg *aggregator) updateShardsWithLock(newPlacement services.Placement) error {
+	// If someone has already updated the shards ahead of us, do nothing.
+	if !agg.shouldUpdateShardsWithLock(newPlacement) {
+		return nil
+	}
+	instance, found := newPlacement.Instance(agg.instanceID)
+	if !found {
+		return fmt.Errorf("instance %s not found in the placement", agg.instanceID)
 	}
 
-	// Waiting for the ticking goroutine to return.
-	close(agg.doneCh)
-	agg.wg.Wait()
+	var (
+		newShards = instance.Shards()
+		incoming  []*aggregatorShard
+		closing   []*aggregatorShard
+	)
+	for _, shard := range agg.shards {
+		if shard == nil {
+			continue
+		}
+		if !newShards.Contains(shard.ID()) {
+			closing = append(closing, shard)
+		}
+	}
+	// NB(xichen): shard ids are guaranteed to be sorted in ascending order.
+	newShardIDs := newShards.AllIDs()
+	if len(newShardIDs) > 0 {
+		newShardLen := newShardIDs[len(newShardIDs)-1] + 1
+		incoming = make([]*aggregatorShard, newShardLen)
+	}
+	for _, shardID := range newShardIDs {
+		if int(shardID) < len(agg.shards) && agg.shards[shardID] != nil {
+			incoming[shardID] = agg.shards[shardID]
+		} else {
+			incoming[shardID] = newAggregatorShard(shardID, agg.opts)
+			agg.metrics.shards.add.Inc(1)
+		}
+	}
+	agg.shardIDs = newShardIDs
+	agg.shards = incoming
+	agg.placementCutoverNanos = newPlacement.CutoverNanos()
 
-	// Closing metric map.
-	agg.metricMap.Close()
+	// NB(xichen): asynchronously closing the shards to avoid blocking writes.
+	// Additionally, because each shard write happens while holding the shard
+	// read lock, the shard may only close itself after all its pending writes
+	// are finished.
+	for _, shard := range closing {
+		shard := shard
+		go func() {
+			shard.Close()
+			agg.metrics.shards.close.Inc(1)
+		}()
+	}
+
+	return nil
+}
+
+func (agg *aggregator) shouldUpdateShardsWithLock(newPlacement services.Placement) bool {
+	return agg.placementCutoverNanos < newPlacement.CutoverNanos()
+}
+
+func (agg *aggregator) checkMetricType(metricType unaggregated.Type) error {
+	switch metricType {
+	case unaggregated.CounterType:
+		agg.metrics.counters.Inc(1)
+		return nil
+	case unaggregated.BatchTimerType:
+		agg.metrics.timers.Inc(1)
+		return nil
+	case unaggregated.GaugeType:
+		agg.metrics.gauges.Inc(1)
+		return nil
+	default:
+		agg.metrics.invalidMetricTypes.Inc(1)
+		return errInvalidMetricType
+	}
+}
+
+func (agg *aggregator) ownedShards() []*aggregatorShard {
+	agg.RLock()
+	ownedShards := make([]*aggregatorShard, len(agg.shardIDs))
+	for i, shardID := range agg.shardIDs {
+		ownedShards[i] = agg.shards[shardID]
+	}
+	agg.RUnlock()
+	return ownedShards
 }
 
 func (agg *aggregator) tick() {
@@ -160,34 +410,23 @@ func (agg *aggregator) tick() {
 }
 
 func (agg *aggregator) tickInternal() {
-	start := agg.nowFn()
-	tickExpired := agg.metricMap.DeleteExpired(agg.checkInterval)
-	tickDuration := agg.nowFn().Sub(start)
-	agg.metrics.tickExpired.Inc(tickExpired)
-	agg.metrics.tickDuration.Record(tickDuration)
-	if tickDuration < agg.checkInterval {
-		// NB(xichen): use a channel here instead of sleeping in case
-		// server needs to close and we don't tick frequently enough.
-		select {
-		case <-agg.waitForFn(agg.checkInterval - tickDuration):
-		case <-agg.doneCh:
-		}
+	ownedShards := agg.ownedShards()
+	numShards := len(ownedShards)
+	if numShards == 0 {
+		return
 	}
-}
-
-func (agg *aggregator) reportMetrics() {
-	defer agg.wg.Done()
-
-	reportInterval := agg.opts.InstrumentOptions().ReportInterval()
-	t := time.NewTicker(reportInterval)
-
-	for {
-		select {
-		case <-t.C:
-			agg.metricMap.reportMetrics()
-		case <-agg.doneCh:
-			t.Stop()
-			return
-		}
+	var (
+		start                = agg.nowFn()
+		perShardTickDuration = agg.checkInterval / time.Duration(numShards)
+		tickResult           tickResult
+	)
+	for _, shard := range ownedShards {
+		shardTickResult := shard.Tick(perShardTickDuration)
+		tickResult = tickResult.merge(shardTickResult)
+	}
+	tickDuration := agg.nowFn().Sub(start)
+	agg.metrics.tick.Report(tickResult, tickDuration)
+	if tickDuration < agg.checkInterval {
+		agg.sleepFn(agg.checkInterval - tickDuration)
 	}
 }

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -86,12 +86,14 @@ func (m aggregatorTickMetrics) Report(tickResult tickResult, duration time.Durat
 type aggregatorShardMetrics struct {
 	add   tally.Counter
 	close tally.Counter
+	owned tally.Gauge
 }
 
 func newAggregatorShardMetrics(scope tally.Scope) aggregatorShardMetrics {
 	return aggregatorShardMetrics{
 		add:   scope.Counter("add"),
 		close: scope.Counter("close"),
+		owned: scope.Gauge("owned"),
 	}
 }
 
@@ -412,6 +414,7 @@ func (agg *aggregator) tick() {
 func (agg *aggregator) tickInternal() {
 	ownedShards := agg.ownedShards()
 	numShards := len(ownedShards)
+	agg.metrics.shards.owned.Update(float64(numShards))
 	if numShards == 0 {
 		return
 	}

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -21,58 +21,222 @@
 package aggregator
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 
+	placementproto "github.com/m3db/m3cluster/generated/proto/placement"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3cluster/proto/util"
+	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/services/placement"
+	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/protocol/msgpack"
+	"github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestAggregator(t *testing.T) {
-	agg := NewAggregator(testOptions().SetEntryCheckInterval(0)).(*aggregator)
+const (
+	testInstanceID       = "localhost:0"
+	testPlacementKey     = "placement"
+	testNumShards        = 4
+	testPlacementCutover = 1234
+)
 
-	var (
-		resultMu           unaggregated.MetricUnion
-		resultPoliciesList policy.PoliciesList
-	)
-	agg.addMetricWithPoliciesListFn = func(
-		mu unaggregated.MetricUnion,
-		pl policy.PoliciesList,
-	) error {
-		resultMu = mu
-		resultPoliciesList = pl
-		return nil
+var (
+	testValidMetric = unaggregated.MetricUnion{
+		Type:       unaggregated.CounterType,
+		ID:         []byte("foo"),
+		CounterVal: 1234,
 	}
-	agg.waitForFn = func(time.Duration) <-chan time.Time {
-		c := make(chan time.Time)
-		close(c)
-		return c
+	testInvalidMetric = unaggregated.MetricUnion{
+		Type: unaggregated.UnknownType,
+		ID:   []byte("testInvalid"),
+	}
+	testPoliciesList = policy.PoliciesList{
+		policy.NewStagedPolicies(123, false, []policy.Policy{
+			policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
+			policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+		}),
+		policy.NewStagedPolicies(456, true, nil),
+	}
+)
+
+func TestAggregatorOpenAlreadyOpen(t *testing.T) {
+	agg, _ := testAggregator(t)
+	agg.state = aggregatorOpen
+	require.Equal(t, errAggregatorIsOpenOrClosed, agg.Open())
+}
+
+func TestAggregatorOpenSuccess(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+	require.Equal(t, aggregatorOpen, agg.state)
+	require.Equal(t, []uint32{0, 1, 2, 3}, agg.shardIDs)
+	for i := 0; i < testNumShards; i++ {
+		require.NotNil(t, agg.shards[i])
+	}
+	require.Equal(t, int64(testPlacementCutover), agg.placementCutoverNanos)
+}
+
+func TestAggregatorAddMetricWithPoliciesListInvalidMetricType(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+	err := agg.AddMetricWithPoliciesList(testInvalidMetric, testPoliciesList)
+	require.Equal(t, errInvalidMetricType, err)
+}
+
+func TestAggregatorAddMetricWithPoliciesListNotOpen(t *testing.T) {
+	agg, _ := testAggregator(t)
+	err := agg.AddMetricWithPoliciesList(testValidMetric, testPoliciesList)
+	require.Equal(t, errAggregatorIsNotOpenOrClosed, err)
+}
+
+func TestAggregatorAddMetricWithPoliciesListPlacementWatcherUnwatched(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+
+	require.NoError(t, agg.placementWatcher.Unwatch())
+	err := agg.AddMetricWithPoliciesList(testValidMetric, testPoliciesList)
+	require.Error(t, err)
+}
+
+func TestAggregatorAddMetricWithPoliciesListNotResponsibleForShard(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+	agg.shardFn = func([]byte, int) uint32 { return testNumShards }
+	err := agg.AddMetricWithPoliciesList(testValidMetric, testPoliciesList)
+	require.Error(t, err)
+}
+
+func TestAggregatorAddMetricWithPoliciesListSuccessNoPlacementUpdate(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+	agg.shardFn = func([]byte, int) uint32 { return 1 }
+	err := agg.AddMetricWithPoliciesList(testValidMetric, testPoliciesList)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(agg.shards[1].metricMap.entries))
+}
+
+func TestAggregatorAddMetricWithPoliciesListSuccessWithPlacementUpdate(t *testing.T) {
+	agg, store := testAggregator(t)
+	require.NoError(t, agg.Open())
+	agg.shardFn = func([]byte, int) uint32 { return 1 }
+
+	newShardAssignment := []shard.Shard{
+		shard.NewShard(0).SetState(shard.Initializing),
+		shard.NewShard(1).SetState(shard.Initializing),
+		shard.NewShard(2).SetState(shard.Initializing),
+		shard.NewShard(4).SetState(shard.Initializing),
+	}
+	newStagedPlacementProto := testStagedPlacementProtoWithCustomShards(t, newShardAssignment, 5678)
+	_, err := store.Set(testPlacementKey, newStagedPlacementProto)
+	require.NoError(t, err)
+
+	// Wait for the placement to be updated.
+	for {
+		stagedPlacement, stagedPlacementDoneFn, err := agg.placementWatcher.ActiveStagedPlacement()
+		require.NoError(t, err)
+		placement, placementDoneFn, err := stagedPlacement.ActivePlacement()
+		require.NoError(t, err)
+		cutoverNanos := placement.CutoverNanos()
+		placementDoneFn()
+		stagedPlacementDoneFn()
+		if cutoverNanos == 5678 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Add a counter metric
-	require.NoError(t, agg.AddMetricWithPoliciesList(testCounter, testCustomPoliciesList))
-	require.Equal(t, testCounter, resultMu)
-	require.Equal(t, testCustomPoliciesList, resultPoliciesList)
+	existingShard := agg.shards[3]
+	err = agg.AddMetricWithPoliciesList(testValidMetric, testPoliciesList)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(agg.shards))
+	for i := 0; i < 5; i++ {
+		if i == 3 {
+			require.Nil(t, agg.shards[i])
+		} else {
+			require.NotNil(t, agg.shards[i])
+		}
+	}
+	require.Equal(t, 1, len(agg.shards[1].metricMap.entries))
+	for {
+		existingShard.RLock()
+		closed := existingShard.closed
+		existingShard.RUnlock()
+		if closed {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
 
-	// Force a tick
+func TestAggregatorCloseAlreadyClosed(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.Equal(t, errAggregatorIsNotOpenOrClosed, agg.Close())
+}
+
+func TestAggregatorCloseSuccess(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+	require.NoError(t, agg.Close())
+	require.Equal(t, aggregatorClosed, agg.state)
+}
+
+func TestAggregatorTick(t *testing.T) {
+	agg, _ := testAggregator(t)
+	require.NoError(t, agg.Open())
+
+	// Forcing a tick.
 	agg.tickInternal()
 
-	// Close the aggregator
-	agg.Close()
+	require.NoError(t, agg.Close())
+}
 
-	// Closing a second time should be a no op
-	agg.Close()
+func testAggregator(t *testing.T) (*aggregator, kv.Store) {
+	opts := testOptions().SetEntryCheckInterval(0)
 
-	// Adding a metric to a closed aggregator should result in an error
-	err := agg.AddMetricWithPoliciesList(testCounter, testCustomPoliciesList)
-	require.Equal(t, errAggregatorClosed, err)
+	testStagedPlacementProto := testStagedPlacementProtoWithNumShards(t, testNumShards)
+	testPlacementStore := mem.NewStore()
+	_, err := testPlacementStore.SetIfNotExists(testPlacementKey, testStagedPlacementProto)
+	require.NoError(t, err)
+	placementWatcherOpts := placement.NewStagedPlacementWatcherOptions().
+		SetStagedPlacementKey(testPlacementKey).
+		SetStagedPlacementStore(testPlacementStore)
+	opts = opts.SetInstanceID(testInstanceID).SetStagedPlacementWatcherOptions(placementWatcherOpts)
 
-	// Assert the aggregator is closed
-	require.Equal(t, int32(1), atomic.LoadInt32(&agg.closed))
+	return NewAggregator(opts).(*aggregator), testPlacementStore
+}
+
+func testStagedPlacementProtoWithNumShards(t *testing.T, numShards int) *placementproto.PlacementSnapshots {
+	shardSet := make([]shard.Shard, numShards)
+	for i := 0; i < numShards; i++ {
+		shardSet[i] = shard.NewShard(uint32(i)).SetState(shard.Initializing)
+	}
+	return testStagedPlacementProtoWithCustomShards(t, shardSet, testPlacementCutover)
+}
+
+func testStagedPlacementProtoWithCustomShards(
+	t *testing.T,
+	shardSet []shard.Shard,
+	cutoverNanos int64,
+) *placementproto.PlacementSnapshots {
+	shards := shard.NewShards(shardSet)
+	instance := placement.NewInstance().
+		SetID(testInstanceID).
+		SetShards(shards)
+	testPlacement := placement.NewPlacement().
+		SetInstances([]services.PlacementInstance{instance}).
+		SetShards(shards.AllIDs()).
+		SetCutoverNanos(cutoverNanos)
+	testStagedPlacement := placement.NewStagedPlacement().
+		SetPlacements([]services.Placement{testPlacement})
+	stagedPlacementProto, err := util.StagedPlacementToProto(testStagedPlacement)
+	require.NoError(t, err)
+	return stagedPlacementProto
 }
 
 func testOptions() Options {

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -23,7 +23,6 @@ package aggregator
 import (
 	"container/list"
 	"errors"
-	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,10 +33,6 @@ import (
 	"github.com/m3db/m3x/errors"
 
 	"github.com/uber-go/tally"
-)
-
-const (
-	uninitializedCutoverNanos = math.MinInt64
 )
 
 var (

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -53,11 +53,6 @@ var (
 		policy.NewPolicy(10*time.Second, xtime.Second, 48*time.Hour),
 		policy.NewPolicy(time.Minute, xtime.Minute, 720*time.Hour),
 	}
-	testInvalidID     = id.RawID("testInvalid")
-	testInvalidMetric = unaggregated.MetricUnion{
-		Type: unaggregated.UnknownType,
-		ID:   testInvalidID,
-	}
 )
 
 func TestEntryIncDecWriter(t *testing.T) {

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -42,7 +42,6 @@ var (
 )
 
 type metricListMetrics struct {
-	numElems       tally.Gauge
 	encodeErrors   tally.Counter
 	flushCollected tally.Counter
 	flushSuccess   tally.Counter
@@ -53,7 +52,6 @@ type metricListMetrics struct {
 func newMetricListMetrics(scope tally.Scope) metricListMetrics {
 	flushScope := scope.SubScope("flush")
 	return metricListMetrics{
-		numElems:       scope.Gauge("num-elems"),
 		encodeErrors:   scope.Counter("encode-errors"),
 		flushCollected: flushScope.Counter("collected"),
 		flushSuccess:   flushScope.Counter("success"),
@@ -63,6 +61,7 @@ func newMetricListMetrics(scope tally.Scope) metricListMetrics {
 }
 
 type encodeFn func(mp aggregated.ChunkedMetricWithPolicy) error
+type waitForFn func(d time.Duration) <-chan time.Time
 
 // metricList stores aggregated metrics at a given resolution
 // and flushes aggregations periodically.
@@ -134,19 +133,15 @@ func newMetricList(resolution time.Duration, opts Options) *metricList {
 	return l
 }
 
-// Close closes the list.
-func (l *metricList) Close() {
-	l.Lock()
-	if l.closed {
-		l.Unlock()
-		return
-	}
-	l.closed = true
-	l.Unlock()
+// Resolution returns the resolution of the list.
+func (l *metricList) Resolution() time.Duration { return l.resolution }
 
-	// Waiting for the ticking goroutine to finish.
-	close(l.doneCh)
-	l.wgFlush.Wait()
+// Len returns the number of elements in the list.
+func (l *metricList) Len() int {
+	l.RLock()
+	numElems := l.aggregations.Len()
+	l.RUnlock()
+	return numElems
 }
 
 // PushBack adds an element to the list.
@@ -163,6 +158,21 @@ func (l *metricList) PushBack(value interface{}) (*list.Element, error) {
 	elem := l.aggregations.PushBack(value)
 	l.Unlock()
 	return elem, nil
+}
+
+// Close closes the list.
+func (l *metricList) Close() {
+	l.Lock()
+	if l.closed {
+		l.Unlock()
+		return
+	}
+	l.closed = true
+	l.Unlock()
+
+	// Waiting for the ticking goroutine to finish.
+	close(l.doneCh)
+	l.wgFlush.Wait()
 }
 
 // flush flushes out aggregated metrics.
@@ -301,18 +311,6 @@ func (l *metricList) processAggregatedMetric(
 	}
 }
 
-func (l *metricList) reportMetrics() {
-	l.RLock()
-	if l.closed {
-		l.RUnlock()
-		return
-	}
-	numElems := l.aggregations.Len()
-	l.RUnlock()
-
-	l.metrics.numElems.Update(float64(numElems))
-}
-
 type newMetricListFn func(resolution time.Duration, opts Options) *metricList
 
 // metricLists contains all the metric lists.
@@ -320,7 +318,6 @@ type metricLists struct {
 	sync.RWMutex
 
 	opts            Options
-	handler         Handler
 	newMetricListFn newMetricListFn
 	closed          bool
 	lists           map[time.Duration]*metricList
@@ -329,33 +326,17 @@ type metricLists struct {
 func newMetricLists(opts Options) *metricLists {
 	return &metricLists{
 		opts:            opts,
-		handler:         opts.FlushHandler(),
 		newMetricListFn: newMetricList,
 		lists:           make(map[time.Duration]*metricList),
 	}
 }
 
-// Len returns the number of lists
+// Len returns the number of lists.
 func (l *metricLists) Len() int {
 	l.RLock()
 	numLists := len(l.lists)
 	l.RUnlock()
 	return numLists
-}
-
-// Close closes the metric lists
-func (l *metricLists) Close() {
-	l.Lock()
-	if l.closed {
-		l.Unlock()
-		return
-	}
-	l.closed = true
-	for _, list := range l.lists {
-		list.Close()
-	}
-	l.handler.Close()
-	l.Unlock()
 }
 
 // FindOrCreate looks up a metric list based on a resolution,
@@ -388,14 +369,30 @@ func (l *metricLists) FindOrCreate(resolution time.Duration) (*metricList, error
 	return list, nil
 }
 
-func (l *metricLists) reportMetrics() {
+// Tick ticks through each list and returns the list sizes.
+func (l *metricLists) Tick() map[time.Duration]int {
 	l.RLock()
+	defer l.RUnlock()
+
+	activeElems := make(map[time.Duration]int, len(l.lists))
+	for _, list := range l.lists {
+		resolution := list.Resolution()
+		numElems := list.Len()
+		activeElems[resolution] = numElems
+	}
+	return activeElems
+}
+
+// Close closes the metric lists.
+func (l *metricLists) Close() {
+	l.Lock()
+	defer l.Unlock()
+
 	if l.closed {
-		l.RUnlock()
 		return
 	}
+	l.closed = true
 	for _, list := range l.lists {
-		list.reportMetrics()
+		list.Close()
 	}
-	l.RUnlock()
 }

--- a/aggregator/mock/aggregator.go
+++ b/aggregator/mock/aggregator.go
@@ -46,6 +46,8 @@ func NewAggregator() Aggregator {
 	return &mockAggregator{}
 }
 
+func (agg *mockAggregator) Open() error { return nil }
+
 func (agg *mockAggregator) AddMetricWithPoliciesList(
 	mu unaggregated.MetricUnion,
 	pl policy.PoliciesList,
@@ -86,7 +88,7 @@ func (agg *mockAggregator) AddMetricWithPoliciesList(
 	return nil
 }
 
-func (agg *mockAggregator) Close() {}
+func (agg *mockAggregator) Close() error { return nil }
 
 func (agg *mockAggregator) NumMetricsAdded() int {
 	agg.RLock()

--- a/aggregator/shard.go
+++ b/aggregator/shard.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3metrics/metric/unaggregated"
+	"github.com/m3db/m3metrics/policy"
+)
+
+var (
+	errAggregatorShardClosed = errors.New("aggregator shard is closed")
+)
+
+type addMetricWithPoliciesListFn func(mu unaggregated.MetricUnion, pl policy.PoliciesList) error
+
+type aggregatorShard struct {
+	sync.RWMutex
+
+	shard                       uint32
+	closed                      bool
+	metricMap                   *metricMap
+	addMetricWithPoliciesListFn addMetricWithPoliciesListFn
+}
+
+func newAggregatorShard(shard uint32, opts Options) *aggregatorShard {
+	s := &aggregatorShard{
+		shard:     shard,
+		metricMap: newMetricMap(opts),
+	}
+	s.addMetricWithPoliciesListFn = s.metricMap.AddMetricWithPoliciesList
+	return s
+}
+
+func (s *aggregatorShard) ID() uint32 { return s.shard }
+
+func (s *aggregatorShard) AddMetricWithPoliciesList(
+	mu unaggregated.MetricUnion,
+	pl policy.PoliciesList,
+) error {
+	s.RLock()
+	if s.closed {
+		s.RUnlock()
+		return errAggregatorShardClosed
+	}
+	err := s.addMetricWithPoliciesListFn(mu, pl)
+	s.RUnlock()
+	return err
+}
+
+func (s *aggregatorShard) Tick(target time.Duration) tickResult {
+	return s.metricMap.Tick(target)
+}
+
+func (s *aggregatorShard) Close() {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.metricMap.Close()
+}

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -56,13 +56,13 @@ aggregator:
   defaultPolicies:
     - 10s:2d
     - 1m:40d
-  entryPool:
-    size: 4096
   counterElemPool:
     size: 4096
   timerElemPool:
     size: 4096
   gaugeElemPool:
+    size: 4096
+  entryPool:
     size: 4096
   bufferedEncoderPool:
     size: 4096

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -46,12 +46,13 @@ aggregator:
           capacity: 32
         - count: 1024
           capacity: 16
+  shardFnType: murmur32
   minFlushInterval: 5s
   maxFlushSize: 1440
   flush:
     type: logging
-  entryTTL: 24h
-  entryCheckInterval: 1h
+  entryTTL: 6h
+  entryCheckInterval: 10m
   defaultPolicies:
     - 10s:2d
     - 1m:40d

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b71cb03c4fd6b9ec2f01be00eb0db982a88e15115c90f511be43aaeeb61fda8d
-updated: 2017-05-22T18:57:31.35747021-04:00
+hash: b470cc126c32ae7ea57e615e910ec2ec2e36da12029cbe6370a8241cc766427e
+updated: 2017-05-24T19:54:42.399850038-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -48,7 +48,7 @@ imports:
   - runtime/internal
   - utilities
 - name: github.com/m3db/m3cluster
-  version: f7c0adb482990557c46fe004f216214e3b7a3df9
+  version: b596a86b06f37c9150ea352d6ec1549ed19f304b
   subpackages:
   - client
   - client/etcd

--- a/glide.lock
+++ b/glide.lock
@@ -1,29 +1,76 @@
-hash: 8dbe61fa8b0166cd53c2b397916b22e723a515708e58533ccb9f2e4ee38ce110
-updated: 2017-05-11T09:06:17.03711491-04:00
+hash: b71cb03c4fd6b9ec2f01be00eb0db982a88e15115c90f511be43aaeeb61fda8d
+updated: 2017-05-22T18:57:31.35747021-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
   subpackages:
   - lib/go/thrift
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
+- name: github.com/coreos/etcd
+  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
+  subpackages:
+  - auth/authpb
+  - clientv3
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - mvcc/mvccpb
+  - pkg/tlsutil
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
   - oleutil
+- name: github.com/golang/mock
+  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  subpackages:
+  - gomock
 - name: github.com/golang/protobuf
   version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
   subpackages:
+  - jsonpb
   - proto
+- name: github.com/grpc-ecosystem/go-grpc-prometheus
+  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+- name: github.com/grpc-ecosystem/grpc-gateway
+  version: 84398b94e188ee336f307779b57b3aa91af7063c
+  subpackages:
+  - runtime
+  - runtime/internal
+  - utilities
+- name: github.com/m3db/m3cluster
+  version: f7c0adb482990557c46fe004f216214e3b7a3df9
+  subpackages:
+  - client
+  - client/etcd
+  - etcd/watchmanager
+  - generated/proto/metadata
+  - generated/proto/placement
+  - kv
+  - kv/etcd
+  - kv/mem
+  - kv/util/runtime
+  - proto/util
+  - services
+  - services/client
+  - services/heartbeat/etcd
+  - services/placement
+  - services/placement/algo
+  - services/placement/service
+  - shard
 - name: github.com/m3db/m3metrics
   version: 5a4ec9a107763207c0e077c04a56e73119208408
   subpackages:
   - generated/proto/schema
-  - metric
   - metric/aggregated
   - metric/id
   - metric/unaggregated
@@ -34,8 +81,10 @@ imports:
   subpackages:
   - checked
   - clock
+  - close
   - config
   - errors
+  - id
   - instrument
   - log
   - net
@@ -45,12 +94,31 @@ imports:
   - retry
   - sync
   - time
+  - watch
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
 - name: github.com/prometheus/common
   version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
 - name: github.com/shirou/gopsutil
   version: b62e301a8b9958eebb7299683eb57fab229a9501
   subpackages:
@@ -64,6 +132,8 @@ imports:
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/Sirupsen/logrus
   version: cd7d1bbe41066b6c1f19780f895901052150a575
+- name: github.com/spaolacci/murmur3
+  version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 - name: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/stretchr/testify
@@ -84,6 +154,10 @@ imports:
   version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
   subpackages:
   - context
+  - http2
+  - http2/hpack
+  - internal/timeseries
+  - trace
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
 - name: google.golang.org/appengine
@@ -97,6 +171,17 @@ imports:
   - internal/log
   - internal/modules
   - internal/remote_api
+- name: google.golang.org/grpc
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 - name: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/vmihailenco/msgpack.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,54 +3,63 @@ package: github.com/m3db/m3aggregator
 import:
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
-
+- package: github.com/m3db/m3cluster
+  version: f7c0adb482990557c46fe004f216214e3b7a3df9
 - package: github.com/m3db/m3metrics
   version: 5a4ec9a107763207c0e077c04a56e73119208408
-
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
-
 - package: github.com/m3db/m3x
   version: bd6be18ffb184691512eb442561b16a59c15d797
-
 - package: github.com/uber-go/tally
   version: 3.0.0
-
 - package: github.com/golang/protobuf
   version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
-
 - package: golang.org/x/net
   version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
-
 - package: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
-
 - package: github.com/prometheus/common
   version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
-
 - package: github.com/Sirupsen/logrus
   version: cd7d1bbe41066b6c1f19780f895901052150a575
-
 - package: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
-
 - package: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
-
 - package: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
-
 - package: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
-
 - package: github.com/shirou/gopsutil
   version: b62e301a8b9958eebb7299683eb57fab229a9501
-
 - package: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
-
 - package: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
-
 - package: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
+- package: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+- package: github.com/coreos/etcd
+  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
+- package: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- package: github.com/golang/mock
+  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+- package: github.com/grpc-ecosystem/go-grpc-prometheus
+  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+- package: github.com/grpc-ecosystem/grpc-gateway
+  version: 84398b94e188ee336f307779b57b3aa91af7063c
+- package: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+- package: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+- package: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+- package: github.com/prometheus/procfs
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
+- package: github.com/spaolacci/murmur3
+  version: 0d12bf811670bf6a1a63828dfbd003eded177fce
+- package: google.golang.org/grpc
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
 - package: github.com/m3db/m3cluster
-  version: f7c0adb482990557c46fe004f216214e3b7a3df9
+  version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
   version: 5a4ec9a107763207c0e077c04a56e73119208408
 - package: google.golang.org/appengine

--- a/integration/options.go
+++ b/integration/options.go
@@ -27,37 +27,58 @@ const (
 	defaultClientBatchSize          = 1440
 	defaultClientConnectTimeout     = time.Second
 	defaultWorkerPoolSize           = 4
+	defaultInstanceID               = "localhost:6000"
+	defaultNumShards                = 1024
+	defaultPlacementKVKey           = "placement"
 )
 
 type testOptions interface {
-	// SetMsgpackAddr sets the msgpack server address
+	// SetMsgpackAddr sets the msgpack server address.
 	SetMsgpackAddr(value string) testOptions
 
-	// MsgpackAddr returns the msgpack server address
+	// MsgpackAddr returns the msgpack server address.
 	MsgpackAddr() string
 
-	// SetHTTPAddr sets the http server address
+	// SetHTTPAddr sets the http server address.
 	SetHTTPAddr(value string) testOptions
 
-	// HTTPAddr returns the http server address
+	// HTTPAddr returns the http server address.
 	HTTPAddr() string
 
-	// SetClientBatchSize sets the client-side batch size
+	// SetInstanceID sets the instance id.
+	SetInstanceID(value string) testOptions
+
+	// InstanceID returns the instance id.
+	InstanceID() string
+
+	// SetNumShards sets the number of shards.
+	SetNumShards(value int) testOptions
+
+	// NumShards returns the number of shards.
+	NumShards() int
+
+	// SetPlacementKVKey sets the placement kv key.
+	SetPlacementKVKey(value string) testOptions
+
+	// PlacementKVKey returns the placement kv key.
+	PlacementKVKey() string
+
+	// SetClientBatchSize sets the client-side batch size.
 	SetClientBatchSize(value int) testOptions
 
-	// ClientBatchSize returns the client-side batch size
+	// ClientBatchSize returns the client-side batch size.
 	ClientBatchSize() int
 
-	// SetClientConnectTimeout sets the client-side connect timeout
+	// SetClientConnectTimeout sets the client-side connect timeout.
 	SetClientConnectTimeout(value time.Duration) testOptions
 
-	// ClientConnectTimeout returns the client-side connect timeout
+	// ClientConnectTimeout returns the client-side connect timeout.
 	ClientConnectTimeout() time.Duration
 
-	// SetServerStateChangeTimeout sets the client connect timeout
+	// SetServerStateChangeTimeout sets the client connect timeout.
 	SetServerStateChangeTimeout(value time.Duration) testOptions
 
-	// ServerStateChangeTimeout returns the client connect timeout
+	// ServerStateChangeTimeout returns the client connect timeout.
 	ServerStateChangeTimeout() time.Duration
 
 	// SetWorkerPoolSize sets the number of workers in the worker pool.
@@ -70,6 +91,9 @@ type testOptions interface {
 type options struct {
 	msgpackAddr              string
 	httpAddr                 string
+	instanceID               string
+	numShards                int
+	placementKVKey           string
 	serverStateChangeTimeout time.Duration
 	workerPoolSize           int
 	clientBatchSize          int
@@ -78,6 +102,9 @@ type options struct {
 
 func newTestOptions() testOptions {
 	return &options{
+		instanceID:               defaultInstanceID,
+		numShards:                defaultNumShards,
+		placementKVKey:           defaultPlacementKVKey,
 		serverStateChangeTimeout: defaultServerStateChangeTimeout,
 		workerPoolSize:           defaultWorkerPoolSize,
 		clientBatchSize:          defaultClientBatchSize,
@@ -103,6 +130,36 @@ func (o *options) SetHTTPAddr(value string) testOptions {
 
 func (o *options) HTTPAddr() string {
 	return o.httpAddr
+}
+
+func (o *options) SetInstanceID(value string) testOptions {
+	opts := *o
+	opts.instanceID = value
+	return &opts
+}
+
+func (o *options) InstanceID() string {
+	return o.instanceID
+}
+
+func (o *options) SetNumShards(value int) testOptions {
+	opts := *o
+	opts.numShards = value
+	return &opts
+}
+
+func (o *options) NumShards() int {
+	return o.numShards
+}
+
+func (o *options) SetPlacementKVKey(value string) testOptions {
+	opts := *o
+	opts.placementKVKey = value
+	return &opts
+}
+
+func (o *options) PlacementKVKey() string {
+	return o.placementKVKey
 }
 
 func (o *options) SetClientBatchSize(value int) testOptions {

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -23,22 +23,32 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
 	"github.com/m3db/m3aggregator/aggregator"
 	"github.com/m3db/m3aggregator/aggregator/handler"
+	"github.com/m3db/m3cluster/client"
+	etcdclient "github.com/m3db/m3cluster/client/etcd"
+	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/services/placement"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/protocol/msgpack"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/retry"
+
+	"github.com/spaolacci/murmur3"
 )
 
 var (
 	errUnknownQuantileSuffixFnType   = errors.New("unknown quantile suffix function type")
 	errUnknownFlushHandlerType       = errors.New("unknown flush handler type")
+	errNoKVClientConfiguration       = errors.New("no kv client configuration")
 	errNoForwardHandlerConfiguration = errors.New("no forward flush configuration")
 	emptyPolicy                      policy.Policy
 )
@@ -87,6 +97,15 @@ type AggregatorConfiguration struct {
 	// Stream configuration for computing quantiles.
 	Stream streamConfiguration `yaml:"stream"`
 
+	// Client configuration for key value store.
+	KVClient kvClientConfiguration `yaml:"kvClient" validate:"nonzero"`
+
+	// Placement watcher configuration for watching placement updates.
+	PlacementWatcher placementWatcherConfiguration `yaml:"placementWatcher"`
+
+	// Sharding function type.
+	ShardFnType *shardFnType `yaml:"shardFnType"`
+
 	// Minimum flush interval across all resolutions.
 	MinFlushInterval time.Duration `yaml:"minFlushInterval"`
 
@@ -126,6 +145,7 @@ type AggregatorConfiguration struct {
 
 // NewAggregatorOptions creates a new set of aggregator options.
 func (c *AggregatorConfiguration) NewAggregatorOptions(
+	address string,
 	instrumentOpts instrument.Options,
 ) (aggregator.Options, error) {
 	scope := instrumentOpts.MetricsScope()
@@ -160,7 +180,40 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	}
 	opts = opts.SetStreamOptions(streamOpts)
 
-	// Set flushing options.
+	// Set instance id.
+	instanceID, err := instanceID(address)
+	if err != nil {
+		return nil, err
+	}
+	opts = opts.SetInstanceID(instanceID)
+
+	// Create kv client.
+	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("kvClient"))
+	client, err := c.KVClient.NewKVClient(iOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set placement watcher options.
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("placement-watcher"))
+	watcherOpts, err := c.PlacementWatcher.NewPlacementWatcherOptions(iOpts, client)
+	if err != nil {
+		return nil, err
+	}
+	opts = opts.SetStagedPlacementWatcherOptions(watcherOpts)
+
+	// Set sharding function.
+	shardFnType := defaultShardFn
+	if c.ShardFnType != nil {
+		shardFnType = *c.ShardFnType
+	}
+	shardFn, err := shardFnType.ShardFn()
+	if err != nil {
+		return nil, err
+	}
+	opts = opts.SetShardFn(shardFn)
+
+	// Set flushing handler.
 	if c.MinFlushInterval != 0 {
 		opts = opts.SetMinFlushInterval(c.MinFlushInterval)
 	}
@@ -295,6 +348,97 @@ func (c *streamConfiguration) NewStreamOptions(instrumentOpts instrument.Options
 	return opts, nil
 }
 
+// TODO(xichen): add configuration for in-memory client with pre-populated data
+// for different namespaces so we can start up m3aggregator without a real etcd cluster.
+type kvClientConfiguration struct {
+	Etcd *etcdclient.Configuration `yaml:"etcd"`
+}
+
+func (c *kvClientConfiguration) NewKVClient(instrumentOpts instrument.Options) (client.Client, error) {
+	if c.Etcd == nil {
+		return nil, errNoKVClientConfiguration
+	}
+	return c.Etcd.NewClient(instrumentOpts)
+}
+
+type placementWatcherConfiguration struct {
+	// Placement kv namespace.
+	Namespace string `yaml:"namespace" validate:"nonzero"`
+
+	// Placement key.
+	Key string `yaml:"key" validate:"nonzero"`
+
+	// Initial watch timeout.
+	InitWatchTimeout time.Duration `yaml:"initWatchTimeout"`
+}
+
+func (c *placementWatcherConfiguration) NewPlacementWatcherOptions(
+	instrumentOpts instrument.Options,
+	client client.Client,
+) (services.StagedPlacementWatcherOptions, error) {
+	store, err := client.Store(c.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := placement.NewStagedPlacementWatcherOptions().
+		SetInstrumentOptions(instrumentOpts).
+		SetStagedPlacementKey(c.Key).
+		SetStagedPlacementStore(store)
+	if c.InitWatchTimeout != 0 {
+		opts = opts.SetInitWatchTimeout(c.InitWatchTimeout)
+	}
+	return opts, nil
+}
+
+type shardFnType string
+
+// List of supported sharding function types.
+const (
+	unknownShardFn  shardFnType = "unknown"
+	murmur32ShardFn shardFnType = "murmur32"
+
+	defaultShardFn = murmur32ShardFn
+)
+
+var (
+	validShardFnTypes = []shardFnType{
+		murmur32ShardFn,
+	}
+)
+
+func (t *shardFnType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	if str == "" {
+		*t = defaultShardFn
+		return nil
+	}
+	validTypes := make([]string, 0, len(validShardFnTypes))
+	for _, valid := range validShardFnTypes {
+		if str == string(valid) {
+			*t = valid
+			return nil
+		}
+		validTypes = append(validTypes, string(valid))
+	}
+	return fmt.Errorf("invalid shrading function type '%s' valid types are: %s",
+		str, strings.Join(validTypes, ", "))
+}
+
+func (t shardFnType) ShardFn() (aggregator.ShardFn, error) {
+	switch t {
+	case murmur32ShardFn:
+		return func(id []byte, numShards int) uint32 {
+			return murmur3.Sum32(id) % uint32(numShards)
+		}, nil
+	default:
+		return nil, fmt.Errorf("unrecognized hash gen type %v", t)
+	}
+}
+
 // flushHandlerConfiguration contains configuration for flushing metrics.
 type flushHandlerConfiguration struct {
 	// Flushing handler type.
@@ -384,4 +528,16 @@ func setMetricPrefixOrSuffix(
 		return opts
 	}
 	return fn([]byte(str))
+}
+
+func instanceID(address string) (string, error) {
+	hostName, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("error determining host name: %v", err)
+	}
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", fmt.Errorf("error parse msgpack server address %s: %v", address, err)
+	}
+	return net.JoinHostPort(hostName, port), nil
 }

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -127,9 +127,6 @@ type AggregatorConfiguration struct {
 	// Default policies.
 	DefaultPolicies []policy.Policy `yaml:"defaultPolicies" validate:"nonzero"`
 
-	// Pool of entries.
-	EntryPool pool.ObjectPoolConfiguration `yaml:"entryPool"`
-
 	// Pool of counter elements.
 	CounterElemPool pool.ObjectPoolConfiguration `yaml:"counterElemPool"`
 
@@ -138,6 +135,9 @@ type AggregatorConfiguration struct {
 
 	// Pool of gauge elements.
 	GaugeElemPool pool.ObjectPoolConfiguration `yaml:"gaugeElemPool"`
+
+	// Pool of entries.
+	EntryPool pool.ObjectPoolConfiguration `yaml:"entryPool"`
 
 	// Pool of buffered encoders.
 	BufferedEncoderPool pool.ObjectPoolConfiguration `yaml:"bufferedEncoderPool"`
@@ -244,13 +244,6 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	sort.Sort(policy.ByResolutionAsc(policies))
 	opts = opts.SetDefaultPolicies(policies)
 
-	// Set entry pool.
-	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("entry-pool"))
-	entryPoolOpts := c.EntryPool.NewObjectPoolOptions(iOpts)
-	entryPool := aggregator.NewEntryPool(entryPoolOpts)
-	opts = opts.SetEntryPool(entryPool)
-	entryPool.Init(func() *aggregator.Entry { return aggregator.NewEntry(nil, opts) })
-
 	// Set counter elem pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("counter-elem-pool"))
 	counterElemPoolOpts := c.CounterElemPool.NewObjectPoolOptions(iOpts)
@@ -271,6 +264,13 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
 	opts = opts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem { return aggregator.NewGaugeElem(nil, emptyPolicy, opts) })
+
+	// Set entry pool.
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("entry-pool"))
+	entryPoolOpts := c.EntryPool.NewObjectPoolOptions(iOpts)
+	entryPool := aggregator.NewEntryPool(entryPoolOpts)
+	opts = opts.SetEntryPool(entryPool)
+	entryPool.Init(func() *aggregator.Entry { return aggregator.NewEntry(nil, opts) })
 
 	// Set buffered encoder pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("buffered-encoder-pool"))

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -188,7 +188,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	opts = opts.SetInstanceID(instanceID)
 
 	// Create kv client.
-	iOpts = instrumentOpts.SetMetricsScope(instrumentOpts.MetricsScope().SubScope("kvClient"))
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("kvClient"))
 	client, err := c.KVClient.NewKVClient(iOpts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
cc @robskillington @cw9 @jeromefroe @prateek 

Currently all the metrics are stored in a global map, which in turn also stores the element for each metric in a single list per resolution. While this works for small to medium qps, it doesn't scale as the number of unique metrics grows because we have SLAs on the list flush latency for each resolution, which worsens as there are more and more metrics put on the list.

This PR adds logic to shard metrics within each aggregation server so that each shard has its own map / list to store aggregated metrics. This reduce lock contention among metrics on the map, as well as the number of elements per list, which helps with the flush latency.