### PR TITLE
Add write timeout for forward handler

### DIFF
--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -554,6 +554,9 @@ type forwardHandlerConfiguration struct {
 	// Connection keep alive.
 	ConnectionKeepAlive *bool `yaml:"connectionKeepAlive"`
 
+	// Connection write timeout.
+	ConnectionWriteTimeout time.Duration `yaml:"connectionWriteTimeout"`
+
 	// Reconnect retrier.
 	ReconnectRetrier xretry.Configuration `yaml:"reconnect"`
 }
@@ -571,6 +574,9 @@ func (c *forwardHandlerConfiguration) NewHandler(
 	}
 	if c.ConnectionKeepAlive != nil {
 		opts = opts.SetConnectionKeepAlive(*c.ConnectionKeepAlive)
+	}
+	if c.ConnectionWriteTimeout != 0 {
+		opts = opts.SetConnectionWriteTimeout(c.ConnectionWriteTimeout)
 	}
 
 	scope := instrumentOpts.MetricsScope().SubScope("reconnect")


### PR DESCRIPTION
cc @cw9 @jeromefroe @prateek @dgromov 

This PR adds an option to provide write timeout for the forward handler so when one connection is blocked, the metrics will be retried on other connections.