### PR TITLE
More performance optimizations

### DIFF
--- a/aggregation/counter.go
+++ b/aggregation/counter.go
@@ -20,20 +20,34 @@
 
 package aggregation
 
+import "sync"
+
 var (
 	emptyCounter Counter
 )
 
-// Counter aggregates counter values
+// Counter aggregates counter values.
 type Counter struct {
 	sum int64 // Sum of the values received
 }
 
-// NewCounter creates a new counter
+// NewCounter creates a new counter.
 func NewCounter() Counter { return emptyCounter }
 
-// Add adds a counter value
+// Add adds a counter value.
 func (c *Counter) Add(value int64) { c.sum += value }
 
-// Sum returns the sum of counter values
+// Sum returns the sum of counter values.
 func (c *Counter) Sum() int64 { return c.sum }
+
+// LockedCounter is a locked counter.
+type LockedCounter struct {
+	sync.Mutex
+	Counter
+}
+
+// NewLockedCounter creates a new locked counter.
+func NewLockedCounter() *LockedCounter { return &LockedCounter{} }
+
+// Reset resets the locked counter.
+func (lc *LockedCounter) Reset() { lc.Counter = emptyCounter }

--- a/aggregation/gauge.go
+++ b/aggregation/gauge.go
@@ -20,20 +20,34 @@
 
 package aggregation
 
+import "sync"
+
 var (
 	emptyGauge Gauge
 )
 
-// Gauge aggregates gauge values
+// Gauge aggregates gauge values.
 type Gauge struct {
 	value float64 // latest value received
 }
 
-// NewGauge creates a new gauge
+// NewGauge creates a new gauge.
 func NewGauge() Gauge { return emptyGauge }
 
-// Set sets the gauge value
+// Set sets the gauge value.
 func (g *Gauge) Set(value float64) { g.value = value }
 
-// Value returns the latest value
+// Value returns the latest value.
 func (g *Gauge) Value() float64 { return g.value }
+
+// LockedGauge is a locked gauge.
+type LockedGauge struct {
+	sync.Mutex
+	Gauge
+}
+
+// NewLockedGauge creates a new locked gauge.
+func NewLockedGauge() *LockedGauge { return &LockedGauge{} }
+
+// Reset resets the locked gauge.
+func (lg *LockedGauge) Reset() { lg.Gauge = emptyGauge }

--- a/aggregation/quantile/cm/options.go
+++ b/aggregation/quantile/cm/options.go
@@ -28,10 +28,16 @@ import (
 )
 
 const (
-	minEps            = 0.0
-	maxEps            = 0.5
-	defaultEps        = 1e-3
-	defaultCapacity   = 16
+	minEps          = 0.0
+	maxEps          = 0.5
+	defaultEps      = 1e-3
+	defaultCapacity = 16
+
+	// By default the timer values are inserted and the underlying
+	// streams are compressed every time the value is added.
+	defaultInsertAndCompressEvery = 1
+
+	// By default the stream is not flushed when values are added.
 	defaultFlushEvery = 0
 )
 
