### PR TITLE
Various performance optimizations and bug fixes

### DIFF
--- a/aggregation/quantile/cm/options.go
+++ b/aggregation/quantile/cm/options.go
@@ -28,12 +28,13 @@ import (
 )
 
 const (
-	minEps          = 0.0
-	maxEps          = 0.5
-	minQuantile     = 0.0
-	maxQuantile     = 1.0
-	defaultEps      = 1e-3
-	defaultCapacity = 16
+	minEps            = 0.0
+	maxEps            = 0.5
+	minQuantile       = 0.0
+	maxQuantile       = 1.0
+	defaultEps        = 1e-3
+	defaultCapacity   = 16
+	defaultFlushEvery = 0
 )
 
 var (
@@ -52,6 +53,7 @@ type options struct {
 	eps        float64
 	quantiles  []float64
 	capacity   int
+	flushEvery int
 	streamPool StreamPool
 	samplePool SamplePool
 	floatsPool pool.FloatsPool
@@ -60,9 +62,10 @@ type options struct {
 // NewOptions creates a new options
 func NewOptions() Options {
 	o := &options{
-		eps:       defaultEps,
-		quantiles: defaultQuantiles,
-		capacity:  defaultCapacity,
+		eps:        defaultEps,
+		quantiles:  defaultQuantiles,
+		capacity:   defaultCapacity,
+		flushEvery: defaultFlushEvery,
 	}
 
 	o.initPools()
@@ -97,6 +100,16 @@ func (o *options) SetCapacity(value int) Options {
 
 func (o *options) Capacity() int {
 	return o.capacity
+}
+
+func (o *options) SetFlushEvery(value int) Options {
+	opts := *o
+	opts.flushEvery = value
+	return &opts
+}
+
+func (o *options) FlushEvery() int {
+	return o.flushEvery
 }
 
 func (o *options) SetStreamPool(value StreamPool) Options {

--- a/aggregation/quantile/cm/options.go
+++ b/aggregation/quantile/cm/options.go
@@ -44,7 +44,6 @@ var (
 
 	errInvalidEps       = fmt.Errorf("epsilon value must be between %f and %f", minEps, maxEps)
 	errInvalidQuantiles = fmt.Errorf("quantiles must be nonempty and between %f and %f", minQuantile, maxQuantile)
-	errNoSamplePool     = errors.New("no sample pool set")
 	errNoFloatsPool     = errors.New("no floats pool set")
 	errNoStreamPool     = errors.New("no stream pool set")
 )
@@ -140,9 +139,6 @@ func (o *options) Validate() error {
 	if o.streamPool == nil {
 		return errNoStreamPool
 	}
-	if o.samplePool == nil {
-		return errNoSamplePool
-	}
 	if o.floatsPool == nil {
 		return errNoFloatsPool
 	}
@@ -155,9 +151,6 @@ func (o *options) Validate() error {
 }
 
 func (o *options) initPools() {
-	o.samplePool = NewSamplePool(nil)
-	o.samplePool.Init()
-
 	o.floatsPool = pool.NewFloatsPool(defaultBuckets, nil)
 	o.floatsPool.Init()
 

--- a/aggregation/quantile/cm/options_test.go
+++ b/aggregation/quantile/cm/options_test.go
@@ -53,11 +53,6 @@ func TestOptionsValidateInvalidQuantiles(t *testing.T) {
 	require.Equal(t, errInvalidQuantiles, opts.Validate())
 }
 
-func TestOptionsValidateNoSamplePool(t *testing.T) {
-	opts := testOpts.SetSamplePool(nil)
-	require.Equal(t, errNoSamplePool, opts.Validate())
-}
-
 func TestOptionsValidateNoFloatsPool(t *testing.T) {
 	opts := testOpts.SetFloatsPool(nil)
 	require.Equal(t, errNoFloatsPool, opts.Validate())

--- a/aggregation/quantile/cm/stream.go
+++ b/aggregation/quantile/cm/stream.go
@@ -345,9 +345,7 @@ func (s *stream) addToMinHeap(heap *minHeap, value float64) {
 	// and return the current heap to the pool
 	if len(curr) == cap(curr) {
 		newHeap := s.floatsPool.Get(2 * len(curr))
-		for i := 0; i < len(curr); i++ {
-			newHeap = append(newHeap, curr[i])
-		}
+		newHeap = append(newHeap, curr...)
 		s.floatsPool.Put(curr)
 		*heap = newHeap
 	}

--- a/aggregation/quantile/cm/stream.go
+++ b/aggregation/quantile/cm/stream.go
@@ -311,7 +311,9 @@ func (s *stream) addToMinHeap(heap *minHeap, value float64) {
 	// and return the current heap to the pool
 	if len(curr) == cap(curr) {
 		newHeap := s.floatsPool.Get(2 * len(curr))
-		newHeap = append(newHeap, curr...)
+		for i := 0; i < len(curr); i++ {
+			newHeap = append(newHeap, curr[i])
+		}
 		s.floatsPool.Put(curr)
 		*heap = newHeap
 	}

--- a/aggregation/quantile/cm/stream.go
+++ b/aggregation/quantile/cm/stream.go
@@ -250,7 +250,7 @@ func (s *stream) insert() {
 		return
 	}
 
-	for s.bufMore.Len() > 0 && s.bufMore.Min() > s.samples.Back().value {
+	for s.bufMore.Len() > 0 && s.bufMore.Min() >= s.samples.Back().value {
 		sample := s.acquireSampleFn()
 		sample.setData(s.bufMore.Pop(), 1, 0)
 		s.samples.PushBack(sample)

--- a/aggregation/quantile/cm/stream_test.go
+++ b/aggregation/quantile/cm/stream_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testFlushEvery = 100
+)
+
 func testStreamOptions() Options {
 	return NewOptions().
 		SetEps(0.01).
@@ -89,85 +93,44 @@ func TestStreamWithThreeSamples(t *testing.T) {
 	}
 }
 
-func TestStreamWithIncreasingSamples(t *testing.T) {
-	numSamples := 100000
+func TestStreamWithIncreasingSamplesNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
-	s := NewStream(opts)
-	for i := 0; i < numSamples; i++ {
-		s.Add(float64(i))
-	}
-	s.Flush()
-
-	require.Equal(t, 0.0, s.Min())
-	require.Equal(t, float64(numSamples-1), s.Max())
-	margin := float64(numSamples) * opts.Eps()
-	for _, q := range opts.Quantiles() {
-		val := s.Quantile(q)
-		require.True(t, val >= float64(numSamples)*q-margin && val <= float64(numSamples)*q+margin)
-	}
+	testStreamWithIncreasingSamples(t, opts)
 }
 
-func TestStreamWithDecreasingSamples(t *testing.T) {
-	numSamples := 100000
-	opts := testStreamOptions()
-	s := NewStream(opts)
-	for i := numSamples - 1; i >= 0; i-- {
-		s.Add(float64(i))
-	}
-	s.Flush()
-
-	require.Equal(t, 0.0, s.Min())
-	require.Equal(t, float64(numSamples-1), s.Max())
-	margin := float64(numSamples) * opts.Eps()
-	for _, q := range opts.Quantiles() {
-		val := s.Quantile(q)
-		require.True(t, val >= float64(numSamples)*q-margin && val <= float64(numSamples)*q+margin)
-	}
+func TestStreamWithIncreasingSamplesWithPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
+	testStreamWithIncreasingSamples(t, opts)
 }
 
-func TestStreamWithRandomSamples(t *testing.T) {
-	numSamples := 100000
-	maxInt64 := int64(math.MaxInt64)
+func TestStreamWithDecreasingSamplesNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
-	s := NewStream(opts)
-	min := math.MaxFloat64
-	max := -1.0
-
-	rand.Seed(100)
-	for i := 0; i < numSamples; i++ {
-		v := float64(rand.Int63n(maxInt64))
-		min = math.Min(min, v)
-		max = math.Max(max, v)
-		s.Add(v)
-
-	}
-	s.Flush()
-
-	require.Equal(t, min, s.Min())
-	require.Equal(t, max, s.Max())
-	margin := float64(maxInt64) * opts.Eps()
-	for _, q := range opts.Quantiles() {
-		val := s.Quantile(q)
-		require.True(t, val >= float64(maxInt64)*q-margin && val <= float64(maxInt64)*q+margin)
-	}
+	testStreamWithDecreasingSamples(t, opts)
 }
 
-func TestStreamWithSkewedDistribution(t *testing.T) {
+func TestStreamWithDecreasingSamplesWithPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
+	testStreamWithDecreasingSamples(t, opts)
+}
+
+func TestStreamWithRandomSamplesNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
-	s := NewStream(opts)
-	for i := 0; i < 10000; i++ {
-		s.Add(1.0)
-	}
+	testStreamWithRandomSamples(t, opts)
+}
 
-	// Add a huge sample value (10M)
-	s.Add(10000000.0)
-	s.Flush()
+func TestStreamWithRandomSamplesWithPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
+	testStreamWithRandomSamples(t, opts)
+}
 
-	require.Equal(t, 1.0, s.Min())
-	require.Equal(t, 10000000.0, s.Max())
-	for _, q := range opts.Quantiles() {
-		require.Equal(t, 1.0, s.Quantile(q))
-	}
+func TestStreamWithSkewedDistributionNoPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions()
+	testStreamWithSkewedDistribution(t, opts)
+}
+
+func TestStreamWithSkewedDistributionWithPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
+	testStreamWithSkewedDistribution(t, opts)
 }
 
 func TestStreamClose(t *testing.T) {
@@ -208,4 +171,81 @@ func TestStreamAddToMinHeap(t *testing.T) {
 	s.addToMinHeap(&heap, inputs[1])
 	require.Equal(t, inputs, []float64(heap))
 	require.Equal(t, 2, cap(heap))
+}
+
+func testStreamWithIncreasingSamples(t *testing.T, opts Options) {
+	numSamples := 100000
+	s := NewStream(opts)
+	for i := 0; i < numSamples; i++ {
+		s.Add(float64(i))
+	}
+	s.Flush()
+
+	require.Equal(t, 0.0, s.Min())
+	require.Equal(t, float64(numSamples-1), s.Max())
+	margin := float64(numSamples) * opts.Eps()
+	for _, q := range opts.Quantiles() {
+		val := s.Quantile(q)
+		require.True(t, val >= float64(numSamples)*q-margin && val <= float64(numSamples)*q+margin)
+	}
+}
+
+func testStreamWithDecreasingSamples(t *testing.T, opts Options) {
+	numSamples := 100000
+	s := NewStream(opts)
+	for i := numSamples - 1; i >= 0; i-- {
+		s.Add(float64(i))
+	}
+	s.Flush()
+
+	require.Equal(t, 0.0, s.Min())
+	require.Equal(t, float64(numSamples-1), s.Max())
+	margin := float64(numSamples) * opts.Eps()
+	for _, q := range opts.Quantiles() {
+		val := s.Quantile(q)
+		require.True(t, val >= float64(numSamples)*q-margin && val <= float64(numSamples)*q+margin)
+	}
+}
+
+func testStreamWithRandomSamples(t *testing.T, opts Options) {
+	numSamples := 100000
+	maxInt64 := int64(math.MaxInt64)
+	s := NewStream(opts)
+	min := math.MaxFloat64
+	max := -1.0
+
+	rand.Seed(100)
+	for i := 0; i < numSamples; i++ {
+		v := float64(rand.Int63n(maxInt64))
+		min = math.Min(min, v)
+		max = math.Max(max, v)
+		s.Add(v)
+
+	}
+	s.Flush()
+
+	require.Equal(t, min, s.Min())
+	require.Equal(t, max, s.Max())
+	margin := float64(maxInt64) * opts.Eps()
+	for _, q := range opts.Quantiles() {
+		val := s.Quantile(q)
+		require.True(t, val >= float64(maxInt64)*q-margin && val <= float64(maxInt64)*q+margin)
+	}
+}
+
+func testStreamWithSkewedDistribution(t *testing.T, opts Options) {
+	s := NewStream(opts)
+	for i := 0; i < 10000; i++ {
+		s.Add(1.0)
+	}
+
+	// Add a huge sample value (10M)
+	s.Add(10000000.0)
+	s.Flush()
+
+	require.Equal(t, 1.0, s.Min())
+	require.Equal(t, 10000000.0, s.Max())
+	for _, q := range opts.Quantiles() {
+		require.Equal(t, 1.0, s.Quantile(q))
+	}
 }

--- a/aggregation/quantile/cm/types.go
+++ b/aggregation/quantile/cm/types.go
@@ -102,6 +102,16 @@ type Options interface {
 	// Capacity returns the initial heap capacity
 	Capacity() int
 
+	// SetFlushEvery sets how frequently the underlying stream is flushed
+	// to reduce processing time when computing aggregated statistics from
+	// the stream.
+	SetFlushEvery(value int) Options
+
+	// FlushEvery returns how frequently the underlying stream is flushed
+	// to reduce processing time when computing aggregated statistics from
+	// the stream.
+	FlushEvery() int
+
 	// SetStreamPool sets the stream pool
 	SetStreamPool(value StreamPool) Options
 

--- a/aggregation/quantile/tdigest/tdigest.go
+++ b/aggregation/quantile/tdigest/tdigest.go
@@ -297,9 +297,7 @@ func (d *tDigest) upperBound(index int) float64 {
 func (d *tDigest) appendCentroid(centroids []Centroid, c Centroid) []Centroid {
 	if len(centroids) == cap(centroids) {
 		newCentroids := d.centroidsPool.Get(2 * len(centroids))
-		for i := 0; i < len(centroids); i++ {
-			newCentroids = append(newCentroids, centroids[i])
-		}
+		newCentroids = append(newCentroids, centroids...)
 		d.centroidsPool.Put(centroids)
 		centroids = newCentroids
 	}

--- a/aggregation/quantile/tdigest/tdigest.go
+++ b/aggregation/quantile/tdigest/tdigest.go
@@ -297,7 +297,9 @@ func (d *tDigest) upperBound(index int) float64 {
 func (d *tDigest) appendCentroid(centroids []Centroid, c Centroid) []Centroid {
 	if len(centroids) == cap(centroids) {
 		newCentroids := d.centroidsPool.Get(2 * len(centroids))
-		newCentroids = append(newCentroids, centroids...)
+		for i := 0; i < len(centroids); i++ {
+			newCentroids = append(newCentroids, centroids[i])
+		}
 		d.centroidsPool.Put(centroids)
 		centroids = newCentroids
 	}

--- a/aggregation/timer.go
+++ b/aggregation/timer.go
@@ -36,16 +36,16 @@ type Timer struct {
 
 // NewTimer creates a new timer
 func NewTimer(opts cm.Options) Timer {
-	return Timer{
-		stream: opts.StreamPool().Get(),
-	}
+	stream := opts.StreamPool().Get()
+	stream.Reset()
+	return Timer{stream: stream}
 }
 
 // Add adds a timer value
 func (t *Timer) Add(value float64) {
 	t.count++
 	t.sum += value
-	t.sumSq += math.Pow(value, 2)
+	t.sumSq += value * value
 	t.stream.Add(value)
 }
 
@@ -93,7 +93,7 @@ func (t *Timer) Mean() float64 {
 
 // Stdev returns the standard deviation timer value
 func (t *Timer) Stdev() float64 {
-	num := float64(t.count)*t.sumSq - math.Pow(t.sum, 2)
+	num := float64(t.count)*t.sumSq - t.sum*t.sum
 	div := t.count * (t.count - 1)
 	if div == 0 {
 		return 0.0

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -99,6 +99,8 @@ func newMetricList(resolution time.Duration, opts Options) *metricList {
 		map[string]string{"resolution": resolution.String()},
 	)
 	encoderPool := opts.BufferedEncoderPool()
+	encoder := encoderPool.Get()
+	encoder.Reset()
 	l := &metricList{
 		opts:          opts,
 		nowFn:         opts.ClockOptions().NowFn(),
@@ -110,7 +112,7 @@ func newMetricList(resolution time.Duration, opts Options) *metricList {
 		resolution:    resolution,
 		flushInterval: flushInterval,
 		aggregations:  list.New(),
-		encoder:       msgpack.NewAggregatedEncoder(encoderPool.Get()),
+		encoder:       msgpack.NewAggregatedEncoder(encoder),
 		metrics:       newMetricListMetrics(scope),
 	}
 	l.encodeFn = l.encoder.EncodeChunkedMetricWithPolicy

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b470cc126c32ae7ea57e615e910ec2ec2e36da12029cbe6370a8241cc766427e
-updated: 2017-05-24T19:54:42.399850038-04:00
+hash: a09098084fafe0c54dbd21de708de3382f4bcb4f2ff1981d6acb0c5d80386463
+updated: 2017-05-29T22:06:13.337274575-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 5a4ec9a107763207c0e077c04a56e73119208408
+  version: 18bc01a7057d55b78e528236e0e9db297bcd4fa3
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: b596a86b06f37c9150ea352d6ec1549ed19f304b
 - package: github.com/m3db/m3metrics
-  version: 5a4ec9a107763207c0e077c04a56e73119208408
+  version: 18bc01a7057d55b78e528236e0e9db297bcd4fa3
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -36,6 +36,10 @@ import (
 	"github.com/uber-go/tally"
 )
 
+const (
+	unknownRemoteHostAddress = "<unknown>"
+)
+
 type serverMetrics struct {
 	openConnections tally.Gauge
 	addMetricErrors tally.Counter
@@ -205,7 +209,7 @@ func (s *server) handleConnection(conn net.Conn) {
 	// If there is an error during decoding, it's likely due to a broken connection
 	// and therefore we ignore the EOF error
 	if err := it.Err(); err != nil && err != io.EOF {
-		remoteAddress := "<unknown>"
+		remoteAddress := unknownRemoteHostAddress
 		if remoteAddr := conn.RemoteAddr(); remoteAddr != nil {
 			remoteAddress = remoteAddr.String()
 		}

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -205,7 +205,14 @@ func (s *server) handleConnection(conn net.Conn) {
 	// If there is an error during decoding, it's likely due to a broken connection
 	// and therefore we ignore the EOF error
 	if err := it.Err(); err != nil && err != io.EOF {
-		s.log.Errorf("decode error: %v", err)
+		remoteAddress := "<unknown>"
+		if remoteAddr := conn.RemoteAddr(); remoteAddr != nil {
+			remoteAddress = remoteAddr.String()
+		}
+		s.log.WithFields(
+			xlog.NewLogField("remoteAddress", remoteAddress),
+			xlog.NewLogErrField(err),
+		).Error("decode error")
 		s.metrics.decodeErrors.Inc(1)
 	}
 }

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -329,7 +329,7 @@ type streamConfiguration struct {
 	StreamPool pool.ObjectPoolConfiguration `yaml:"streamPool"`
 
 	// Pool of metric samples.
-	SamplePool pool.ObjectPoolConfiguration `yaml:"samplePool"`
+	SamplePool *pool.ObjectPoolConfiguration `yaml:"samplePool"`
 
 	// Pool of float slices.
 	FloatsPool pool.BucketizedPoolConfiguration `yaml:"floatsPool"`
@@ -342,13 +342,15 @@ func (c *streamConfiguration) NewStreamOptions(instrumentOpts instrument.Options
 		SetQuantiles(c.Quantiles).
 		SetCapacity(c.Capacity)
 
-	iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("sample-pool"))
-	samplePoolOpts := c.SamplePool.NewObjectPoolOptions(iOpts)
-	samplePool := cm.NewSamplePool(samplePoolOpts)
-	opts = opts.SetSamplePool(samplePool)
-	samplePool.Init()
+	if c.SamplePool != nil {
+		iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("sample-pool"))
+		samplePoolOpts := c.SamplePool.NewObjectPoolOptions(iOpts)
+		samplePool := cm.NewSamplePool(samplePoolOpts)
+		opts = opts.SetSamplePool(samplePool)
+		samplePool.Init()
+	}
 
-	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("floats-pool"))
+	iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("floats-pool"))
 	floatsPoolOpts := c.FloatsPool.NewObjectPoolOptions(iOpts)
 	floatsPool := pool.NewFloatsPool(c.FloatsPool.NewBuckets(), floatsPoolOpts)
 	opts = opts.SetFloatsPool(floatsPool)

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -325,6 +325,9 @@ type streamConfiguration struct {
 	// Initial heap capacity for quantile computation.
 	Capacity int `yaml:"capacity"`
 
+	// Flush frequency.
+	FlushEvery int `yaml:"flushEvery"`
+
 	// Pool of streams.
 	StreamPool pool.ObjectPoolConfiguration `yaml:"streamPool"`
 
@@ -341,6 +344,10 @@ func (c *streamConfiguration) NewStreamOptions(instrumentOpts instrument.Options
 		SetEps(c.Eps).
 		SetQuantiles(c.Quantiles).
 		SetCapacity(c.Capacity)
+
+	if c.FlushEvery != 0 {
+		opts = opts.SetFlushEvery(c.FlushEvery)
+	}
 
 	if c.SamplePool != nil {
 		iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("sample-pool"))


### PR DESCRIPTION
cc @robskillington @cw9 @prateek @jeromefroe 

This PR contains various performance optimizations for the aggregation tier. Specifically, it includes
* Adding an option to provide a nil sample pool, which effectively disables sample pooling. The sample pool is used to provide sample objects for every timer value, which is on the critical path and is heavily contended. Profile shows getting values from the pool and putting values into the pool accounts for >30% of the CPU due to heavy contention. Disabling sample pooling significantly reduced write p99 (4ms -> 1ms) and flush p99 (1.5s -> 200ms).
* Adding an option to periodically flush streams at write time, therefore reducing processing load during global flushing. This has significantly improved flush p99 for aggregation servers that have large batches of timer values. In one case, we saw 5s -> 150ms reduction w.r.t. p99 flush latency.
* Replace math.Pow(x, 2) with x * x. This used to account for 4% of the CPU due to math.Pow(x, 2) being 100x more expensive than the plain multiplication. 
* Preallocate enough buffer for the buffered encoder. The buffered encode is used to hold the aggregated metrics. Previous it starts with an empty buffer and gradually grows to the maximum flush size, which requires unnecessary copy and reallocations.

It also includes more instrumentation and bug fixes. Specifically, it includes:
* Fixing a memory leak in timer creation where the underlying stream is not reset, causing the stream (and the float slices and the samples) to not be properly returned to pool.
* Adding logging to record the remote address when a decode error happens. This has allowed us to determine the primary cause of the decode errors is due to misconfigured hosts in the wrong datacenter.