### PR TITLE
Coordinate flushes across aggregated metric lists

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -148,7 +148,8 @@ type aggregator struct {
 	instanceID    string
 	shardFn       ShardFn
 	checkInterval time.Duration
-	handler       Handler
+	flushManager  FlushManager
+	flushHandler  Handler
 
 	shardIDs              []uint32
 	shards                []*aggregatorShard
@@ -174,7 +175,8 @@ func NewAggregator(opts Options) Aggregator {
 		instanceID:            opts.InstanceID(),
 		shardFn:               opts.ShardFn(),
 		checkInterval:         opts.EntryCheckInterval(),
-		handler:               opts.FlushHandler(),
+		flushManager:          opts.FlushManager(),
+		flushHandler:          opts.FlushHandler(),
 		placementWatcher:      placementWatcher,
 		placementCutoverNanos: uninitializedCutoverNanos,
 		metrics:               metrics,
@@ -235,7 +237,8 @@ func (agg *aggregator) Close() error {
 	for _, shardID := range agg.shardIDs {
 		agg.shards[shardID].Close()
 	}
-	agg.handler.Close()
+	agg.flushManager.Close()
+	agg.flushHandler.Close()
 	return nil
 }
 

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -240,7 +240,23 @@ func testStagedPlacementProtoWithCustomShards(
 }
 
 func testOptions() Options {
-	return NewOptions().SetFlushHandler(&mockHandler{
-		handleFn: func(msgpack.Buffer) error { return nil },
-	})
+	return NewOptions().
+		SetFlushManager(&mockFlushManager{
+			registerFn: func(flusher PeriodicFlusher) error { return nil },
+		}).
+		SetFlushHandler(&mockHandler{
+			handleFn: func(msgpack.Buffer) error { return nil },
+		})
 }
+
+type registerFn func(flusher PeriodicFlusher) error
+
+type mockFlushManager struct {
+	registerFn registerFn
+}
+
+func (mgr *mockFlushManager) Register(flusher PeriodicFlusher) error {
+	return mgr.registerFn(flusher)
+}
+
+func (mgr *mockFlushManager) Close() {}

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -93,6 +93,8 @@ func (e *Entry) IncWriter() { atomic.AddInt32(&e.numWriters, 1) }
 func (e *Entry) DecWriter() { atomic.AddInt32(&e.numWriters, -1) }
 
 // ResetSetData resets the entry and sets initial data.
+// NB(xichen): we need to reset the options here to use the correct
+// time lock contained in the options.
 func (e *Entry) ResetSetData(lists *metricLists, opts Options) {
 	e.closed = false
 	e.opts = opts

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -62,6 +62,7 @@ func newEntryMetrics(scope tally.Scope) entryMetrics {
 type Entry struct {
 	sync.RWMutex
 
+	closed                 bool
 	opts                   Options
 	hasDefaultPoliciesList bool
 	useDefaultPolicies     bool
@@ -71,7 +72,6 @@ type Entry struct {
 	numWriters             int32
 	lastAccessNanos        int64
 	aggregations           map[policy.Policy]*list.Element
-	closed                 bool
 	metrics                entryMetrics
 }
 
@@ -79,11 +79,10 @@ type Entry struct {
 func NewEntry(lists *metricLists, opts Options) *Entry {
 	scope := opts.InstrumentOptions().MetricsScope().SubScope("entry")
 	e := &Entry{
-		opts:         opts,
 		aggregations: make(map[policy.Policy]*list.Element),
 		metrics:      newEntryMetrics(scope),
 	}
-	e.ResetSetData(lists)
+	e.ResetSetData(lists, opts)
 	return e
 }
 
@@ -94,8 +93,9 @@ func (e *Entry) IncWriter() { atomic.AddInt32(&e.numWriters, 1) }
 func (e *Entry) DecWriter() { atomic.AddInt32(&e.numWriters, -1) }
 
 // ResetSetData resets the entry and sets initial data.
-func (e *Entry) ResetSetData(lists *metricLists) {
+func (e *Entry) ResetSetData(lists *metricLists, opts Options) {
 	e.closed = false
+	e.opts = opts
 	e.hasDefaultPoliciesList = false
 	e.useDefaultPolicies = false
 	e.cutoverNanos = uninitializedCutoverNanos

--- a/aggregator/entry_pool_test.go
+++ b/aggregator/entry_pool_test.go
@@ -37,7 +37,7 @@ func TestEntryPool(t *testing.T) {
 	// Retrieve an entry from the pool.
 	entry := p.Get()
 	lists := &metricLists{}
-	entry.ResetSetData(&metricLists{})
+	entry.ResetSetData(&metricLists{}, testOptions())
 	require.Equal(t, lists, entry.lists)
 
 	// Put the entry back to pool.

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -661,7 +661,7 @@ func testEntry() (*Entry, *metricLists, *time.Time) {
 	}
 
 	e := NewEntry(nil, opts)
-	e.ResetSetData(lists)
+	e.ResetSetData(lists, opts)
 
 	return e, lists, &now
 }

--- a/aggregator/flush_mgr.go
+++ b/aggregator/flush_mgr.go
@@ -1,0 +1,338 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/sync"
+
+	"github.com/uber-go/tally"
+)
+
+var (
+	errFlushManagerClosed = errors.New("flush manager is closed")
+)
+
+// PeriodicFlusher flushes periodically.
+type PeriodicFlusher interface {
+	// FlushInterval returns the periodic flush interval.
+	FlushInterval() time.Duration
+
+	// Flush performs a flush.
+	Flush()
+}
+
+// FlushManager manages and coordinates flushing activities across many
+// periodic flushers with different flush intervals with controlled concurrency
+// for flushes to minimize spikes in CPU load and reduce p99 flush latencies.
+type FlushManager interface {
+	// Register registers a metric list with the flush manager.
+	Register(flusher PeriodicFlusher) error
+
+	// Close closes the flush manager.
+	Close()
+}
+
+type flushManagerMetrics struct {
+	queueSize tally.Gauge
+}
+
+func newFlushManagerMetrics(scope tally.Scope) flushManagerMetrics {
+	return flushManagerMetrics{
+		queueSize: scope.Gauge("queue-size"),
+	}
+}
+
+type flushManager struct {
+	sync.Mutex
+
+	nowFn         clock.NowFn
+	checkEvery    time.Duration
+	jitterEnabled bool
+	workers       xsync.WorkerPool
+	scope         tally.Scope
+
+	closed     bool
+	rand       *rand.Rand
+	buckets    []*flushBucket
+	flushTimes flushMetadataHeap
+	sleepFn    sleepFn
+	wgFlush    sync.WaitGroup
+	metrics    flushManagerMetrics
+}
+
+// NewFlushManager creates a new flush manager.
+func NewFlushManager(opts FlushManagerOptions) FlushManager {
+	if opts == nil {
+		opts = NewFlushManagerOptions()
+	}
+	nowFn := opts.ClockOptions().NowFn()
+	scope := opts.InstrumentOptions().MetricsScope()
+	rand := rand.New(rand.NewSource(nowFn().UnixNano()))
+	workers := xsync.NewWorkerPool(opts.WorkerPoolSize())
+	workers.Init()
+
+	mgr := &flushManager{
+		nowFn:         nowFn,
+		checkEvery:    opts.CheckEvery(),
+		jitterEnabled: opts.JitterEnabled(),
+		workers:       workers,
+		scope:         scope,
+		rand:          rand,
+		sleepFn:       time.Sleep,
+		metrics:       newFlushManagerMetrics(scope),
+	}
+	if mgr.checkEvery > 0 {
+		mgr.wgFlush.Add(1)
+		go mgr.flush()
+	}
+	return mgr
+}
+
+func (mgr *flushManager) Register(flusher PeriodicFlusher) error {
+	mgr.Lock()
+	bucket, err := mgr.bucketForWithLock(flusher)
+	if err == nil {
+		bucket.Add(flusher)
+		mgr.Unlock()
+		return nil
+	}
+	mgr.Unlock()
+	return err
+}
+
+func (mgr *flushManager) bucketForWithLock(l PeriodicFlusher) (*flushBucket, error) {
+	if mgr.closed {
+		return nil, errFlushManagerClosed
+	}
+	flushInterval := l.FlushInterval()
+	for _, bucket := range mgr.buckets {
+		if bucket.interval == flushInterval {
+			return bucket, nil
+		}
+	}
+	bucketScope := mgr.scope.SubScope("bucket").Tagged(map[string]string{
+		"interval": flushInterval.String(),
+	})
+	bucket := newBucket(flushInterval, bucketScope)
+	mgr.buckets = append(mgr.buckets, bucket)
+
+	// NB(xichen): this is a new bucket so we need to update the flush times
+	// heap for the flush goroutine to pick it up.
+	nowNanos := mgr.nowNanos()
+	nextFlushNanos := nowNanos + int64(flushInterval)
+	if mgr.jitterEnabled {
+		jitterNanos := int64(mgr.rand.Int63n(int64(flushInterval)))
+		nextFlushNanos = nowNanos + jitterNanos
+	}
+	newFlushMetadata := flushMetadata{
+		timeNanos: nextFlushNanos,
+		bucketIdx: len(mgr.buckets) - 1,
+	}
+	mgr.flushTimes.Push(newFlushMetadata)
+
+	return bucket, nil
+}
+
+func (mgr *flushManager) Close() {
+	mgr.Lock()
+	if mgr.closed {
+		mgr.Unlock()
+		return
+	}
+	mgr.closed = true
+	mgr.Unlock()
+
+	mgr.wgFlush.Wait()
+}
+
+// NB(xichen): apparently timer.Reset() is more difficult to use than I originally
+// anticipated. For now I'm simply waking up every second to check for updates. Maybe
+// when I have more time I'll spend a few hours to get timer.Reset() right and switch
+// to a timer.Start + timer.Stop + timer.Reset + timer.After based approach.
+func (mgr *flushManager) flush() {
+	defer mgr.wgFlush.Done()
+
+	for {
+		var (
+			shouldFlush = false
+			duration    tally.Timer
+			flushers    []PeriodicFlusher
+			waitFor     = mgr.checkEvery
+		)
+		mgr.Lock()
+		if mgr.closed {
+			mgr.Unlock()
+			break
+		}
+		numFlushTimes := mgr.flushTimes.Len()
+		mgr.metrics.queueSize.Update(float64(numFlushTimes))
+		if numFlushTimes > 0 {
+			earliestFlush := mgr.flushTimes.Min()
+			if nowNanos := mgr.nowNanos(); nowNanos >= earliestFlush.timeNanos {
+				// NB(xichen): make a shallow copy of the flushers inside the lock
+				// and use the snapshot for flushing below.
+				shouldFlush = true
+				bucketIdx := earliestFlush.bucketIdx
+				duration = mgr.buckets[bucketIdx].duration
+				flushers = mgr.buckets[bucketIdx].flushers
+				nextFlushMetadata := flushMetadata{
+					timeNanos: earliestFlush.timeNanos + int64(mgr.buckets[bucketIdx].interval),
+					bucketIdx: bucketIdx,
+				}
+				mgr.flushTimes.Pop()
+				mgr.flushTimes.Push(nextFlushMetadata)
+			} else {
+				// NB(xichen): don't oversleep if the next flush is about to happen.
+				timeToNextFlush := time.Duration(earliestFlush.timeNanos - nowNanos)
+				if timeToNextFlush < waitFor {
+					waitFor = timeToNextFlush
+				}
+			}
+		}
+		mgr.Unlock()
+
+		if !shouldFlush {
+			mgr.sleepFn(waitFor)
+		} else {
+			var wgWorkers sync.WaitGroup
+			start := mgr.nowFn()
+			for _, flusher := range flushers {
+				flusher := flusher
+				wgWorkers.Add(1)
+				mgr.workers.Go(func() {
+					flusher.Flush()
+					wgWorkers.Done()
+				})
+			}
+			wgWorkers.Wait()
+			duration.Record(mgr.nowFn().Sub(start))
+		}
+	}
+
+	// Perform a final flush across all flushers before returning.
+	var wgWorkers sync.WaitGroup
+	for _, bucket := range mgr.buckets {
+		for _, flusher := range bucket.flushers {
+			flusher := flusher
+			wgWorkers.Add(1)
+			mgr.workers.Go(func() {
+				flusher.Flush()
+				wgWorkers.Done()
+			})
+		}
+	}
+	wgWorkers.Wait()
+}
+
+func (mgr *flushManager) nowNanos() int64 { return mgr.nowFn().UnixNano() }
+
+// flushBucket contains all the registered lists for a given flush interval.
+type flushBucket struct {
+	interval time.Duration
+	flushers []PeriodicFlusher
+	duration tally.Timer
+}
+
+func newBucket(interval time.Duration, scope tally.Scope) *flushBucket {
+	return &flushBucket{
+		interval: interval,
+		duration: scope.Timer("duration"),
+	}
+}
+
+func (b *flushBucket) Add(flusher PeriodicFlusher) {
+	b.flushers = append(b.flushers, flusher)
+}
+
+// flushMetadata contains metadata information for a flush.
+type flushMetadata struct {
+	timeNanos int64
+	bucketIdx int
+}
+
+// flushMetadataHeap is a min heap for flush metadata where the metadata with the
+// earliest flush time will be at the top of the heap. Unlike the generic heap in
+// the container/heap package, pushing data to or popping data off of the heap doesn't
+// require conversion between flush metadata and interface{}, therefore avoiding the
+// memory and GC overhead due to the additional allocations.
+type flushMetadataHeap []flushMetadata
+
+// Len returns the number of values in the heap.
+func (h flushMetadataHeap) Len() int { return len(h) }
+
+// Min returns the metadata with the earliest flush time from the heap.
+func (h flushMetadataHeap) Min() flushMetadata { return h[0] }
+
+// Push pushes a flush metadata onto the heap.
+func (h *flushMetadataHeap) Push(value flushMetadata) {
+	*h = append(*h, value)
+	h.shiftUp(h.Len() - 1)
+}
+
+// Pop pops the metadata with the earliest flush time from the heap.
+func (h *flushMetadataHeap) Pop() flushMetadata {
+	var (
+		old = *h
+		n   = old.Len()
+		val = old[0]
+	)
+
+	old[0], old[n-1] = old[n-1], old[0]
+	h.heapify(0, n-1)
+	*h = (*h)[0 : n-1]
+	return val
+}
+
+func (h flushMetadataHeap) shiftUp(i int) {
+	for {
+		parent := (i - 1) / 2
+		if parent == i || h[parent].timeNanos <= h[i].timeNanos {
+			break
+		}
+		h[parent], h[i] = h[i], h[parent]
+		i = parent
+	}
+}
+
+func (h flushMetadataHeap) heapify(i, n int) {
+	for {
+		left := i*2 + 1
+		right := left + 1
+		smallest := i
+		if left < n && h[left].timeNanos < h[smallest].timeNanos {
+			smallest = left
+		}
+		if right < n && h[right].timeNanos < h[smallest].timeNanos {
+			smallest = right
+		}
+		if smallest == i {
+			return
+		}
+		h[i], h[smallest] = h[smallest], h[i]
+		i = smallest
+	}
+}

--- a/aggregator/flush_mgr_options.go
+++ b/aggregator/flush_mgr_options.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"math"
+	"runtime"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+)
+
+const (
+	defaultCheckEvery    = time.Second
+	defaultJitterEnabled = true
+)
+
+var (
+	defaultWorkerPoolSize = int(math.Max(float64(runtime.NumCPU()/8), 1.0))
+)
+
+// FlushManagerOptions provide a set of options for the flush manager.
+type FlushManagerOptions interface {
+	// SetClockOptions sets the clock options.
+	SetClockOptions(value clock.Options) FlushManagerOptions
+
+	// ClockOptions returns the clock options.
+	ClockOptions() clock.Options
+
+	// SetInstrumentOptions sets the instrument options.
+	SetInstrumentOptions(value instrument.Options) FlushManagerOptions
+
+	// InstrumentOptions returns the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// SetCheckEvery sets the check period.
+	SetCheckEvery(value time.Duration) FlushManagerOptions
+
+	// CheckEvery returns the check period.
+	CheckEvery() time.Duration
+
+	// SetJitterEnabled sets whether jittering is enabled.
+	SetJitterEnabled(value bool) FlushManagerOptions
+
+	// JitterEnabled returns whether jittering is enabled.
+	JitterEnabled() bool
+
+	// SetWorkerPoolSize sets the worker pool size.
+	SetWorkerPoolSize(value int) FlushManagerOptions
+
+	// WorkerPoolSize returns worker pool size.
+	WorkerPoolSize() int
+}
+
+type flushManagerOptions struct {
+	clockOpts      clock.Options
+	instrumentOpts instrument.Options
+	checkEvery     time.Duration
+	jitterEnabled  bool
+	workerPoolSize int
+}
+
+// NewFlushManagerOptions create a new set of flush manager options.
+func NewFlushManagerOptions() FlushManagerOptions {
+	return &flushManagerOptions{
+		clockOpts:      clock.NewOptions(),
+		instrumentOpts: instrument.NewOptions(),
+		checkEvery:     defaultCheckEvery,
+		jitterEnabled:  defaultJitterEnabled,
+		workerPoolSize: defaultWorkerPoolSize,
+	}
+}
+
+func (o *flushManagerOptions) SetClockOptions(value clock.Options) FlushManagerOptions {
+	opts := *o
+	opts.clockOpts = value
+	return &opts
+}
+
+func (o *flushManagerOptions) ClockOptions() clock.Options {
+	return o.clockOpts
+}
+
+func (o *flushManagerOptions) SetInstrumentOptions(value instrument.Options) FlushManagerOptions {
+	opts := *o
+	opts.instrumentOpts = value
+	return &opts
+}
+
+func (o *flushManagerOptions) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
+}
+
+func (o *flushManagerOptions) SetCheckEvery(value time.Duration) FlushManagerOptions {
+	opts := *o
+	opts.checkEvery = value
+	return &opts
+}
+
+func (o *flushManagerOptions) CheckEvery() time.Duration {
+	return o.checkEvery
+}
+
+func (o *flushManagerOptions) SetJitterEnabled(value bool) FlushManagerOptions {
+	opts := *o
+	opts.jitterEnabled = value
+	return &opts
+}
+
+func (o *flushManagerOptions) JitterEnabled() bool {
+	return o.jitterEnabled
+}
+
+func (o *flushManagerOptions) SetWorkerPoolSize(value int) FlushManagerOptions {
+	opts := *o
+	opts.workerPoolSize = value
+	return &opts
+}
+
+func (o *flushManagerOptions) WorkerPoolSize() int {
+	return o.workerPoolSize
+}

--- a/aggregator/flush_mgr_test.go
+++ b/aggregator/flush_mgr_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlushManagerRegisterClosed(t *testing.T) {
+	mgr, _ := testFlushManager()
+	mgr.closed = true
+	require.Equal(t, errFlushManagerClosed, mgr.Register(nil))
+}
+
+func TestFlushManagerRegisterSuccess(t *testing.T) {
+	mgr, now := testFlushManager()
+	*now = time.Unix(1234, 0)
+
+	flushers := []PeriodicFlusher{
+		&mockFlusher{flushInterval: time.Second},
+		&mockFlusher{flushInterval: time.Minute},
+		&mockFlusher{flushInterval: time.Second},
+		&mockFlusher{flushInterval: time.Hour},
+	}
+	for _, flusher := range flushers {
+		require.NoError(t, mgr.Register(flusher))
+	}
+	expectedBuckets := []*flushBucket{
+		&flushBucket{
+			interval: time.Second,
+			flushers: []PeriodicFlusher{flushers[0], flushers[2]},
+		},
+		&flushBucket{
+			interval: time.Minute,
+			flushers: []PeriodicFlusher{flushers[1]},
+		},
+		&flushBucket{
+			interval: time.Hour,
+			flushers: []PeriodicFlusher{flushers[3]},
+		},
+	}
+	require.Equal(t, len(expectedBuckets), len(mgr.buckets))
+	for i := 0; i < len(expectedBuckets); i++ {
+		require.Equal(t, expectedBuckets[i].interval, mgr.buckets[i].interval)
+		require.Equal(t, expectedBuckets[i].flushers, mgr.buckets[i].flushers)
+	}
+	expectedFlushTimes := []flushMetadata{
+		{timeNanos: 1235000000000, bucketIdx: 0},
+		{timeNanos: 1294000000000, bucketIdx: 1},
+		{timeNanos: 4834000000000, bucketIdx: 2},
+	}
+	require.Equal(t, flushMetadataHeap(expectedFlushTimes), mgr.flushTimes)
+}
+
+func TestFlushManagerCloseSuccess(t *testing.T) {
+	opts, _ := testFlushManagerOptions()
+	opts = opts.SetCheckEvery(time.Second)
+	mgr := NewFlushManager(opts).(*flushManager)
+
+	// Wait a little for the flush goroutine to start.
+	time.Sleep(100 * time.Millisecond)
+
+	mgr.Close()
+	require.True(t, mgr.closed)
+	require.Panics(t, func() { mgr.wgFlush.Done() })
+}
+
+func TestFlushManagerFlush(t *testing.T) {
+	opts := NewFlushManagerOptions().
+		SetCheckEvery(100 * time.Millisecond).
+		SetJitterEnabled(false)
+	mgr := NewFlushManager(opts).(*flushManager)
+
+	var flushCounts [4]int
+	flushers := []PeriodicFlusher{
+		&mockFlusher{
+			flushInterval: 100 * time.Millisecond,
+			flushFn:       func() { flushCounts[0]++ },
+		},
+		&mockFlusher{
+			flushInterval: 200 * time.Millisecond,
+			flushFn:       func() { flushCounts[1]++ },
+		},
+		&mockFlusher{
+			flushInterval: 100 * time.Millisecond,
+			flushFn:       func() { flushCounts[2]++ },
+		},
+		&mockFlusher{
+			flushInterval: 500 * time.Millisecond,
+			flushFn:       func() { flushCounts[3]++ },
+		},
+	}
+
+	for _, flusher := range flushers {
+		require.NoError(t, mgr.Register(flusher))
+	}
+	time.Sleep(1200 * time.Millisecond)
+	mgr.Close()
+
+	require.True(t, flushCounts[0] >= 12)
+	require.True(t, flushCounts[1] >= 6)
+	require.True(t, flushCounts[2] >= 12)
+	require.True(t, flushCounts[3] == 3)
+
+}
+
+func testFlushManager() (*flushManager, *time.Time) {
+	opts, now := testFlushManagerOptions()
+	return NewFlushManager(opts).(*flushManager), now
+}
+
+func testFlushManagerOptions() (FlushManagerOptions, *time.Time) {
+	var now time.Time
+	nowFn := func() time.Time { return now }
+	clockOpts := clock.NewOptions().SetNowFn(nowFn)
+	return NewFlushManagerOptions().
+		SetClockOptions(clockOpts).
+		SetCheckEvery(0).
+		SetJitterEnabled(false), &now
+}
+
+type flushFn func()
+
+type mockFlusher struct {
+	flushInterval time.Duration
+	flushFn       flushFn
+}
+
+func (f *mockFlusher) FlushInterval() time.Duration { return f.flushInterval }
+
+func (f *mockFlusher) Flush() { f.flushFn() }

--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -195,7 +195,7 @@ func (m *metricMap) findOrCreate(mid id.RawID) *Entry {
 	entry, found := m.lookupEntryWithLock(idHash)
 	if !found {
 		entry = m.entryPool.Get()
-		entry.ResetSetData(m.metricLists)
+		entry.ResetSetData(m.metricLists, m.opts)
 		m.entries[idHash] = m.entryList.PushBack(hashedEntry{
 			idHash: idHash,
 			entry:  entry,

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -84,6 +84,7 @@ type options struct {
 	placementWatcherOpts   services.StagedPlacementWatcherOptions
 	instanceID             string
 	shardFn                ShardFn
+	flushManager           FlushManager
 	minFlushInterval       time.Duration
 	maxFlushSize           int
 	flushHandler           Handler
@@ -349,6 +350,16 @@ func (o *options) SetShardFn(value ShardFn) Options {
 
 func (o *options) ShardFn() ShardFn {
 	return o.shardFn
+}
+
+func (o *options) SetFlushManager(value FlushManager) Options {
+	opts := *o
+	opts.flushManager = value
+	return &opts
+}
+
+func (o *options) FlushManager() FlushManager {
+	return o.flushManager
 }
 
 func (o *options) SetMinFlushInterval(value time.Duration) Options {

--- a/aggregator/shard.go
+++ b/aggregator/shard.go
@@ -45,6 +45,10 @@ type aggregatorShard struct {
 }
 
 func newAggregatorShard(shard uint32, opts Options) *aggregatorShard {
+	// NB(xichen): instead of sharding a global time lock, each shard has
+	// its own time lock to ensure for an aggregation window, all metrics
+	// owned by the shard are aggregated before they are flushed.
+	opts = opts.SetTimeLock(&sync.RWMutex{})
 	s := &aggregatorShard{
 		shard:     shard,
 		metricMap: newMetricMap(opts),

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -247,6 +247,12 @@ type Options interface {
 	// ShardFn returns the sharding function.
 	ShardFn() ShardFn
 
+	// SetFlushManager sets the flush manager.
+	SetFlushManager(value FlushManager) Options
+
+	// FlushManager returns the flush manager.
+	FlushManager() FlushManager
+
 	// SetMinFlushInterval sets the minimum flush interval
 	SetMinFlushInterval(value time.Duration) Options
 

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -26,47 +26,6 @@ metrics:
     includeHost: true
   samplingRate: 0.01
 
-aggregator:
-  stream:
-    eps: 0.001
-    quantiles:
-      - 0.5
-      - 0.95
-      - 0.99
-    capacity: 32
-    streamPool:
-      size: 4096
-    samplePool:
-      size: 4096
-    floatsPool:
-      buckets:
-        - count: 4096
-          capacity: 16
-        - count: 2048
-          capacity: 32
-        - count: 1024
-          capacity: 16
-  shardFnType: murmur32
-  minFlushInterval: 5s
-  maxFlushSize: 1440
-  flush:
-    type: logging
-  entryTTL: 6h
-  entryCheckInterval: 10m
-  defaultPolicies:
-    - 10s:2d
-    - 1m:40d
-  counterElemPool:
-    size: 4096
-  timerElemPool:
-    size: 4096
-  gaugeElemPool:
-    size: 4096
-  entryPool:
-    size: 4096
-  bufferedEncoderPool:
-    size: 4096
-
 msgpack:
   listenAddress: 0.0.0.0:6000
   retry:
@@ -100,3 +59,51 @@ http:
   listenAddress: 0.0.0.0:6001
   readTimeout: 45s
   writeTimeout: 45s
+
+aggregator:
+  stream:
+    eps: 0.001
+    quantiles:
+      - 0.5
+      - 0.95
+      - 0.99
+    capacity: 32
+    streamPool:
+      size: 4096
+    samplePool:
+      size: 4096
+    floatsPool:
+      buckets:
+        - count: 4096
+          capacity: 16
+        - count: 2048
+          capacity: 32
+        - count: 1024
+          capacity: 16
+  placementWatcher:
+    namespace: /m3aggregator
+    key: placement
+  shardFnType: murmur32
+  flushManager:
+    checkEvery: 1s
+    jitterEnabled: true
+    numWorkersPerCPU: 0.25
+  minFlushInterval: 5s
+  maxFlushSize: 1440
+  flush:
+    type: logging
+  entryTTL: 6h
+  entryCheckInterval: 10m
+  defaultPolicies:
+    - 10s:2d
+    - 1m:40d
+  counterElemPool:
+    size: 4096
+  timerElemPool:
+    size: 4096
+  gaugeElemPool:
+    size: 4096
+  entryPool:
+    size: 4096
+  bufferedEncoderPool:
+    size: 4096

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -87,7 +87,7 @@ aggregator:
   flushManager:
     checkEvery: 1s
     jitterEnabled: true
-    numWorkersPerCPU: 0.25
+    numWorkersPerCPU: 0.125
   minFlushInterval: 5s
   maxFlushSize: 1440
   flush:

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -122,6 +122,8 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 		return aggregator.NewEntry(nil, aggregatorOpts)
 	})
 	aggregatorOpts = aggregatorOpts.SetEntryPool(entryPool)
+	flushManager := aggregator.NewFlushManager(nil)
+	aggregatorOpts = aggregatorOpts.SetFlushManager(flushManager)
 
 	// Set up placement watcher.
 	shardSet := make([]shard.Shard, opts.NumShards())

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -63,7 +63,7 @@ func (c *MsgpackServerConfiguration) NewMsgpackServerOptions(
 // unaggregatedIteratorConfiguration contains configuration for unaggregated iterator.
 type unaggregatedIteratorConfiguration struct {
 	// Whether to ignore encoded data streams whose version is higher than the current known version.
-	IgnoreHigherVersion bool `yaml:"ignoreHigherVersion"`
+	IgnoreHigherVersion *bool `yaml:"ignoreHigherVersion"`
 
 	// Reader buffer size.
 	ReaderBufferSize int `yaml:"readerBufferSize"`
@@ -83,8 +83,10 @@ func (c *unaggregatedIteratorConfiguration) NewUnaggregatedIteratorPool(
 	instrumentOpts instrument.Options,
 ) msgpackp.UnaggregatedIteratorPool {
 	scope := instrumentOpts.MetricsScope()
-	opts := msgpackp.NewUnaggregatedIteratorOptions().SetIgnoreHigherVersion(c.IgnoreHigherVersion)
-
+	opts := msgpackp.NewUnaggregatedIteratorOptions()
+	if c.IgnoreHigherVersion != nil {
+		opts = opts.SetIgnoreHigherVersion(*c.IgnoreHigherVersion)
+	}
 	if c.ReaderBufferSize != 0 {
 		opts = opts.SetReaderBufferSize(c.ReaderBufferSize)
 	}

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -103,7 +103,7 @@ func (c *unaggregatedIteratorConfiguration) NewUnaggregatedIteratorPool(
 	largeFloatsPool.Init()
 
 	// Set iterator pool.
-	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("unaggreagted-iterator-pool"))
+	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("unaggregated-iterator-pool"))
 	iteratorPoolOpts := c.IteratorPool.NewObjectPoolOptions(iOpts)
 	iteratorPool := msgpackp.NewUnaggregatedIteratorPool(iteratorPoolOpts)
 	opts = opts.SetIteratorPool(iteratorPool)


### PR DESCRIPTION
cc @robskillington @cw9 @jeromefroe @prateek 

This PR adds logic to coordinate flushes across aggregated metric lists in different shards in order to reduce spikiness in p99 flush latencies by controlling the concurrency of flushes and adding jitters to different flushes. 