@@ -46,20 +52,22 @@ var (
 )
 
 type options struct {
-	eps        float64
-	capacity   int
-	flushEvery int
-	streamPool StreamPool
-	samplePool SamplePool
-	floatsPool pool.FloatsPool
+	eps                    float64
+	capacity               int
+	insertAndCompressEvery int
+	flushEvery             int
+	streamPool             StreamPool
+	samplePool             SamplePool
+	floatsPool             pool.FloatsPool
 }
 
 // NewOptions creates a new options
 func NewOptions() Options {
 	o := &options{
-		eps:        defaultEps,
-		capacity:   defaultCapacity,
-		flushEvery: defaultFlushEvery,
+		eps:                    defaultEps,
+		capacity:               defaultCapacity,
+		insertAndCompressEvery: defaultInsertAndCompressEvery,
+		flushEvery:             defaultFlushEvery,
 	}
 
 	o.initPools()
@@ -84,6 +92,16 @@ func (o *options) SetCapacity(value int) Options {
 
 func (o *options) Capacity() int {
 	return o.capacity
+}
+
+func (o *options) SetInsertAndCompressEvery(value int) Options {
+	opts := *o
+	opts.insertAndCompressEvery = value
+	return &opts
+}
+
+func (o *options) InsertAndCompressEvery() int {
+	return o.insertAndCompressEvery
 }
 
 func (o *options) SetFlushEvery(value int) Options {

--- a/aggregation/quantile/cm/stream_test.go
+++ b/aggregation/quantile/cm/stream_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	testFlushEvery = 100
+	testInsertAndCompressEvery = 100
+	testFlushEvery             = 1000
 )
 
 var (
@@ -96,43 +97,91 @@ func TestStreamWithThreeSamples(t *testing.T) {
 	}
 }
 
-func TestStreamWithIncreasingSamplesNoPeriodicFlush(t *testing.T) {
+func TestStreamWithIncreasingSamplesNoPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
 	testStreamWithIncreasingSamples(t, opts)
 }
 
-func TestStreamWithIncreasingSamplesWithPeriodicFlush(t *testing.T) {
+func TestStreamWithIncreasingSamplesPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetInsertAndCompressEvery(testInsertAndCompressEvery)
+	testStreamWithIncreasingSamples(t, opts)
+}
+
+func TestStreamWithIncreasingSamplesNoPeriodicInsertCompressPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
 	testStreamWithIncreasingSamples(t, opts)
 }
 
-func TestStreamWithDecreasingSamplesNoPeriodicFlush(t *testing.T) {
+func TestStreamWithIncreasingSamplesPeriodicInsertCompressPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().
+		SetInsertAndCompressEvery(testInsertAndCompressEvery).
+		SetFlushEvery(testFlushEvery)
+	testStreamWithIncreasingSamples(t, opts)
+}
+
+func TestStreamWithDecreasingSamplesNoPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
 	testStreamWithDecreasingSamples(t, opts)
 }
 
-func TestStreamWithDecreasingSamplesWithPeriodicFlush(t *testing.T) {
+func TestStreamWithDecreasingSamplesPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetInsertAndCompressEvery(testInsertAndCompressEvery)
+	testStreamWithDecreasingSamples(t, opts)
+}
+
+func TestStreamWithDecreasingSamplesNoPeriodicInsertCompressPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
 	testStreamWithDecreasingSamples(t, opts)
 }
 
-func TestStreamWithRandomSamplesNoPeriodicFlush(t *testing.T) {
+func TestStreamWithDecreasingSamplesPeriodicInsertCompressPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().
+		SetInsertAndCompressEvery(testInsertAndCompressEvery).
+		SetFlushEvery(testFlushEvery)
+	testStreamWithDecreasingSamples(t, opts)
+}
+
+func TestStreamWithRandomSamplesNoPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
 	testStreamWithRandomSamples(t, opts)
 }
 
-func TestStreamWithRandomSamplesWithPeriodicFlush(t *testing.T) {
+func TestStreamWithRandomSamplesPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetInsertAndCompressEvery(testInsertAndCompressEvery)
+	testStreamWithRandomSamples(t, opts)
+}
+
+func TestStreamWithRandomSamplesNoPeriodicInsertCompressPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
 	testStreamWithRandomSamples(t, opts)
 }
 
-func TestStreamWithSkewedDistributionNoPeriodicFlush(t *testing.T) {
+func TestStreamWithRandomSamplesPeriodicInsertCompressPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().
+		SetInsertAndCompressEvery(testInsertAndCompressEvery).
+		SetFlushEvery(testFlushEvery)
+	testStreamWithRandomSamples(t, opts)
+}
+
+func TestStreamWithSkewedDistributionNoPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions()
 	testStreamWithSkewedDistribution(t, opts)
 }
 
-func TestStreamWithSkewedDistributionWithPeriodicFlush(t *testing.T) {
+func TestStreamWithSkewedDistributionPeriodicInsertCompressNoPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().SetInsertAndCompressEvery(testInsertAndCompressEvery)
+	testStreamWithSkewedDistribution(t, opts)
+}
+
+func TestStreamWithSkewedDistributionNoPeriodicInsertCompressPeriodicFlush(t *testing.T) {
 	opts := testStreamOptions().SetFlushEvery(testFlushEvery)
+	testStreamWithSkewedDistribution(t, opts)
+}
+
+func TestStreamWithSkewedDistributionPeriodicInsertCompressPeriodicFlush(t *testing.T) {
+	opts := testStreamOptions().
+		SetInsertAndCompressEvery(testInsertAndCompressEvery).
+		SetFlushEvery(testFlushEvery)
 	testStreamWithSkewedDistribution(t, opts)
 }
 

--- a/aggregation/quantile/cm/types.go
+++ b/aggregation/quantile/cm/types.go
@@ -96,6 +96,16 @@ type Options interface {
 	// Capacity returns the initial heap capacity
 	Capacity() int
 
+	// SetInsertAndCompressEvery sets how frequently the timer values are
+	// inserted into the stream and compressed to reduce write latency for
+	// high frequency timers.
+	SetInsertAndCompressEvery(value int) Options
+
+	// InsertAndCompressEvery returns how frequently the timer values are
+	// inserted into the stream and compressed to reduce write latency for
+	// high frequency timers.
+	InsertAndCompressEvery() int
+
 	// SetFlushEvery sets how frequently the underlying stream is flushed
 	// to reduce processing time when computing aggregated statistics from
 	// the stream.

--- a/aggregation/timer.go
+++ b/aggregation/timer.go
@@ -22,6 +22,7 @@ package aggregation
 
 import (
 	"math"
+	"sync"
 
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
 )
@@ -105,3 +106,15 @@ func (t *Timer) Stdev() float64 {
 func (t *Timer) Close() {
 	t.stream.Close()
 }
+
+// LockedTimer is a locked timer.
+type LockedTimer struct {
+	sync.Mutex
+	Timer
+}
+
+// NewLockedTimer creates a new locked timer.
+func NewLockedTimer(timer Timer) *LockedTimer { return &LockedTimer{Timer: timer} }
+
+// Reset resets the locked timer.
+func (lt *LockedTimer) Reset(timer Timer) { lt.Timer = timer }

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -148,12 +148,6 @@ type Options interface {
 	// TimerPrefix returns the prefix for timers
 	TimerPrefix() []byte
 
-	// SetTimerQuantiles sets the timer quantiles
-	SetTimerQuantiles(quantiles []float64) Options
-
-	// TimerQuantiles returns the quantiles for timers
-	TimerQuantiles() []float64
-
 	// SetTimerSumSuffix sets the sum suffix for timers
 	SetTimerSumSuffix(value []byte) Options
 
@@ -201,6 +195,12 @@ type Options interface {
 
 	// TimerMedianSuffix returns the median suffix for timers
 	TimerMedianSuffix() []byte
+
+	// SetTimerQuantiles sets the timer quantiles
+	SetTimerQuantiles(quantiles []float64) Options
+
+	// TimerQuantiles returns the quantiles for timers
+	TimerQuantiles() []float64
 
 	// SetTimerQuantileSuffixFn sets the quantile suffix function for timers
 	SetTimerQuantileSuffixFn(value QuantileSuffixFn) Options
@@ -297,6 +297,12 @@ type Options interface {
 
 	// EntryCheckBatchPercent returns the batch percentage for checking expired entries
 	EntryCheckBatchPercent() float64
+
+	// SetMaxTimerBatchSizePerWrite sets the maximum timer batch size for each batched write.
+	SetMaxTimerBatchSizePerWrite(value int) Options
+
+	// MaxTimerBatchSizePerWrite returns the maximum timer batch size for each batched write.
+	MaxTimerBatchSizePerWrite() int
 
 	// SetDefaultPolicies sets the default policies
 	SetDefaultPolicies(value []policy.Policy) Options

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -329,6 +329,9 @@ type streamConfiguration struct {
 	// Initial heap capacity for quantile computation.
 	Capacity int `yaml:"capacity"`
 
+	// Insertion and compression frequency.
+	InsertAndCompressEvery int `yaml:"insertAndCompressEvery"`
+
 	// Flush frequency.
 	FlushEvery int `yaml:"flushEvery"`
 
@@ -348,6 +351,9 @@ func (c *streamConfiguration) NewStreamOptions(instrumentOpts instrument.Options
 		SetEps(c.Eps).
 		SetCapacity(c.Capacity)
 
+	if c.InsertAndCompressEvery != 0 {
+		opts = opts.SetInsertAndCompressEvery(c.InsertAndCompressEvery)
+	}
 	if c.FlushEvery != 0 {
 		opts = opts.SetFlushEvery(c.FlushEvery)
 	}

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -135,6 +135,9 @@ type AggregatorConfiguration struct {
 	// EntryCheckBatchPercent determines the percentage of entries checked in a batch.
 	EntryCheckBatchPercent float64 `yaml:"entryCheckBatchPercent" validate:"min=0.0,max=1.0"`
 
+	// MaxTimerBatchSizePerWrite determines the maximum timer batch size for each batched write.
+	MaxTimerBatchSizePerWrite int `yaml:"maxTimerBatchSizePerWrite"`
+
 	// Default policies.
 	DefaultPolicies []policy.Policy `yaml:"defaultPolicies" validate:"nonzero"`
 
@@ -176,12 +179,13 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	opts = setMetricPrefixOrSuffix(opts, c.TimerMedianSuffix, opts.SetTimerMedianSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.GaugePrefix, opts.SetGaugePrefix)
 
-	// Set timer quantile suffix function.
+	// Set timer quantiles and quantile suffix function.
+	opts = opts.SetTimerQuantiles(c.TimerQuantiles)
 	quantileSuffixFn, err := c.parseTimerQuantileSuffixFn()
 	if err != nil {
 		return nil, err
 	}
-	opts = opts.SetTimerQuantileSuffixFn(quantileSuffixFn).SetTimerQuantiles(c.TimerQuantiles)
+	opts = opts.SetTimerQuantileSuffixFn(quantileSuffixFn)
 
 	// Set stream options.
 	iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("stream"))
@@ -252,6 +256,9 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	}
 	if c.EntryCheckBatchPercent != 0.0 {
 		opts = opts.SetEntryCheckBatchPercent(c.EntryCheckBatchPercent)
+	}
+	if c.MaxTimerBatchSizePerWrite != 0 {
+		opts = opts.SetMaxTimerBatchSizePerWrite(c.MaxTimerBatchSizePerWrite)
 	}
 
 	// Set default policies.

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -136,7 +136,7 @@ type AggregatorConfiguration struct {
 	EntryCheckBatchPercent float64 `yaml:"entryCheckBatchPercent" validate:"min=0.0,max=1.0"`
 
 	// MaxTimerBatchSizePerWrite determines the maximum timer batch size for each batched write.
-	MaxTimerBatchSizePerWrite int `yaml:"maxTimerBatchSizePerWrite"`
+	MaxTimerBatchSizePerWrite int `yaml:"maxTimerBatchSizePerWrite" validate:"min=0"`
 
 	// Default policies.
 	DefaultPolicies []policy.Policy `yaml:"defaultPolicies" validate:"nonzero"`


### PR DESCRIPTION
cc @cw9 @jeromefroe @prateek @dgromov 

This PR adds more performance optimizations for the agg tier, including:
* Make elem lock per time bucket. Previously we used to lock the entire element during writing or flushing, regardless of which time bucket we are writing too, resulting in higher lock contention than necessary. This PR now makes the lock per time bucket and thus more granular, so that writes to the current time bucket don't contend with reads from the previous time bucket during flushing.
* Add option to support periodic insertion and compression. For high frequency timers in large timer batches, it is very important to add timers as fast as possible. By only performing insertion and compression, I noticed a p99 write latency drop from 400ms to 30ms for higher frequency timer writes.
* Add option to support splitting large timer batches into smaller ones. This provides the flexibility to write a large batch of timers in smaller batches, therefore making each batched write hold locks for shorter period of time and thus reduce lock contention with flushes. I noticed significant flush time reduction for high frequency timers in large batches due to batch splitting (8s -> 1s).