### PR TITLE
Add default aggregation types for Counter and Gauge

### DIFF
--- a/aggregation/counter.go
+++ b/aggregation/counter.go
@@ -50,9 +50,6 @@ func NewCounter(opts Options) Counter {
 // Update updates the counter value.
 func (c *Counter) Update(value int64) {
 	c.sum += value
-	if c.UseDefaultAggregation {
-		return
-	}
 
 	c.count++
 	if c.max < value {
@@ -98,9 +95,9 @@ func (c *Counter) Max() int64 { return c.max }
 // ValueOf returns the value for the aggregation type.
 func (c *Counter) ValueOf(aggType policy.AggregationType) float64 {
 	switch aggType {
-	case policy.Lower:
+	case policy.Min:
 		return float64(c.Min())
-	case policy.Upper:
+	case policy.Max:
 		return float64(c.Max())
 	case policy.Mean:
 		return c.Mean()

--- a/aggregation/counter_test.go
+++ b/aggregation/counter_test.go
@@ -30,21 +30,22 @@ import (
 
 func TestCounterDefaultAggregationType(t *testing.T) {
 	c := NewCounter(NewOptions())
+	require.False(t, c.HasExpensiveAggregations)
 	for i := 1; i <= 100; i++ {
 		c.Update(int64(i))
 	}
 	require.Equal(t, int64(5050), c.Sum())
-	require.Equal(t, float64(5050), c.ValueOf(policy.Sum))
-	require.Equal(t, float64(0), c.ValueOf(policy.Count))
-	require.Equal(t, float64(0), c.ValueOf(policy.Mean))
+	require.Equal(t, 5050.0, c.ValueOf(policy.Sum))
+	require.Equal(t, 100.0, c.ValueOf(policy.Count))
+	require.Equal(t, 50.5, c.ValueOf(policy.Mean))
 }
 
 func TestCounterCustomAggregationType(t *testing.T) {
 	opts := NewOptions()
-	opts.UseDefaultAggregation = false
 	opts.HasExpensiveAggregations = true
 
 	c := NewCounter(opts)
+	require.True(t, c.HasExpensiveAggregations)
 
 	for i := 1; i <= 100; i++ {
 		c.Update(int64(i))
@@ -53,9 +54,9 @@ func TestCounterCustomAggregationType(t *testing.T) {
 	for aggType := range policy.ValidAggregationTypes {
 		v := c.ValueOf(aggType)
 		switch aggType {
-		case policy.Lower:
+		case policy.Min:
 			require.Equal(t, float64(1), v)
-		case policy.Upper:
+		case policy.Max:
 			require.Equal(t, float64(100), v)
 		case policy.Mean:
 			require.Equal(t, 50.5, v)

--- a/aggregation/gauge.go
+++ b/aggregation/gauge.go
@@ -55,9 +55,6 @@ func NewGauge(opts Options) Gauge {
 // Update updates the gauge value.
 func (g *Gauge) Update(value float64) {
 	g.last = value
-	if g.UseDefaultAggregation {
-		return
-	}
 
 	g.sum += value
 	g.count++
@@ -109,9 +106,9 @@ func (g *Gauge) ValueOf(aggType policy.AggregationType) float64 {
 	switch aggType {
 	case policy.Last:
 		return g.Last()
-	case policy.Lower:
+	case policy.Min:
 		return g.Min()
-	case policy.Upper:
+	case policy.Max:
 		return g.Max()
 	case policy.Mean:
 		return g.Mean()

--- a/aggregation/gauge_test.go
+++ b/aggregation/gauge_test.go
@@ -30,21 +30,23 @@ import (
 
 func TestGaugeDefaultAggregationType(t *testing.T) {
 	g := NewGauge(NewOptions())
+	require.False(t, g.HasExpensiveAggregations)
 	for i := 1.0; i <= 100.0; i++ {
 		g.Update(i)
 	}
 	require.Equal(t, 100.0, g.Last())
 	require.Equal(t, 100.0, g.ValueOf(policy.Last))
-	require.Equal(t, 0.0, g.ValueOf(policy.Count))
-	require.Equal(t, 0.0, g.ValueOf(policy.Mean))
+	require.Equal(t, 100.0, g.ValueOf(policy.Count))
+	require.Equal(t, 50.5, g.ValueOf(policy.Mean))
+	require.Equal(t, 0.0, g.ValueOf(policy.SumSq))
 }
 
 func TestGaugeCustomAggregationType(t *testing.T) {
 	opts := NewOptions()
-	opts.UseDefaultAggregation = false
 	opts.HasExpensiveAggregations = true
 
 	g := NewGauge(opts)
+	require.True(t, g.HasExpensiveAggregations)
 
 	for i := 1; i <= 100; i++ {
 		g.Update(float64(i))
@@ -56,9 +58,9 @@ func TestGaugeCustomAggregationType(t *testing.T) {
 		switch aggType {
 		case policy.Last:
 			require.Equal(t, float64(100), v)
-		case policy.Lower:
+		case policy.Min:
 			require.Equal(t, float64(1), v)
-		case policy.Upper:
+		case policy.Max:
 			require.Equal(t, float64(100), v)
 		case policy.Mean:
 			require.Equal(t, float64(50.5), v)

--- a/aggregation/options.go
+++ b/aggregation/options.go
@@ -23,15 +23,11 @@ package aggregation
 import "github.com/m3db/m3metrics/policy"
 
 var (
-	defaultOptions = Options{UseDefaultAggregation: true, HasExpensiveAggregations: false}
+	defaultOptions Options
 )
 
 // Options is the options for aggregations.
 type Options struct {
-	// UseDefaultAggregation means only default aggregation types are enabled.
-	// TODO(cw) Remove this once we start to support default aggregation types
-	// for Counter ang Gauge.
-	UseDefaultAggregation bool
 	// HasExpensiveAggregations means expensive (multiplication／division)
 	// aggregation types are enabled.
 	HasExpensiveAggregations bool
@@ -44,6 +40,5 @@ func NewOptions() Options {
 
 // ResetSetData resets the aggregation options.
 func (o *Options) ResetSetData(aggTypes policy.AggregationTypes) {
-	o.UseDefaultAggregation = aggTypes.IsDefault()
 	o.HasExpensiveAggregations = isExpensive(aggTypes)
 }

--- a/aggregation/options_test.go
+++ b/aggregation/options_test.go
@@ -30,18 +30,14 @@ import (
 
 func TestOptions(t *testing.T) {
 	o := NewOptions()
-	require.True(t, o.UseDefaultAggregation)
 	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(nil)
-	require.True(t, o.UseDefaultAggregation)
 	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(policy.AggregationTypes{policy.Sum})
-	require.False(t, o.UseDefaultAggregation)
 	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(policy.AggregationTypes{policy.Sum, policy.SumSq})
-	require.False(t, o.UseDefaultAggregation)
 	require.True(t, o.HasExpensiveAggregations)
 }

--- a/aggregation/timer.go
+++ b/aggregation/timer.go
@@ -112,9 +112,9 @@ func (t *Timer) ValueOf(aggType policy.AggregationType) float64 {
 	}
 
 	switch aggType {
-	case policy.Lower:
+	case policy.Min:
 		return t.Min()
-	case policy.Upper:
+	case policy.Max:
 		return t.Max()
 	case policy.Mean:
 		return t.Mean()

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -144,11 +144,11 @@ func newElemBase(opts Options) elemBase {
 }
 
 // resetSetData resets the element base and sets data.
-func (e *elemBase) resetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes, isDefault bool) {
+func (e *elemBase) resetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes, useDefaultAggregation bool) {
 	e.id = id
 	e.sp = sp
 	e.aggTypes = aggTypes
-	e.useDefaultAggregation = isDefault
+	e.useDefaultAggregation = useDefaultAggregation
 	e.aggOpts.ResetSetData(aggTypes)
 	e.tombstoned = false
 	e.closed = false
@@ -186,12 +186,12 @@ func NewCounterElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggreg
 
 // ResetSetData resets the counter element and sets data.
 func (e *CounterElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
-	isDefault := aggTypes.IsDefault()
-	if isDefault {
+	useDefaultAggregation := aggTypes.IsDefault()
+	if useDefaultAggregation {
 		aggTypes = e.opts.DefaultCounterAggregationTypes()
 	}
 
-	e.elemBase.resetSetData(id, sp, aggTypes, isDefault)
+	e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation)
 }
 
 // AddMetric adds a new counter value
@@ -366,15 +366,15 @@ func NewTimerElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggregat
 
 // ResetSetData resets the timer element and sets data.
 func (e *TimerElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
-	isDefault := aggTypes.IsDefault()
-	if isDefault {
+	useDefaultAggregation := aggTypes.IsDefault()
+	if useDefaultAggregation {
 		aggTypes = e.opts.DefaultTimerAggregationTypes()
 		e.quantiles, e.isQuantilesPooled = e.opts.TimerQuantiles(), false
 	} else {
 		e.quantiles, e.isQuantilesPooled = aggTypes.PooledQuantiles(e.opts.QuantilesPool())
 	}
 
-	e.elemBase.resetSetData(id, sp, aggTypes, isDefault)
+	e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation)
 }
 
 // AddMetric adds a new batch of timer values.
@@ -565,12 +565,12 @@ func NewGaugeElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggregat
 
 // ResetSetData resets the gauge element and sets data.
 func (e *GaugeElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
-	isDefault := aggTypes.IsDefault()
-	if isDefault {
+	useDefaultAggregation := aggTypes.IsDefault()
+	if useDefaultAggregation {
 		aggTypes = e.opts.DefaultGaugeAggregationTypes()
 	}
 
-	e.elemBase.resetSetData(id, sp, aggTypes, isDefault)
+	e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation)
 }
 
 // AddMetric adds a new gauge value

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -104,6 +104,7 @@ type elemBase struct {
 	sp         policy.StoragePolicy
 	aggTypes   policy.AggregationTypes
 	aggOpts    aggregation.Options
+	isDefault  bool
 	tombstoned bool
 	closed     bool
 }
@@ -120,7 +121,6 @@ type CounterElem struct {
 type TimerElem struct {
 	elemBase
 
-	isAggTypesPooled  bool
 	isQuantilesPooled bool
 	quantiles         []float64
 
@@ -143,11 +143,12 @@ func newElemBase(opts Options) elemBase {
 	}
 }
 
-// ResetSetData resets the counter and sets data.
-func (e *elemBase) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
+// resetSetData resets the element base and sets data.
+func (e *elemBase) resetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes, isDefault bool) {
 	e.id = id
 	e.sp = sp
 	e.aggTypes = aggTypes
+	e.isDefault = isDefault
 	e.aggOpts.ResetSetData(aggTypes)
 	e.tombstoned = false
 	e.closed = false
@@ -181,6 +182,16 @@ func NewCounterElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggreg
 	}
 	e.ResetSetData(id, sp, aggTypes)
 	return e
+}
+
+// ResetSetData resets the counter element and sets data.
+func (e *CounterElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
+	isDefault := aggTypes.IsDefault()
+	if isDefault {
+		aggTypes = e.opts.DefaultCounterAggregationTypes()
+	}
+
+	e.elemBase.resetSetData(id, sp, aggTypes, isDefault)
 }
 
 // AddMetric adds a new counter value
@@ -250,7 +261,9 @@ func (e *CounterElem) Close() {
 	pool := e.opts.CounterElemPool()
 	e.Unlock()
 
-	aggTypesPool.Put(e.aggTypes)
+	if !e.isDefault {
+		aggTypesPool.Put(e.aggTypes)
+	}
 	pool.Put(e)
 }
 
@@ -326,25 +339,19 @@ func (e *CounterElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 func (e *CounterElem) processValue(timeNanos int64, agg aggregation.Counter, fn aggMetricFn) {
 	var fullCounterPrefix = e.opts.FullCounterPrefix()
-	if e.aggOpts.UseDefaultAggregation {
-		// No suffix for default aggregations.
-		// TODO(cw) Make aggregation types for Counter configurable.
-		fn(fullCounterPrefix, e.id, e.suffix(policy.Sum), timeNanos, float64(agg.Sum()), e.sp)
+	if e.isDefault {
+		// NB(cw) Use default suffix slice for faster look up.
+		suffixes := e.opts.DefaultCounterAggregationSuffixes()
+		aggTypes := e.opts.DefaultCounterAggregationTypes()
+		for i, aggType := range aggTypes {
+			fn(fullCounterPrefix, e.id, suffixes[i], timeNanos, agg.ValueOf(aggType), e.sp)
+		}
 		return
 	}
 
 	for _, aggType := range e.aggTypes {
-		fn(fullCounterPrefix, e.id, e.suffix(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+		fn(fullCounterPrefix, e.id, e.opts.SuffixForCounter(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
 	}
-}
-
-// NB(cw) suffix overrides default suffixes to not add
-// suffix for default Counter metrics for backward compatibility reasons.
-func (e *CounterElem) suffix(aggType policy.AggregationType) []byte {
-	if aggType == policy.Sum {
-		return nil
-	}
-	return e.opts.Suffix(aggType)
 }
 
 // NewTimerElem creates a new timer element.
@@ -357,20 +364,17 @@ func NewTimerElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggregat
 	return e
 }
 
-// ResetSetData overrides elemBase.ResetData, to include quantile update for timer elements.
+// ResetSetData resets the timer element and sets data.
 func (e *TimerElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
-	e.elemBase.ResetSetData(id, sp, aggTypes)
-
-	if aggTypes.IsDefault() {
-		// TODO(cw) Remove UseDefaultAggregation in aggregation opts and
-		// store it in elemBase.
-		e.aggOpts.ResetSetData(e.opts.DefaultTimerAggregationTypes())
-		e.isAggTypesPooled = false
+	isDefault := aggTypes.IsDefault()
+	if isDefault {
+		aggTypes = e.opts.DefaultTimerAggregationTypes()
 		e.quantiles, e.isQuantilesPooled = e.opts.TimerQuantiles(), false
 	} else {
-		e.isAggTypesPooled = true
 		e.quantiles, e.isQuantilesPooled = aggTypes.PooledQuantiles(e.opts.QuantilesPool())
 	}
+
+	e.elemBase.resetSetData(id, sp, aggTypes, isDefault)
 }
 
 // AddMetric adds a new batch of timer values.
@@ -455,7 +459,7 @@ func (e *TimerElem) Close() {
 	if e.isQuantilesPooled {
 		quantileFloatsPool.Put(e.quantiles)
 	}
-	if e.isAggTypesPooled {
+	if !e.isDefault {
 		aggTypesPool.Put(e.aggTypes)
 	}
 	pool.Put(e)
@@ -534,7 +538,7 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 func (e *TimerElem) processValue(timeNanos int64, agg aggregation.Timer, fn aggMetricFn) {
 	fullTimerPrefix := e.opts.FullTimerPrefix()
-	if e.aggTypes.IsDefault() {
+	if e.isDefault {
 		// NB(cw) Use default suffix slice for faster look up.
 		suffixes := e.opts.DefaultTimerAggregationSuffixes()
 		aggTypes := e.opts.DefaultTimerAggregationTypes()
@@ -545,7 +549,7 @@ func (e *TimerElem) processValue(timeNanos int64, agg aggregation.Timer, fn aggM
 	}
 
 	for _, aggType := range e.aggTypes {
-		fn(fullTimerPrefix, e.id, e.opts.Suffix(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+		fn(fullTimerPrefix, e.id, e.opts.SuffixForTimer(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
 	}
 }
 
@@ -557,6 +561,16 @@ func NewGaugeElem(id id.RawID, sp policy.StoragePolicy, aggTypes policy.Aggregat
 	}
 	e.ResetSetData(id, sp, aggTypes)
 	return e
+}
+
+// ResetSetData resets the gauge element and sets data.
+func (e *GaugeElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes policy.AggregationTypes) {
+	isDefault := aggTypes.IsDefault()
+	if isDefault {
+		aggTypes = e.opts.DefaultGaugeAggregationTypes()
+	}
+
+	e.elemBase.resetSetData(id, sp, aggTypes, isDefault)
 }
 
 // AddMetric adds a new gauge value
@@ -625,7 +639,9 @@ func (e *GaugeElem) Close() {
 	pool := e.opts.GaugeElemPool()
 	e.Unlock()
 
-	aggTypesPool.Put(e.aggTypes)
+	if !e.isDefault {
+		aggTypesPool.Put(e.aggTypes)
+	}
 	pool.Put(e)
 }
 
@@ -701,23 +717,17 @@ func (e *GaugeElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 func (e *GaugeElem) processValue(timeNanos int64, agg aggregation.Gauge, fn aggMetricFn) {
 	var fullGaugePrefix = e.opts.FullGaugePrefix()
-	if e.aggOpts.UseDefaultAggregation {
-		// No suffix for default aggregations.
-		// TODO(cw) Make aggregation types for Gauge configurable.
-		fn(fullGaugePrefix, e.id, e.suffix(policy.Last), timeNanos, agg.Last(), e.sp)
+	if e.isDefault {
+		// NB(cw) Use default suffix slice for faster look up.
+		suffixes := e.opts.DefaultGaugeAggregationSuffixes()
+		aggTypes := e.opts.DefaultGaugeAggregationTypes()
+		for i, aggType := range aggTypes {
+			fn(fullGaugePrefix, e.id, suffixes[i], timeNanos, agg.ValueOf(aggType), e.sp)
+		}
 		return
 	}
 
 	for _, aggType := range e.aggTypes {
-		fn(fullGaugePrefix, e.id, e.suffix(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+		fn(fullGaugePrefix, e.id, e.opts.SuffixForGauge(aggType), timeNanos, agg.ValueOf(aggType), e.sp)
 	}
-}
-
-// NB(cw) suffix overrides default suffixes to not add
-// suffix for default Gauge metrics for backward compatibility reasons.
-func (e *GaugeElem) suffix(aggType policy.AggregationType) []byte {
-	if aggType == policy.Last {
-		return nil
-	}
-	return e.opts.Suffix(aggType)
 }

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -36,13 +36,14 @@ import (
 )
 
 var (
-	testCounterID             = id.RawID("testCounter")
-	testBatchTimerID          = id.RawID("testBatchTimer")
-	testGaugeID               = id.RawID("testGauge")
-	testStoragePolicy         = policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour)
-	testAggregationTypes      = policy.AggregationTypes{policy.Mean, policy.Sum}
-	testTimerAggregationTypes = policy.AggregationTypes{policy.Mean, policy.P99}
-	testTimestamps            = []time.Time{
+	testCounterID                 = id.RawID("testCounter")
+	testBatchTimerID              = id.RawID("testBatchTimer")
+	testGaugeID                   = id.RawID("testGauge")
+	testStoragePolicy             = policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour)
+	testAggregationTypes          = policy.AggregationTypes{policy.Mean, policy.Sum}
+	testAggregationTypesExpensive = policy.AggregationTypes{policy.SumSq}
+	testTimerAggregationTypes     = policy.AggregationTypes{policy.SumSq, policy.P99}
+	testTimestamps                = []time.Time{
 		time.Unix(216, 0), time.Unix(217, 0), time.Unix(221, 0),
 	}
 	testAlignedStarts = []int64{
@@ -65,8 +66,8 @@ var (
 	}
 	suffixMap = map[policy.AggregationType][]byte{
 		policy.Last:   []byte(".last"),
-		policy.Lower:  []byte(".lower"),
-		policy.Upper:  []byte(".upper"),
+		policy.Min:    []byte(".min"),
+		policy.Max:    []byte(".max"),
 		policy.Mean:   []byte(".mean"),
 		policy.Median: []byte(".median"),
 		policy.Count:  []byte(".count"),
@@ -91,71 +92,79 @@ var (
 
 func TestElemBaseID(t *testing.T) {
 	e := &elemBase{}
-	e.ResetSetData(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes)
+	e.resetSetData(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes, true)
 	require.Equal(t, testCounterID, e.ID())
 }
 
 func TestElemBaseResetSetData(t *testing.T) {
 	e := &elemBase{}
-	e.ResetSetData(testCounterID, testStoragePolicy, testAggregationTypes)
+	e.resetSetData(testCounterID, testStoragePolicy, testAggregationTypesExpensive, false)
 	require.Equal(t, testCounterID, e.id)
 	require.Equal(t, testStoragePolicy, e.sp)
 	require.False(t, e.tombstoned)
 	require.False(t, e.closed)
-	require.False(t, e.aggOpts.UseDefaultAggregation)
-	require.False(t, e.aggOpts.HasExpensiveAggregations)
+	require.False(t, e.isDefault)
+	require.True(t, e.aggOpts.HasExpensiveAggregations)
 }
 
 func TestCounterResetSetData(t *testing.T) {
-	ce := &CounterElem{}
+	opts := NewOptions()
+	ce := NewCounterElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
+	require.Equal(t, opts.DefaultCounterAggregationTypes(), ce.aggTypes)
+	require.True(t, ce.isDefault)
+	require.False(t, ce.aggOpts.HasExpensiveAggregations)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
-	ce.ResetSetData(testCounterID, sp, policy.AggregationTypes{policy.SumSq})
+	ce.ResetSetData(testCounterID, sp, testAggregationTypesExpensive)
 
 	require.Equal(t, testCounterID, ce.id)
 	require.Equal(t, sp, ce.sp)
-	require.Equal(t, policy.AggregationTypes{policy.SumSq}, ce.aggTypes)
+	require.Equal(t, testAggregationTypesExpensive, ce.aggTypes)
 	require.False(t, ce.tombstoned)
 	require.False(t, ce.closed)
-	require.False(t, ce.aggOpts.UseDefaultAggregation)
+	require.False(t, ce.isDefault)
 	require.True(t, ce.aggOpts.HasExpensiveAggregations)
 }
 
 func TestTimerResetSetData(t *testing.T) {
-	te := NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, NewOptions())
+	opts := NewOptions()
+	te := NewTimerElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
 	require.False(t, te.isQuantilesPooled)
-	require.False(t, te.isAggTypesPooled)
 	require.True(t, te.aggOpts.HasExpensiveAggregations)
-	require.True(t, te.aggTypes.IsDefault())
+	require.Equal(t, opts.DefaultTimerAggregationTypes(), te.aggTypes)
+	require.True(t, te.isDefault)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
-	te.ResetSetData(testBatchTimerID, sp, policy.AggregationTypes{policy.Upper, policy.P999})
+	te.ResetSetData(testBatchTimerID, sp, policy.AggregationTypes{policy.Max, policy.P999})
 
 	require.Equal(t, testBatchTimerID, te.id)
 	require.Equal(t, sp, te.sp)
-	require.Equal(t, policy.AggregationTypes{policy.Upper, policy.P999}, te.aggTypes)
+	require.Equal(t, policy.AggregationTypes{policy.Max, policy.P999}, te.aggTypes)
 	require.False(t, te.tombstoned)
 	require.False(t, te.closed)
-	require.False(t, te.aggOpts.UseDefaultAggregation)
+	require.False(t, te.isDefault)
 	require.False(t, te.aggOpts.HasExpensiveAggregations)
 	require.Equal(t, []float64{0.999}, te.quantiles)
 	require.True(t, te.isQuantilesPooled)
-	require.True(t, te.isAggTypesPooled)
 }
 
 func TestGaugeResetSetData(t *testing.T) {
-	ge := &GaugeElem{}
+	opts := NewOptions()
+	ge := NewGaugeElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
+	require.Equal(t, opts.DefaultGaugeAggregationTypes(), ge.aggTypes)
+	require.True(t, ge.isDefault)
+	require.False(t, ge.aggOpts.HasExpensiveAggregations)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
-	ge.ResetSetData(testGaugeID, sp, policy.DefaultAggregationTypes)
+	ge.ResetSetData(testGaugeID, sp, testAggregationTypesExpensive)
 
 	require.Equal(t, testGaugeID, ge.id)
 	require.Equal(t, sp, ge.sp)
-	require.Equal(t, policy.DefaultAggregationTypes, ge.aggTypes)
+	require.Equal(t, testAggregationTypesExpensive, ge.aggTypes)
 	require.False(t, ge.tombstoned)
 	require.False(t, ge.closed)
-	require.True(t, ge.aggOpts.UseDefaultAggregation)
-	require.False(t, ge.aggOpts.HasExpensiveAggregations)
+	require.False(t, ge.isDefault)
+	require.True(t, ge.aggOpts.HasExpensiveAggregations)
 }
 
 func TestElemBaseMarkAsTombStoned(t *testing.T) {
@@ -180,7 +189,8 @@ func TestCounterElemAddMetric(t *testing.T) {
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Sum())
-	require.Equal(t, int64(0), e.values[0].counter.Count())
+	require.Equal(t, int64(1), e.values[0].counter.Count())
+	require.Equal(t, int64(0), e.values[0].counter.SumSq())
 
 	// Add the counter metric at slightly different time
 	// but still within the same aggregation interval
@@ -188,7 +198,8 @@ func TestCounterElemAddMetric(t *testing.T) {
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, 2*testCounter.CounterVal, e.values[0].counter.Sum())
-	require.Equal(t, int64(0), e.values[0].counter.Count())
+	require.Equal(t, int64(2), e.values[0].counter.Count())
+	require.Equal(t, int64(0), e.values[0].counter.SumSq())
 
 	// Add the counter metric in the next aggregation interval
 	require.NoError(t, e.AddMetric(testTimestamps[2], testCounter))
@@ -197,7 +208,8 @@ func TestCounterElemAddMetric(t *testing.T) {
 		require.Equal(t, testAlignedStarts[i], e.values[i].timeNanos)
 	}
 	require.Equal(t, testCounter.CounterVal, e.values[1].counter.Sum())
-	require.Equal(t, int64(0), e.values[0].counter.Count())
+	require.Equal(t, int64(2), e.values[0].counter.Count())
+	require.Equal(t, int64(0), e.values[0].counter.SumSq())
 
 	// Adding the counter metric to a closed element results in an error
 	e.closed = true
@@ -205,7 +217,7 @@ func TestCounterElemAddMetric(t *testing.T) {
 }
 
 func TestCounterElemAddMetricWithCustomAggregation(t *testing.T) {
-	e := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypes, testOptions())
+	e := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypesExpensive, testOptions())
 
 	// Add a counter metric
 	require.NoError(t, e.AddMetric(testTimestamps[0], testCounter))
@@ -213,6 +225,7 @@ func TestCounterElemAddMetricWithCustomAggregation(t *testing.T) {
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Sum())
 	require.Equal(t, testCounter.CounterVal, e.values[0].counter.Max())
+	require.Equal(t, int64(testCounter.CounterVal*testCounter.CounterVal), e.values[0].counter.SumSq())
 
 	// Add the counter metric at slightly different time
 	// but still within the same aggregation interval
@@ -342,10 +355,6 @@ func TestCounterFindOrInsert(t *testing.T) {
 		require.Equal(t, e.values[expected[idx].index].counter, res)
 		require.Equal(t, expected[idx].data, times)
 	}
-}
-
-func TestCounterSuffix(t *testing.T) {
-	require.Nil(t, NewCounterElem(testCounterID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions()).suffix(policy.Sum))
 }
 
 func TestTimerElemAddMetric(t *testing.T) {
@@ -536,7 +545,8 @@ func TestGaugeElemAddMetric(t *testing.T) {
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
-	require.Equal(t, 0.0, e.values[0].gauge.Mean())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Sum())
+	require.Equal(t, 0.0, e.values[0].gauge.SumSq())
 
 	// Add the gauge metric at slightly different time
 	// but still within the same aggregation interval
@@ -544,7 +554,8 @@ func TestGaugeElemAddMetric(t *testing.T) {
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
-	require.Equal(t, 0.0, e.values[0].gauge.Mean())
+	require.Equal(t, 2*testGauge.GaugeVal, e.values[0].gauge.Sum())
+	require.Equal(t, 0.0, e.values[0].gauge.SumSq())
 
 	// Add the gauge metric in the next aggregation interval
 	require.NoError(t, e.AddMetric(testTimestamps[2], testGauge))
@@ -553,7 +564,8 @@ func TestGaugeElemAddMetric(t *testing.T) {
 		require.Equal(t, testAlignedStarts[i], e.values[i].timeNanos)
 	}
 	require.Equal(t, testGauge.GaugeVal, e.values[1].gauge.Last())
-	require.Equal(t, 0.0, e.values[0].gauge.Mean())
+	require.Equal(t, testGauge.GaugeVal, e.values[1].gauge.Sum())
+	require.Equal(t, 0.0, e.values[1].gauge.SumSq())
 
 	// Adding the gauge metric to a closed element results in an error
 	e.closed = true
@@ -561,7 +573,7 @@ func TestGaugeElemAddMetric(t *testing.T) {
 }
 
 func TestGaugeElemAddMetricWithCustomAggregation(t *testing.T) {
-	e := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypes, testOptions())
+	e := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypesExpensive, testOptions())
 
 	// Add a gauge metric
 	require.NoError(t, e.AddMetric(testTimestamps[0], testGauge))
@@ -570,6 +582,8 @@ func TestGaugeElemAddMetricWithCustomAggregation(t *testing.T) {
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Sum())
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Mean())
+	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Sum())
+	require.Equal(t, testGauge.GaugeVal*testGauge.GaugeVal, e.values[0].gauge.SumSq())
 
 	// Add the gauge metric at slightly different time
 	// but still within the same aggregation interval
@@ -578,6 +592,8 @@ func TestGaugeElemAddMetricWithCustomAggregation(t *testing.T) {
 	require.Equal(t, testAlignedStarts[0], e.values[0].timeNanos)
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Last())
 	require.Equal(t, testGauge.GaugeVal, e.values[0].gauge.Max())
+	require.Equal(t, 2*testGauge.GaugeVal, e.values[0].gauge.Sum())
+	require.Equal(t, 2*testGauge.GaugeVal*testGauge.GaugeVal, e.values[0].gauge.SumSq())
 
 	// Add the gauge metric in the next aggregation interval
 	require.NoError(t, e.AddMetric(testTimestamps[2], testGauge))
@@ -703,10 +719,6 @@ func TestGaugeFindOrInsert(t *testing.T) {
 	}
 }
 
-func TestGaugeSuffix(t *testing.T) {
-	require.Nil(t, NewGaugeElem(testGaugeID, testStoragePolicy, policy.DefaultAggregationTypes, testOptions()).suffix(policy.Last))
-}
-
 type testIndexData struct {
 	index int
 	data  []int64
@@ -806,15 +818,15 @@ func testGaugeElem(aggTypes policy.AggregationTypes) *GaugeElem {
 }
 
 func expectCounterSuffix(aggType policy.AggregationType) []byte {
-	return NewCounterElem(testCounterID, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, NewOptions()).suffix(aggType)
+	return NewOptions().SuffixForCounter(aggType)
 }
 
 func expectTimerSuffix(aggType policy.AggregationType) []byte {
-	return NewOptions().Suffix(aggType)
+	return NewOptions().SuffixForTimer(aggType)
 }
 
 func expectGaugeSuffix(aggType policy.AggregationType) []byte {
-	return NewGaugeElem(testGaugeID, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, NewOptions()).suffix(aggType)
+	return NewOptions().SuffixForGauge(aggType)
 }
 
 func expectedAggMetricsForCounter(
@@ -858,8 +870,8 @@ func expectedAggMetricsForTimer(
 		{policy.Sum, 18.0},
 		{policy.SumSq, 83.38},
 		{policy.Mean, 3.6},
-		{policy.Lower, 1.0},
-		{policy.Upper, 6.5},
+		{policy.Min, 1.0},
+		{policy.Max, 6.5},
 		{policy.Count, 5.0},
 		{policy.Stdev, 2.15522620622523},
 		{policy.Median, 3.5},

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -103,7 +103,7 @@ func TestElemBaseResetSetData(t *testing.T) {
 	require.Equal(t, testStoragePolicy, e.sp)
 	require.False(t, e.tombstoned)
 	require.False(t, e.closed)
-	require.False(t, e.isDefault)
+	require.False(t, e.useDefaultAggregation)
 	require.True(t, e.aggOpts.HasExpensiveAggregations)
 }
 
@@ -111,7 +111,7 @@ func TestCounterResetSetData(t *testing.T) {
 	opts := NewOptions()
 	ce := NewCounterElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
 	require.Equal(t, opts.DefaultCounterAggregationTypes(), ce.aggTypes)
-	require.True(t, ce.isDefault)
+	require.True(t, ce.useDefaultAggregation)
 	require.False(t, ce.aggOpts.HasExpensiveAggregations)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
@@ -122,7 +122,7 @@ func TestCounterResetSetData(t *testing.T) {
 	require.Equal(t, testAggregationTypesExpensive, ce.aggTypes)
 	require.False(t, ce.tombstoned)
 	require.False(t, ce.closed)
-	require.False(t, ce.isDefault)
+	require.False(t, ce.useDefaultAggregation)
 	require.True(t, ce.aggOpts.HasExpensiveAggregations)
 }
 
@@ -132,7 +132,7 @@ func TestTimerResetSetData(t *testing.T) {
 	require.False(t, te.isQuantilesPooled)
 	require.True(t, te.aggOpts.HasExpensiveAggregations)
 	require.Equal(t, opts.DefaultTimerAggregationTypes(), te.aggTypes)
-	require.True(t, te.isDefault)
+	require.True(t, te.useDefaultAggregation)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
 	te.ResetSetData(testBatchTimerID, sp, policy.AggregationTypes{policy.Max, policy.P999})
@@ -142,7 +142,7 @@ func TestTimerResetSetData(t *testing.T) {
 	require.Equal(t, policy.AggregationTypes{policy.Max, policy.P999}, te.aggTypes)
 	require.False(t, te.tombstoned)
 	require.False(t, te.closed)
-	require.False(t, te.isDefault)
+	require.False(t, te.useDefaultAggregation)
 	require.False(t, te.aggOpts.HasExpensiveAggregations)
 	require.Equal(t, []float64{0.999}, te.quantiles)
 	require.True(t, te.isQuantilesPooled)
@@ -152,7 +152,7 @@ func TestGaugeResetSetData(t *testing.T) {
 	opts := NewOptions()
 	ge := NewGaugeElem(nil, policy.DefaultStoragePolicy, policy.DefaultAggregationTypes, opts)
 	require.Equal(t, opts.DefaultGaugeAggregationTypes(), ge.aggTypes)
-	require.True(t, ge.isDefault)
+	require.True(t, ge.useDefaultAggregation)
 	require.False(t, ge.aggOpts.HasExpensiveAggregations)
 
 	sp := policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
@@ -163,7 +163,7 @@ func TestGaugeResetSetData(t *testing.T) {
 	require.Equal(t, testAggregationTypesExpensive, ge.aggTypes)
 	require.False(t, ge.tombstoned)
 	require.False(t, ge.closed)
-	require.False(t, ge.isDefault)
+	require.False(t, ge.useDefaultAggregation)
 	require.True(t, ge.aggOpts.HasExpensiveAggregations)
 }
 

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -40,10 +40,10 @@ import (
 var (
 	testPoliciesVersion = 2
 	compressor          = policy.NewAggregationIDCompressor()
-	compressedUpper, _  = compressor.Compress(policy.AggregationTypes{policy.Upper})
+	compressedMax, _    = compressor.Compress(policy.AggregationTypes{policy.Max})
 	testPolicies        = []policy.Policy{
 		policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
-		policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), compressedUpper),
+		policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), compressedMax),
 		policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 30*24*time.Hour), policy.DefaultAggregationID),
 	}
 	testNewPolicies = []policy.Policy{
@@ -579,7 +579,7 @@ func TestEntryAddMetricWithPoliciesListWithPolicyUpdateIDOwnsID(t *testing.T) {
 
 func TestEntryAddMetricWithPoliciesListWithInvalidAggregationType(t *testing.T) {
 	compressor := policy.NewAggregationIDCompressor()
-	compressedMin, err := compressor.Compress(policy.AggregationTypes{policy.Lower})
+	compressedMin, err := compressor.Compress(policy.AggregationTypes{policy.Min})
 	require.NoError(t, err)
 	compressedLast, err := compressor.Compress(policy.AggregationTypes{policy.Last})
 	require.NoError(t, err)

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -209,7 +209,7 @@ func NewOptions() Options {
 func (o *options) SetDefaultCounterAggregationTypes(aggTypes policy.AggregationTypes) Options {
 	opts := *o
 	opts.defaultCounterAggregationTypes = aggTypes
-	opts.computeDefaultCounterAggregationSuffix()
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -220,8 +220,8 @@ func (o *options) DefaultCounterAggregationTypes() policy.AggregationTypes {
 func (o *options) SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options {
 	opts := *o
 	opts.defaultTimerAggregationTypes = aggTypes
-	opts.computeDefaultTimerAggregationSuffix()
 	opts.computeQuantiles()
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -232,7 +232,7 @@ func (o *options) DefaultTimerAggregationTypes() policy.AggregationTypes {
 func (o *options) SetDefaultGaugeAggregationTypes(aggTypes policy.AggregationTypes) Options {
 	opts := *o
 	opts.defaultGaugeAggregationTypes = aggTypes
-	opts.computeDefaultGaugeAggregationSuffix()
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -287,6 +287,7 @@ func (o *options) GaugePrefix() []byte {
 func (o *options) SetAggregationLastSuffix(value []byte) Options {
 	opts := *o
 	opts.lastSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -297,6 +298,7 @@ func (o *options) AggregationLastSuffix() []byte {
 func (o *options) SetAggregationMinSuffix(value []byte) Options {
 	opts := *o
 	opts.minSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -307,6 +309,7 @@ func (o *options) AggregationMinSuffix() []byte {
 func (o *options) SetAggregationMaxSuffix(value []byte) Options {
 	opts := *o
 	opts.maxSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -314,15 +317,10 @@ func (o *options) AggregationMaxSuffix() []byte {
 	return o.maxSuffix
 }
 
-func (o *options) SetAggregationSumSuffix(value []byte) Options {
-	opts := *o
-	opts.sumSuffix = value
-	return &opts
-}
-
 func (o *options) SetAggregationMeanSuffix(value []byte) Options {
 	opts := *o
 	opts.meanSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -333,6 +331,7 @@ func (o *options) AggregationMeanSuffix() []byte {
 func (o *options) SetAggregationMedianSuffix(value []byte) Options {
 	opts := *o
 	opts.medianSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -343,11 +342,19 @@ func (o *options) AggregationMedianSuffix() []byte {
 func (o *options) SetAggregationCountSuffix(value []byte) Options {
 	opts := *o
 	opts.countSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
 func (o *options) AggregationCountSuffix() []byte {
 	return o.countSuffix
+}
+
+func (o *options) SetAggregationSumSuffix(value []byte) Options {
+	opts := *o
+	opts.sumSuffix = value
+	opts.computeSuffixes()
+	return &opts
 }
 
 func (o *options) AggregationSumSuffix() []byte {
@@ -357,6 +364,7 @@ func (o *options) AggregationSumSuffix() []byte {
 func (o *options) SetAggregationSumSqSuffix(value []byte) Options {
 	opts := *o
 	opts.sumSqSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -367,6 +375,7 @@ func (o *options) AggregationSumSqSuffix() []byte {
 func (o *options) SetAggregationStdevSuffix(value []byte) Options {
 	opts := *o
 	opts.stdevSuffix = value
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -377,9 +386,7 @@ func (o *options) AggregationStdevSuffix() []byte {
 func (o *options) SetTimerQuantileSuffixFn(value QuantileSuffixFn) Options {
 	opts := *o
 	opts.timerQuantileSuffixFn = value
-	opts.computeDefaultSuffixes()
-	opts.computeTimerSuffix()
-	opts.computeDefaultTimerAggregationSuffix()
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -616,21 +623,21 @@ func (o *options) SetQuantilesPool(pool pool.FloatsPool) Options {
 func (o *options) SetCounterSuffixOverride(m map[policy.AggregationType][]byte) Options {
 	opts := *o
 	opts.counterSuffixOverride = m
-	opts.computeCounterSuffix()
+	opts.computeSuffixes()
 	return &opts
 }
 
 func (o *options) SetTimerSuffixOverride(m map[policy.AggregationType][]byte) Options {
 	opts := *o
 	opts.timerSuffixOverride = m
-	opts.computeTimerSuffix()
+	opts.computeSuffixes()
 	return &opts
 }
 
 func (o *options) SetGaugeSuffixOverride(m map[policy.AggregationType][]byte) Options {
 	opts := *o
 	opts.gaugeSuffixOverride = m
-	opts.computeGaugeSuffix()
+	opts.computeSuffixes()
 	return &opts
 }
 
@@ -716,13 +723,7 @@ func (o *options) initPools() {
 func (o *options) computeAllDerived() {
 	o.computeFullPrefixes()
 	o.computeQuantiles()
-	o.computeDefaultSuffixes()
-	o.computeCounterSuffix()
-	o.computeTimerSuffix()
-	o.computeGaugeSuffix()
-	o.computeDefaultCounterAggregationSuffix()
-	o.computeDefaultTimerAggregationSuffix()
-	o.computeDefaultGaugeAggregationSuffix()
+	o.computeSuffixes()
 }
 
 func (o *options) computeFullPrefixes() {
@@ -733,6 +734,17 @@ func (o *options) computeFullPrefixes() {
 
 func (o *options) computeQuantiles() {
 	o.timerQuantiles, _ = o.DefaultTimerAggregationTypes().PooledQuantiles(o.QuantilesPool())
+}
+
+func (o *options) computeSuffixes() {
+	// NB(cw) The order matters.
+	o.computeDefaultSuffixes()
+	o.computeCounterSuffixes()
+	o.computeTimerSuffixes()
+	o.computeGaugeSuffixes()
+	o.computeDefaultCounterAggregationSuffix()
+	o.computeDefaultTimerAggregationSuffix()
+	o.computeDefaultGaugeAggregationSuffix()
 }
 
 func (o *options) computeDefaultSuffixes() {
@@ -767,37 +779,28 @@ func (o *options) computeDefaultSuffixes() {
 	}
 }
 
-func (o *options) computeCounterSuffix() {
-	o.counterSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
-	for aggType := range policy.ValidAggregationTypes {
-		if suffix, ok := o.counterSuffixOverride[aggType]; ok {
-			o.counterSuffixes[aggType.ID()] = suffix
-			continue
-		}
-		o.counterSuffixes[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
-	}
+func (o *options) computeCounterSuffixes() {
+	o.counterSuffixes = o.computeOverrideSuffixes(o.counterSuffixOverride)
 }
 
-func (o *options) computeTimerSuffix() {
-	o.timerSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
-	for aggType := range policy.ValidAggregationTypes {
-		if suffix, ok := o.timerSuffixOverride[aggType]; ok {
-			o.timerSuffixes[aggType.ID()] = suffix
-			continue
-		}
-		o.timerSuffixes[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
-	}
+func (o *options) computeTimerSuffixes() {
+	o.timerSuffixes = o.computeOverrideSuffixes(o.timerSuffixOverride)
 }
 
-func (o *options) computeGaugeSuffix() {
-	o.gaugeSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
+func (o *options) computeGaugeSuffixes() {
+	o.gaugeSuffixes = o.computeOverrideSuffixes(o.gaugeSuffixOverride)
+}
+
+func (o options) computeOverrideSuffixes(m map[policy.AggregationType][]byte) [][]byte {
+	res := make([][]byte, policy.MaxAggregationTypeID+1)
 	for aggType := range policy.ValidAggregationTypes {
-		if suffix, ok := o.gaugeSuffixOverride[aggType]; ok {
-			o.gaugeSuffixes[aggType.ID()] = suffix
+		if suffix, ok := m[aggType]; ok {
+			res[aggType.ID()] = suffix
 			continue
 		}
-		o.gaugeSuffixes[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
+		res[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
 	}
+	return res
 }
 
 func (o *options) computeDefaultCounterAggregationSuffix() {

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -47,8 +47,8 @@ var (
 	defaultAggregationSumSuffix      = []byte(".sum")
 	defaultAggregationSumSqSuffix    = []byte(".sum_sq")
 	defaultAggregationMeanSuffix     = []byte(".mean")
-	defaultAggregationLowerSuffix    = []byte(".lower")
-	defaultAggregationUpperSuffix    = []byte(".upper")
+	defaultAggregationMinSuffix      = []byte(".min")
+	defaultAggregationMaxSuffix      = []byte(".max")
 	defaultAggregationCountSuffix    = []byte(".count")
 	defaultAggregationStdevSuffix    = []byte(".stdev")
 	defaultAggregationMedianSuffix   = []byte(".median")
@@ -64,12 +64,15 @@ var (
 		policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 40*24*time.Hour), policy.DefaultAggregationID),
 	}
 
+	defaultDefaultCounterAggregationTypes = policy.AggregationTypes{
+		policy.Sum,
+	}
 	defaultDefaultTimerAggregationTypes = policy.AggregationTypes{
 		policy.Sum,
 		policy.SumSq,
 		policy.Mean,
-		policy.Lower,
-		policy.Upper,
+		policy.Min,
+		policy.Max,
 		policy.Count,
 		policy.Stdev,
 		policy.Median,
@@ -77,90 +80,121 @@ var (
 		policy.P95,
 		policy.P99,
 	}
+	defaultDefaultGaugeAggregationTypes = policy.AggregationTypes{
+		policy.Last,
+	}
+
+	defaultCounterSuffixOverride = map[policy.AggregationType][]byte{
+		policy.Sum: nil,
+	}
+	defaultTimerSuffixOverride = map[policy.AggregationType][]byte{
+		policy.Min: []byte(".lower"),
+		policy.Max: []byte(".upper"),
+	}
+	defaultGaugeSuffixOverride = map[policy.AggregationType][]byte{
+		policy.Last: nil,
+	}
 )
 
 type options struct {
 	// Base options.
-	metricPrefix                    []byte
-	counterPrefix                   []byte
-	timerPrefix                     []byte
-	sumSuffix                       []byte
-	sumSqSuffix                     []byte
-	meanSuffix                      []byte
-	lastSuffix                      []byte
-	lowerSuffix                     []byte
-	upperSuffix                     []byte
-	countSuffix                     []byte
-	stdevSuffix                     []byte
-	medianSuffix                    []byte
-	defaultTimerAggregationTypes    policy.AggregationTypes
-	defaultTimerAggregationSuffixes [][]byte
-	timerQuantiles                  []float64
-	timerQuantileSuffixFn           QuantileSuffixFn
-	gaugePrefix                     []byte
-	timeLock                        *sync.RWMutex
-	clockOpts                       clock.Options
-	instrumentOpts                  instrument.Options
-	streamOpts                      cm.Options
-	placementWatcherOpts            services.StagedPlacementWatcherOptions
-	instanceID                      string
-	shardFn                         ShardFn
-	flushManager                    FlushManager
-	minFlushInterval                time.Duration
-	maxFlushSize                    int
-	flushHandler                    Handler
-	entryTTL                        time.Duration
-	entryCheckInterval              time.Duration
-	entryCheckBatchPercent          float64
-	maxTimerBatchSizePerWrite       int
-	defaultPolicies                 []policy.Policy
-	entryPool                       EntryPool
-	counterElemPool                 CounterElemPool
-	timerElemPool                   TimerElemPool
-	gaugeElemPool                   GaugeElemPool
-	bufferedEncoderPool             msgpack.BufferedEncoderPool
-	aggTypesPool                    policy.AggregationTypesPool
-	quantilesPool                   pool.FloatsPool
+	defaultCounterAggregationTypes policy.AggregationTypes
+	defaultTimerAggregationTypes   policy.AggregationTypes
+	defaultGaugeAggregationTypes   policy.AggregationTypes
+	metricPrefix                   []byte
+	counterPrefix                  []byte
+	timerPrefix                    []byte
+	gaugePrefix                    []byte
+	sumSuffix                      []byte
+	sumSqSuffix                    []byte
+	meanSuffix                     []byte
+	lastSuffix                     []byte
+	minSuffix                      []byte
+	maxSuffix                      []byte
+	countSuffix                    []byte
+	stdevSuffix                    []byte
+	medianSuffix                   []byte
+	timerQuantileSuffixFn          QuantileSuffixFn
+	timeLock                       *sync.RWMutex
+	clockOpts                      clock.Options
+	instrumentOpts                 instrument.Options
+	streamOpts                     cm.Options
+	placementWatcherOpts           services.StagedPlacementWatcherOptions
+	instanceID                     string
+	shardFn                        ShardFn
+	flushManager                   FlushManager
+	minFlushInterval               time.Duration
+	maxFlushSize                   int
+	flushHandler                   Handler
+	entryTTL                       time.Duration
+	entryCheckInterval             time.Duration
+	entryCheckBatchPercent         float64
+	maxTimerBatchSizePerWrite      int
+	defaultPolicies                []policy.Policy
+	entryPool                      EntryPool
+	counterElemPool                CounterElemPool
+	timerElemPool                  TimerElemPool
+	gaugeElemPool                  GaugeElemPool
+	bufferedEncoderPool            msgpack.BufferedEncoderPool
+	aggTypesPool                   policy.AggregationTypesPool
+	quantilesPool                  pool.FloatsPool
+
+	counterSuffixOverride map[policy.AggregationType][]byte
+	timerSuffixOverride   map[policy.AggregationType][]byte
+	gaugeSuffixOverride   map[policy.AggregationType][]byte
+
+	defaultSuffixes [][]byte
+	counterSuffixes [][]byte
+	timerSuffixes   [][]byte
+	gaugeSuffixes   [][]byte
 
 	// Derived options.
-	fullCounterPrefix []byte
-	fullTimerPrefix   []byte
-	fullGaugePrefix   []byte
-	suffixes          [][]byte
+	fullCounterPrefix                 []byte
+	fullTimerPrefix                   []byte
+	fullGaugePrefix                   []byte
+	defaultCounterAggregationSuffixes [][]byte
+	defaultTimerAggregationSuffixes   [][]byte
+	defaultGaugeAggregationSuffixes   [][]byte
+	timerQuantiles                    []float64
 }
 
 // NewOptions create a new set of options.
 func NewOptions() Options {
 	o := &options{
-		metricPrefix:                 defaultMetricPrefix,
-		counterPrefix:                defaultCounterPrefix,
-		timerPrefix:                  defaultTimerPrefix,
-		lastSuffix:                   defaultAggregationLastSuffix,
-		sumSuffix:                    defaultAggregationSumSuffix,
-		sumSqSuffix:                  defaultAggregationSumSqSuffix,
-		meanSuffix:                   defaultAggregationMeanSuffix,
-		lowerSuffix:                  defaultAggregationLowerSuffix,
-		upperSuffix:                  defaultAggregationUpperSuffix,
-		countSuffix:                  defaultAggregationCountSuffix,
-		stdevSuffix:                  defaultAggregationStdevSuffix,
-		medianSuffix:                 defaultAggregationMedianSuffix,
-		defaultTimerAggregationTypes: defaultDefaultTimerAggregationTypes,
-		timerQuantileSuffixFn:        defaultTimerQuantileSuffixFn,
-		gaugePrefix:                  defaultGaugePrefix,
-		timeLock:                     &sync.RWMutex{},
-		clockOpts:                    clock.NewOptions(),
-		instrumentOpts:               instrument.NewOptions(),
-		streamOpts:                   cm.NewOptions(),
-		placementWatcherOpts:         placement.NewStagedPlacementWatcherOptions(),
-		instanceID:                   defaultInstanceID,
-		shardFn:                      defaultShardFn,
-		minFlushInterval:             defaultMinFlushInterval,
-		maxFlushSize:                 defaultMaxFlushSize,
-		entryTTL:                     defaultEntryTTL,
-		entryCheckInterval:           defaultEntryCheckInterval,
-		entryCheckBatchPercent:       defaultEntryCheckBatchPercent,
-		maxTimerBatchSizePerWrite:    defaultMaxTimerBatchSizePerWrite,
-		defaultPolicies:              defaultDefaultPolicies,
+		defaultCounterAggregationTypes: defaultDefaultCounterAggregationTypes,
+		defaultTimerAggregationTypes:   defaultDefaultTimerAggregationTypes,
+		defaultGaugeAggregationTypes:   defaultDefaultGaugeAggregationTypes,
+		metricPrefix:                   defaultMetricPrefix,
+		counterPrefix:                  defaultCounterPrefix,
+		timerPrefix:                    defaultTimerPrefix,
+		gaugePrefix:                    defaultGaugePrefix,
+		lastSuffix:                     defaultAggregationLastSuffix,
+		minSuffix:                      defaultAggregationMinSuffix,
+		maxSuffix:                      defaultAggregationMaxSuffix,
+		meanSuffix:                     defaultAggregationMeanSuffix,
+		medianSuffix:                   defaultAggregationMedianSuffix,
+		countSuffix:                    defaultAggregationCountSuffix,
+		sumSuffix:                      defaultAggregationSumSuffix,
+		sumSqSuffix:                    defaultAggregationSumSqSuffix,
+		stdevSuffix:                    defaultAggregationStdevSuffix,
+		timerQuantileSuffixFn:          defaultTimerQuantileSuffixFn,
+		timeLock:                       &sync.RWMutex{},
+		clockOpts:                      clock.NewOptions(),
+		instrumentOpts:                 instrument.NewOptions(),
+		streamOpts:                     cm.NewOptions(),
+		placementWatcherOpts:           placement.NewStagedPlacementWatcherOptions(),
+		instanceID:                     defaultInstanceID,
+		shardFn:                        defaultShardFn,
+		minFlushInterval:               defaultMinFlushInterval,
+		maxFlushSize:                   defaultMaxFlushSize,
+		entryTTL:                       defaultEntryTTL,
+		entryCheckInterval:             defaultEntryCheckInterval,
+		entryCheckBatchPercent:         defaultEntryCheckBatchPercent,
+		maxTimerBatchSizePerWrite:      defaultMaxTimerBatchSizePerWrite,
+		defaultPolicies:                defaultDefaultPolicies,
+		counterSuffixOverride:          defaultCounterSuffixOverride,
+		timerSuffixOverride:            defaultTimerSuffixOverride,
+		gaugeSuffixOverride:            defaultGaugeSuffixOverride,
 	}
 
 	// Initialize pools.
@@ -170,6 +204,40 @@ func NewOptions() Options {
 	o.computeAllDerived()
 
 	return o
+}
+
+func (o *options) SetDefaultCounterAggregationTypes(aggTypes policy.AggregationTypes) Options {
+	opts := *o
+	opts.defaultCounterAggregationTypes = aggTypes
+	opts.computeDefaultCounterAggregationSuffix()
+	return &opts
+}
+
+func (o *options) DefaultCounterAggregationTypes() policy.AggregationTypes {
+	return o.defaultCounterAggregationTypes
+}
+
+func (o *options) SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options {
+	opts := *o
+	opts.defaultTimerAggregationTypes = aggTypes
+	opts.computeDefaultTimerAggregationSuffix()
+	opts.computeQuantiles()
+	return &opts
+}
+
+func (o *options) DefaultTimerAggregationTypes() policy.AggregationTypes {
+	return o.defaultTimerAggregationTypes
+}
+
+func (o *options) SetDefaultGaugeAggregationTypes(aggTypes policy.AggregationTypes) Options {
+	opts := *o
+	opts.defaultGaugeAggregationTypes = aggTypes
+	opts.computeDefaultGaugeAggregationSuffix()
+	return &opts
+}
+
+func (o *options) DefaultGaugeAggregationTypes() policy.AggregationTypes {
+	return o.defaultGaugeAggregationTypes
 }
 
 func (o *options) SetMetricPrefix(value []byte) Options {
@@ -205,6 +273,17 @@ func (o *options) TimerPrefix() []byte {
 	return o.timerPrefix
 }
 
+func (o *options) SetGaugePrefix(value []byte) Options {
+	opts := *o
+	opts.gaugePrefix = value
+	opts.computeFullGaugePrefix()
+	return &opts
+}
+
+func (o *options) GaugePrefix() []byte {
+	return o.gaugePrefix
+}
+
 func (o *options) SetAggregationLastSuffix(value []byte) Options {
 	opts := *o
 	opts.lastSuffix = value
@@ -215,10 +294,60 @@ func (o *options) AggregationLastSuffix() []byte {
 	return o.lastSuffix
 }
 
+func (o *options) SetAggregationMinSuffix(value []byte) Options {
+	opts := *o
+	opts.minSuffix = value
+	return &opts
+}
+
+func (o *options) AggregationMinSuffix() []byte {
+	return o.minSuffix
+}
+
+func (o *options) SetAggregationMaxSuffix(value []byte) Options {
+	opts := *o
+	opts.maxSuffix = value
+	return &opts
+}
+
+func (o *options) AggregationMaxSuffix() []byte {
+	return o.maxSuffix
+}
+
 func (o *options) SetAggregationSumSuffix(value []byte) Options {
 	opts := *o
 	opts.sumSuffix = value
 	return &opts
+}
+
+func (o *options) SetAggregationMeanSuffix(value []byte) Options {
+	opts := *o
+	opts.meanSuffix = value
+	return &opts
+}
+
+func (o *options) AggregationMeanSuffix() []byte {
+	return o.meanSuffix
+}
+
+func (o *options) SetAggregationMedianSuffix(value []byte) Options {
+	opts := *o
+	opts.medianSuffix = value
+	return &opts
+}
+
+func (o *options) AggregationMedianSuffix() []byte {
+	return o.medianSuffix
+}
+
+func (o *options) SetAggregationCountSuffix(value []byte) Options {
+	opts := *o
+	opts.countSuffix = value
+	return &opts
+}
+
+func (o *options) AggregationCountSuffix() []byte {
+	return o.countSuffix
 }
 
 func (o *options) AggregationSumSuffix() []byte {
@@ -235,46 +364,6 @@ func (o *options) AggregationSumSqSuffix() []byte {
 	return o.sumSqSuffix
 }
 
-func (o *options) SetAggregationMeanSuffix(value []byte) Options {
-	opts := *o
-	opts.meanSuffix = value
-	return &opts
-}
-
-func (o *options) AggregationMeanSuffix() []byte {
-	return o.meanSuffix
-}
-
-func (o *options) SetAggregationLowerSuffix(value []byte) Options {
-	opts := *o
-	opts.lowerSuffix = value
-	return &opts
-}
-
-func (o *options) AggregationLowerSuffix() []byte {
-	return o.lowerSuffix
-}
-
-func (o *options) SetAggregationUpperSuffix(value []byte) Options {
-	opts := *o
-	opts.upperSuffix = value
-	return &opts
-}
-
-func (o *options) AggregationUpperSuffix() []byte {
-	return o.upperSuffix
-}
-
-func (o *options) SetAggregationCountSuffix(value []byte) Options {
-	opts := *o
-	opts.countSuffix = value
-	return &opts
-}
-
-func (o *options) AggregationCountSuffix() []byte {
-	return o.countSuffix
-}
-
 func (o *options) SetAggregationStdevSuffix(value []byte) Options {
 	opts := *o
 	opts.stdevSuffix = value
@@ -285,49 +374,17 @@ func (o *options) AggregationStdevSuffix() []byte {
 	return o.stdevSuffix
 }
 
-func (o *options) SetAggregationMedianSuffix(value []byte) Options {
-	opts := *o
-	opts.medianSuffix = value
-	return &opts
-}
-
-func (o *options) AggregationMedianSuffix() []byte {
-	return o.medianSuffix
-}
-
-func (o *options) SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options {
-	opts := *o
-	opts.defaultTimerAggregationTypes = aggTypes
-	opts.computeQuantiles()
-	opts.computeDefaultTimerAggregationSuffix()
-	return &opts
-}
-
-func (o *options) DefaultTimerAggregationTypes() policy.AggregationTypes {
-	return o.defaultTimerAggregationTypes
-}
-
 func (o *options) SetTimerQuantileSuffixFn(value QuantileSuffixFn) Options {
 	opts := *o
 	opts.timerQuantileSuffixFn = value
-	opts.computeSuffixes()
+	opts.computeDefaultSuffixes()
+	opts.computeTimerSuffix()
 	opts.computeDefaultTimerAggregationSuffix()
 	return &opts
 }
 
 func (o *options) TimerQuantileSuffixFn() QuantileSuffixFn {
 	return o.timerQuantileSuffixFn
-}
-
-func (o *options) SetGaugePrefix(value []byte) Options {
-	opts := *o
-	opts.gaugePrefix = value
-	opts.computeFullGaugePrefix()
-	return &opts
-}
-
-func (o *options) GaugePrefix() []byte {
-	return o.gaugePrefix
 }
 
 func (o *options) SetTimeLock(value *sync.RWMutex) Options {
@@ -556,6 +613,27 @@ func (o *options) SetQuantilesPool(pool pool.FloatsPool) Options {
 	return &opts
 }
 
+func (o *options) SetCounterSuffixOverride(m map[policy.AggregationType][]byte) Options {
+	opts := *o
+	opts.counterSuffixOverride = m
+	opts.computeCounterSuffix()
+	return &opts
+}
+
+func (o *options) SetTimerSuffixOverride(m map[policy.AggregationType][]byte) Options {
+	opts := *o
+	opts.timerSuffixOverride = m
+	opts.computeTimerSuffix()
+	return &opts
+}
+
+func (o *options) SetGaugeSuffixOverride(m map[policy.AggregationType][]byte) Options {
+	opts := *o
+	opts.gaugeSuffixOverride = m
+	opts.computeGaugeSuffix()
+	return &opts
+}
+
 func (o *options) QuantilesPool() pool.FloatsPool {
 	return o.quantilesPool
 }
@@ -576,12 +654,28 @@ func (o *options) TimerQuantiles() []float64 {
 	return o.timerQuantiles
 }
 
+func (o *options) DefaultCounterAggregationSuffixes() [][]byte {
+	return o.defaultCounterAggregationSuffixes
+}
+
 func (o *options) DefaultTimerAggregationSuffixes() [][]byte {
 	return o.defaultTimerAggregationSuffixes
 }
 
-func (o *options) Suffix(aggType policy.AggregationType) []byte {
-	return o.suffixes[aggType.ID()]
+func (o *options) DefaultGaugeAggregationSuffixes() [][]byte {
+	return o.defaultGaugeAggregationSuffixes
+}
+
+func (o *options) SuffixForCounter(aggType policy.AggregationType) []byte {
+	return o.counterSuffixes[aggType.ID()]
+}
+
+func (o *options) SuffixForTimer(aggType policy.AggregationType) []byte {
+	return o.timerSuffixes[aggType.ID()]
+}
+
+func (o *options) SuffixForGauge(aggType policy.AggregationType) []byte {
+	return o.gaugeSuffixes[aggType.ID()]
 }
 
 func (o *options) initPools() {
@@ -622,8 +716,13 @@ func (o *options) initPools() {
 func (o *options) computeAllDerived() {
 	o.computeFullPrefixes()
 	o.computeQuantiles()
-	o.computeSuffixes()
+	o.computeDefaultSuffixes()
+	o.computeCounterSuffix()
+	o.computeTimerSuffix()
+	o.computeGaugeSuffix()
+	o.computeDefaultCounterAggregationSuffix()
 	o.computeDefaultTimerAggregationSuffix()
+	o.computeDefaultGaugeAggregationSuffix()
 }
 
 func (o *options) computeFullPrefixes() {
@@ -636,42 +735,89 @@ func (o *options) computeQuantiles() {
 	o.timerQuantiles, _ = o.DefaultTimerAggregationTypes().PooledQuantiles(o.QuantilesPool())
 }
 
-func (o *options) computeSuffixes() {
-	o.suffixes = make([][]byte, policy.MaxAggregationTypeID+1)
+func (o *options) computeDefaultSuffixes() {
+	o.defaultSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
 
 	for aggType := range policy.ValidAggregationTypes {
 		switch aggType {
 		case policy.Last:
-			o.suffixes[aggType.ID()] = o.AggregationLastSuffix()
-		case policy.Lower:
-			o.suffixes[aggType.ID()] = o.AggregationLowerSuffix()
-		case policy.Upper:
-			o.suffixes[aggType.ID()] = o.AggregationUpperSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationLastSuffix()
+		case policy.Min:
+			o.defaultSuffixes[aggType.ID()] = o.AggregationMinSuffix()
+		case policy.Max:
+			o.defaultSuffixes[aggType.ID()] = o.AggregationMaxSuffix()
 		case policy.Mean:
-			o.suffixes[aggType.ID()] = o.AggregationMeanSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationMeanSuffix()
 		case policy.Median:
-			o.suffixes[aggType.ID()] = o.AggregationMedianSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationMedianSuffix()
 		case policy.Count:
-			o.suffixes[aggType.ID()] = o.AggregationCountSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationCountSuffix()
 		case policy.Sum:
-			o.suffixes[aggType.ID()] = o.AggregationSumSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationSumSuffix()
 		case policy.SumSq:
-			o.suffixes[aggType.ID()] = o.AggregationSumSqSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationSumSqSuffix()
 		case policy.Stdev:
-			o.suffixes[aggType.ID()] = o.AggregationStdevSuffix()
+			o.defaultSuffixes[aggType.ID()] = o.AggregationStdevSuffix()
 		default:
 			q, ok := aggType.Quantile()
 			if ok {
-				o.suffixes[aggType.ID()] = o.timerQuantileSuffixFn(q)
+				o.defaultSuffixes[aggType.ID()] = o.timerQuantileSuffixFn(q)
 			}
 		}
+	}
+}
+
+func (o *options) computeCounterSuffix() {
+	o.counterSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
+	for aggType := range policy.ValidAggregationTypes {
+		if suffix, ok := o.counterSuffixOverride[aggType]; ok {
+			o.counterSuffixes[aggType.ID()] = suffix
+			continue
+		}
+		o.counterSuffixes[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
+	}
+}
+
+func (o *options) computeTimerSuffix() {
+	o.timerSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
+	for aggType := range policy.ValidAggregationTypes {
+		if suffix, ok := o.timerSuffixOverride[aggType]; ok {
+			o.timerSuffixes[aggType.ID()] = suffix
+			continue
+		}
+		o.timerSuffixes[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
+	}
+}
+
+func (o *options) computeGaugeSuffix() {
+	o.gaugeSuffixes = make([][]byte, policy.MaxAggregationTypeID+1)
+	for aggType := range policy.ValidAggregationTypes {
+		if suffix, ok := o.gaugeSuffixOverride[aggType]; ok {
+			o.gaugeSuffixes[aggType.ID()] = suffix
+			continue
+		}
+		o.gaugeSuffixes[aggType.ID()] = o.defaultSuffixes[aggType.ID()]
+	}
+}
+
+func (o *options) computeDefaultCounterAggregationSuffix() {
+	o.defaultCounterAggregationSuffixes = make([][]byte, len(o.DefaultCounterAggregationTypes()))
+	for i, aggType := range o.DefaultCounterAggregationTypes() {
+		o.defaultCounterAggregationSuffixes[i] = o.SuffixForCounter(aggType)
 	}
 }
 
 func (o *options) computeDefaultTimerAggregationSuffix() {
 	o.defaultTimerAggregationSuffixes = make([][]byte, len(o.DefaultTimerAggregationTypes()))
 	for i, aggType := range o.DefaultTimerAggregationTypes() {
-		o.defaultTimerAggregationSuffixes[i] = o.Suffix(aggType)
+		o.defaultTimerAggregationSuffixes[i] = o.SuffixForTimer(aggType)
+	}
+}
+
+func (o *options) computeDefaultGaugeAggregationSuffix() {
+	o.defaultGaugeAggregationSuffixes = make([][]byte, len(o.DefaultGaugeAggregationTypes()))
+	for i, aggType := range o.DefaultGaugeAggregationTypes() {
+		o.defaultGaugeAggregationSuffixes[i] = o.SuffixForGauge(aggType)
 	}
 }
 

--- a/aggregator/options_benchmark_test.go
+++ b/aggregator/options_benchmark_test.go
@@ -47,7 +47,7 @@ func BenchmarkSuffixFn(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		aggTypes := opts.DefaultTimerAggregationTypes()
 		for _, aggType := range aggTypes {
-			a = opts.Suffix(aggType)
+			a = opts.SuffixForTimer(aggType)
 		}
 	}
 	b.StopTimer()

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -171,16 +171,16 @@ func TestOptionsSetTimerMeanSuffix(t *testing.T) {
 	require.Equal(t, newMeanSuffix, o.AggregationMeanSuffix())
 }
 
-func TestOptionsSetTimerLowerSuffix(t *testing.T) {
-	newLowerSuffix := []byte("testTimerLowerSuffix")
-	o := NewOptions().SetAggregationMinSuffix(newLowerSuffix)
-	require.Equal(t, newLowerSuffix, o.AggregationMinSuffix())
+func TestOptionsSetTimerMinSuffix(t *testing.T) {
+	newMinSuffix := []byte("testTimerMinSuffix")
+	o := NewOptions().SetAggregationMinSuffix(newMinSuffix)
+	require.Equal(t, newMinSuffix, o.AggregationMinSuffix())
 }
 
-func TestOptionsSetTimerUpperSuffix(t *testing.T) {
-	newUpperSuffix := []byte("testTimerUpperSuffix")
-	o := NewOptions().SetAggregationMaxSuffix(newUpperSuffix)
-	require.Equal(t, newUpperSuffix, o.AggregationMaxSuffix())
+func TestOptionsSetTimerMaxSuffix(t *testing.T) {
+	newMaxSuffix := []byte("testTimerMaxSuffix")
+	o := NewOptions().SetAggregationMaxSuffix(newMaxSuffix)
+	require.Equal(t, newMaxSuffix, o.AggregationMaxSuffix())
 }
 
 func TestOptionsSetTimerCountSuffix(t *testing.T) {

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -155,50 +155,130 @@ func TestOptionsSetTimerPrefix(t *testing.T) {
 
 func TestOptionsSetTimerSumSuffix(t *testing.T) {
 	newSumSuffix := []byte("testTimerSumSuffix")
-	o := NewOptions().SetAggregationSumSuffix(newSumSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Sum}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Sum}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Sum}).
+		SetAggregationSumSuffix(newSumSuffix)
 	require.Equal(t, newSumSuffix, o.AggregationSumSuffix())
+	require.Equal(t, []byte(nil), o.SuffixForCounter(policy.Sum))
+	require.Equal(t, newSumSuffix, o.SuffixForTimer(policy.Sum))
+	require.Equal(t, newSumSuffix, o.SuffixForGauge(policy.Sum))
+	require.Equal(t, [][]byte{[]byte(nil)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newSumSuffix)}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newSumSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerSumSqSuffix(t *testing.T) {
 	newSumSqSuffix := []byte("testTimerSumSqSuffix")
-	o := NewOptions().SetAggregationSumSqSuffix(newSumSqSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.SumSq}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.SumSq}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.SumSq}).
+		SetAggregationSumSqSuffix(newSumSqSuffix)
 	require.Equal(t, newSumSqSuffix, o.AggregationSumSqSuffix())
+	require.Equal(t, newSumSqSuffix, o.SuffixForCounter(policy.SumSq))
+	require.Equal(t, newSumSqSuffix, o.SuffixForTimer(policy.SumSq))
+	require.Equal(t, newSumSqSuffix, o.SuffixForGauge(policy.SumSq))
+	require.Equal(t, [][]byte{[]byte(newSumSqSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newSumSqSuffix)}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newSumSqSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerMeanSuffix(t *testing.T) {
 	newMeanSuffix := []byte("testTimerMeanSuffix")
-	o := NewOptions().SetAggregationMeanSuffix(newMeanSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Mean}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Mean}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Mean}).
+		SetAggregationMeanSuffix(newMeanSuffix)
 	require.Equal(t, newMeanSuffix, o.AggregationMeanSuffix())
+	require.Equal(t, newMeanSuffix, o.SuffixForCounter(policy.Mean))
+	require.Equal(t, newMeanSuffix, o.SuffixForTimer(policy.Mean))
+	require.Equal(t, newMeanSuffix, o.SuffixForGauge(policy.Mean))
+	require.Equal(t, [][]byte{[]byte(newMeanSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newMeanSuffix)}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newMeanSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerMinSuffix(t *testing.T) {
 	newMinSuffix := []byte("testTimerMinSuffix")
-	o := NewOptions().SetAggregationMinSuffix(newMinSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Min}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Min}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Min}).
+		SetAggregationMinSuffix(newMinSuffix)
 	require.Equal(t, newMinSuffix, o.AggregationMinSuffix())
+	require.Equal(t, newMinSuffix, o.SuffixForCounter(policy.Min))
+	require.Equal(t, []byte(".lower"), o.SuffixForTimer(policy.Min))
+	require.Equal(t, newMinSuffix, o.SuffixForGauge(policy.Min))
+	require.Equal(t, [][]byte{[]byte(newMinSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(".lower")}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newMinSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerMaxSuffix(t *testing.T) {
 	newMaxSuffix := []byte("testTimerMaxSuffix")
-	o := NewOptions().SetAggregationMaxSuffix(newMaxSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Max}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Max}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Max}).
+		SetAggregationMaxSuffix(newMaxSuffix)
 	require.Equal(t, newMaxSuffix, o.AggregationMaxSuffix())
+	require.Equal(t, newMaxSuffix, o.SuffixForCounter(policy.Max))
+	require.Equal(t, []byte(".upper"), o.SuffixForTimer(policy.Max))
+	require.Equal(t, newMaxSuffix, o.SuffixForGauge(policy.Max))
+	require.Equal(t, [][]byte{[]byte(newMaxSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(".upper")}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newMaxSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerCountSuffix(t *testing.T) {
 	newCountSuffix := []byte("testTimerCountSuffix")
-	o := NewOptions().SetAggregationCountSuffix(newCountSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Count}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Count}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Count}).
+		SetAggregationCountSuffix(newCountSuffix)
 	require.Equal(t, newCountSuffix, o.AggregationCountSuffix())
+	require.Equal(t, newCountSuffix, o.SuffixForCounter(policy.Count))
+	require.Equal(t, newCountSuffix, o.SuffixForTimer(policy.Count))
+	require.Equal(t, newCountSuffix, o.SuffixForGauge(policy.Count))
+	require.Equal(t, [][]byte{[]byte(newCountSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newCountSuffix)}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newCountSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerStdevSuffix(t *testing.T) {
 	newStdevSuffix := []byte("testTimerStdevSuffix")
-	o := NewOptions().SetAggregationStdevSuffix(newStdevSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Stdev}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Stdev}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Stdev}).
+		SetAggregationStdevSuffix(newStdevSuffix)
 	require.Equal(t, newStdevSuffix, o.AggregationStdevSuffix())
+	require.Equal(t, newStdevSuffix, o.SuffixForCounter(policy.Stdev))
+	require.Equal(t, newStdevSuffix, o.SuffixForTimer(policy.Stdev))
+	require.Equal(t, newStdevSuffix, o.SuffixForGauge(policy.Stdev))
+	require.Equal(t, [][]byte{[]byte(newStdevSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newStdevSuffix)}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newStdevSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerMedianSuffix(t *testing.T) {
 	newMedianSuffix := []byte("testTimerMedianSuffix")
-	o := NewOptions().SetAggregationMedianSuffix(newMedianSuffix)
+	o := NewOptions().
+		SetDefaultCounterAggregationTypes(policy.AggregationTypes{policy.Median}).
+		SetDefaultTimerAggregationTypes(policy.AggregationTypes{policy.Median}).
+		SetDefaultGaugeAggregationTypes(policy.AggregationTypes{policy.Median}).
+		SetAggregationMedianSuffix(newMedianSuffix)
 	require.Equal(t, newMedianSuffix, o.AggregationMedianSuffix())
+	require.Equal(t, newMedianSuffix, o.SuffixForCounter(policy.Median))
+	require.Equal(t, newMedianSuffix, o.SuffixForTimer(policy.Median))
+	require.Equal(t, newMedianSuffix, o.SuffixForGauge(policy.Median))
+	require.Equal(t, [][]byte{[]byte(newMedianSuffix)}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newMedianSuffix)}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(newMedianSuffix)}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerQuantileSuffixFn(t *testing.T) {

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -129,6 +129,24 @@ type Handler interface {
 type Options interface {
 	/// Read-write base options
 
+	// SetDefaultCounterAggregationTypes sets the counter aggregation types.
+	SetDefaultCounterAggregationTypes(aggTypes policy.AggregationTypes) Options
+
+	// DefaultCounterAggregationTypes returns the aggregation types for counters.
+	DefaultCounterAggregationTypes() policy.AggregationTypes
+
+	// SetDefaultTimerAggregationTypes sets the timer aggregation types.
+	SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options
+
+	// DefaultTimerAggregationTypes returns the aggregation types for timers.
+	DefaultTimerAggregationTypes() policy.AggregationTypes
+
+	// SetDefaultGaugeAggregationTypes sets the gauge aggregation types.
+	SetDefaultGaugeAggregationTypes(aggTypes policy.AggregationTypes) Options
+
+	// DefaultGaugeAggregationTypes returns the aggregation types for gauges.
+	DefaultGaugeAggregationTypes() policy.AggregationTypes
+
 	// SetMetricPrefix sets the common prefix for all metric types
 	SetMetricPrefix(value []byte) Options
 
@@ -147,23 +165,29 @@ type Options interface {
 	// TimerPrefix returns the prefix for timers
 	TimerPrefix() []byte
 
+	// SetGaugePrefix sets the prefix for gauges
+	SetGaugePrefix(value []byte) Options
+
+	// GaugePrefix returns the prefix for gauges
+	GaugePrefix() []byte
+
 	// SetAggregationLastSuffix sets the suffix for aggregation type last.
 	SetAggregationLastSuffix(value []byte) Options
 
 	// AggregationLastSuffix returns the suffix for aggregation type last.
 	AggregationLastSuffix() []byte
 
-	// SetAggregationLowerSuffix sets the suffix for aggregation type lower.
-	SetAggregationLowerSuffix(value []byte) Options
+	// SetAggregationMinSuffix sets the suffix for aggregation type min.
+	SetAggregationMinSuffix(value []byte) Options
 
-	// AggregationLowerSuffix returns the suffix for aggregation type lower.
-	AggregationLowerSuffix() []byte
+	// AggregationMinSuffix returns the suffix for aggregation type min.
+	AggregationMinSuffix() []byte
 
-	// SetAggregationUpperSuffix sets the suffix for aggregation type upper.
-	SetAggregationUpperSuffix(value []byte) Options
+	// SetAggregationMaxSuffix sets the suffix for aggregation type max.
+	SetAggregationMaxSuffix(value []byte) Options
 
-	// AggregationUpperSuffix returns the suffix for aggregation type upper.
-	AggregationUpperSuffix() []byte
+	// AggregationMaxSuffix returns the suffix for aggregation type max.
+	AggregationMaxSuffix() []byte
 
 	// SetAggregationMeanSuffix sets the suffix for aggregation type mean.
 	SetAggregationMeanSuffix(value []byte) Options
@@ -201,23 +225,11 @@ type Options interface {
 	// AggregationStdevSuffix returns the suffix for aggregation type standard deviation.
 	AggregationStdevSuffix() []byte
 
-	// SetDefaultTimerAggregationTypes sets the timer aggregation types.
-	SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options
-
-	// DefaultTimerAggregationTypes returns the aggregation types for timers.
-	DefaultTimerAggregationTypes() policy.AggregationTypes
-
 	// SetTimerQuantileSuffixFn sets the quantile suffix function for timers.
 	SetTimerQuantileSuffixFn(value QuantileSuffixFn) Options
 
 	// TimerQuantileSuffixFn returns the quantile suffix function for timers.
 	TimerQuantileSuffixFn() QuantileSuffixFn
-
-	// SetGaugePrefix sets the prefix for gauges
-	SetGaugePrefix(value []byte) Options
-
-	// GaugePrefix returns the prefix for gauges
-	GaugePrefix() []byte
 
 	// SetTimeLock sets the time lock
 	SetTimeLock(value *sync.RWMutex) Options
@@ -357,7 +369,18 @@ type Options interface {
 	// QuantilesPool returns the timer quantiles pool.
 	QuantilesPool() pool.FloatsPool
 
-	/// Read-only derived options
+	/// Write-only options.
+
+	// SetCounterSuffixOverride sets the overrides for counter suffixes.
+	SetCounterSuffixOverride(m map[policy.AggregationType][]byte) Options
+
+	// SetTimerSuffixOverride sets the overrides for timer suffixes.
+	SetTimerSuffixOverride(m map[policy.AggregationType][]byte) Options
+
+	// SetGaugeSuffixOverride sets the overrides for gauge suffixes.
+	SetGaugeSuffixOverride(m map[policy.AggregationType][]byte) Options
+
+	/// Read-only derived options.
 
 	// FullCounterPrefix returns the full prefix for counters
 	FullCounterPrefix() []byte
@@ -371,10 +394,24 @@ type Options interface {
 	// TimerQuantiles returns the quantiles for timers.
 	TimerQuantiles() []float64
 
+	// DefaultCounterAggregationSuffixes returns the suffix for
+	// default counter aggregation types.
+	DefaultCounterAggregationSuffixes() [][]byte
+
 	// DefaultTimerAggregationSuffixes returns the suffix for
 	// default timer aggregation types.
 	DefaultTimerAggregationSuffixes() [][]byte
 
-	// Suffix returns the suffix for the aggregation type
-	Suffix(aggType policy.AggregationType) []byte
+	// DefaultGaugeAggregationSuffixes returns the suffix for
+	// default gauge aggregation types.
+	DefaultGaugeAggregationSuffixes() [][]byte
+
+	// Suffix returns the suffix for the aggregation type for counters.
+	SuffixForCounter(aggType policy.AggregationType) []byte
+
+	// Suffix returns the suffix for the aggregation type for timers.
+	SuffixForTimer(aggType policy.AggregationType) []byte
+
+	// Suffix returns the suffix for the aggregation type for gauges.
+	SuffixForGauge(aggType policy.AggregationType) []byte
 }

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -130,19 +130,19 @@ type Options interface {
 	/// Read-write base options
 
 	// SetDefaultCounterAggregationTypes sets the counter aggregation types.
-	SetDefaultCounterAggregationTypes(aggTypes policy.AggregationTypes) Options
+	SetDefaultCounterAggregationTypes(value policy.AggregationTypes) Options
 
 	// DefaultCounterAggregationTypes returns the aggregation types for counters.
 	DefaultCounterAggregationTypes() policy.AggregationTypes
 
 	// SetDefaultTimerAggregationTypes sets the timer aggregation types.
-	SetDefaultTimerAggregationTypes(aggTypes policy.AggregationTypes) Options
+	SetDefaultTimerAggregationTypes(value policy.AggregationTypes) Options
 
 	// DefaultTimerAggregationTypes returns the aggregation types for timers.
 	DefaultTimerAggregationTypes() policy.AggregationTypes
 
 	// SetDefaultGaugeAggregationTypes sets the gauge aggregation types.
-	SetDefaultGaugeAggregationTypes(aggTypes policy.AggregationTypes) Options
+	SetDefaultGaugeAggregationTypes(value policy.AggregationTypes) Options
 
 	// DefaultGaugeAggregationTypes returns the aggregation types for gauges.
 	DefaultGaugeAggregationTypes() policy.AggregationTypes
@@ -407,11 +407,11 @@ type Options interface {
 	DefaultGaugeAggregationSuffixes() [][]byte
 
 	// Suffix returns the suffix for the aggregation type for counters.
-	SuffixForCounter(aggType policy.AggregationType) []byte
+	SuffixForCounter(value policy.AggregationType) []byte
 
 	// Suffix returns the suffix for the aggregation type for timers.
-	SuffixForTimer(aggType policy.AggregationType) []byte
+	SuffixForTimer(value policy.AggregationType) []byte
 
 	// Suffix returns the suffix for the aggregation type for gauges.
-	SuffixForGauge(aggType policy.AggregationType) []byte
+	SuffixForGauge(value policy.AggregationType) []byte
 }

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -61,18 +61,29 @@ http:
   writeTimeout: 45s
 
 aggregator:
+  counterAggregationTypes: 
+  - Sum
   timerAggregationTypes: 
   - Sum
   - SumSq
   - Mean
-  - Lower
-  - Upper
+  - Min
+  - Max
   - Count
   - Stdev
   - Median
   - P50
   - P95
   - P99
+  gaugeAggregationTypes: 
+  - Last
+  counterSuffixOverride:
+    Sum: ""
+  timerSuffixOverride:
+    Min: ".lower"
+    Max: ".upper"
+  gaugeSuffixOverride:
+    Last: ""
   stream:
     eps: 0.001
     capacity: 32

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -62,21 +62,21 @@ http:
 
 aggregator:
   counterAggregationTypes: 
-  - Sum
+    - Sum
   timerAggregationTypes: 
-  - Sum
-  - SumSq
-  - Mean
-  - Min
-  - Max
-  - Count
-  - Stdev
-  - Median
-  - P50
-  - P95
-  - P99
+    - Sum
+    - SumSq
+    - Mean
+    - Min
+    - Max
+    - Count
+    - Stdev
+    - Median
+    - P50
+    - P95
+    - P99
   gaugeAggregationTypes: 
-  - Last
+    - Last
   counterSuffixOverride:
     Sum: ""
   timerSuffixOverride:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cd03e759ef90d4714b8501ef440122baab21f8785c7b6d4f268ace9c9933526e
-updated: 2017-06-17T14:01:29.488513656-04:00
+hash: d6a3000359f9e9392786be732758ef986c48ad1538d139b21960a994823317ff
+updated: 2017-06-20T17:16:26.293154859-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: aa9e9f07a3e0cae96497e06f8041e89ecd2cb560
+  version: 63f437f75e076ac85705b42290b8fbb0d2172a13
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bda96988b0fe7e4a268da8920983d802d8e78c8d83a73aeafabcc078af3ef24a
-updated: 2017-06-16T13:10:22.903973262-04:00
+hash: cd03e759ef90d4714b8501ef440122baab21f8785c7b6d4f268ace9c9933526e
+updated: 2017-06-17T14:01:29.488513656-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -68,7 +68,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3metrics
-  version: 10535fa7fd083cc14c633b6b6a2b43fdc3e78e7c
+  version: aa9e9f07a3e0cae96497e06f8041e89ecd2cb560
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: 4b5c64d5fdcde721bf249a531359aeb3b9162806
 - package: github.com/m3db/m3metrics
-  version: 10535fa7fd083cc14c633b6b6a2b43fdc3e78e7c
+  version: aa9e9f07a3e0cae96497e06f8041e89ecd2cb560
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: 4b5c64d5fdcde721bf249a531359aeb3b9162806
 - package: github.com/m3db/m3metrics
-  version: aa9e9f07a3e0cae96497e06f8041e89ecd2cb560
+  version: 63f437f75e076ac85705b42290b8fbb0d2172a13
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/integration/custom_aggregation_test.go
+++ b/integration/custom_aggregation_test.go
@@ -34,15 +34,15 @@ import (
 
 var (
 	compressor                             = policy.NewAggregationIDCompressor()
-	compressedLower, _                     = compressor.Compress(policy.AggregationTypes{policy.Lower})
-	compressedLowerAndUpper, _             = compressor.Compress(policy.AggregationTypes{policy.Lower, policy.Upper})
+	compressedMin, _                       = compressor.Compress(policy.AggregationTypes{policy.Min})
+	compressedMinAndMax, _                 = compressor.Compress(policy.AggregationTypes{policy.Min, policy.Max})
 	testPoliciesListWithCustomAggregation1 = policy.PoliciesList{
 		policy.NewStagedPolicies(
 			0,
 			false,
 			[]policy.Policy{
-				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), compressedLower),
-				policy.NewPolicy(policy.NewStoragePolicy(2*time.Second, xtime.Second, 6*time.Hour), compressedLower),
+				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), compressedMin),
+				policy.NewPolicy(policy.NewStoragePolicy(2*time.Second, xtime.Second, 6*time.Hour), compressedMin),
 			},
 		),
 	}
@@ -52,8 +52,8 @@ var (
 			0,
 			false,
 			[]policy.Policy{
-				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), compressedLowerAndUpper),
-				policy.NewPolicy(policy.NewStoragePolicy(3*time.Second, xtime.Second, 24*time.Hour), compressedLowerAndUpper),
+				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), compressedMinAndMax),
+				policy.NewPolicy(policy.NewStoragePolicy(3*time.Second, xtime.Second, 24*time.Hour), compressedMinAndMax),
 			},
 		),
 	}

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -186,9 +186,9 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	scope := instrumentOpts.MetricsScope()
 	opts := aggregator.NewOptions().SetInstrumentOptions(instrumentOpts)
 
-	opts = opts.SetDefaultCounterAggregationTypes(c.CounterAggregationTypes)
-	opts = opts.SetDefaultTimerAggregationTypes(c.TimerAggregationTypes)
-	opts = opts.SetDefaultGaugeAggregationTypes(c.GaugeAggregationTypes)
+	opts = opts.SetDefaultCounterAggregationTypes(c.CounterAggregationTypes).
+		SetDefaultTimerAggregationTypes(c.TimerAggregationTypes).
+		SetDefaultGaugeAggregationTypes(c.GaugeAggregationTypes)
 
 	// Set the prefix and suffix for metrics aggregations.
 	opts = setMetricPrefixOrSuffix(opts, c.MetricPrefix, opts.SetMetricPrefix)
@@ -212,9 +212,9 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	}
 	opts = opts.SetTimerQuantileSuffixFn(quantileSuffixFn)
 
-	opts = opts.SetCounterSuffixOverride(c.parseSuffixOverride(c.CounterSuffixOverride))
-	opts = opts.SetTimerSuffixOverride(c.parseSuffixOverride(c.TimerSuffixOverride))
-	opts = opts.SetGaugeSuffixOverride(c.parseSuffixOverride(c.GaugeSuffixOverride))
+	opts = opts.SetCounterSuffixOverride(c.parseSuffixOverride(c.CounterSuffixOverride)).
+		SetTimerSuffixOverride(c.parseSuffixOverride(c.TimerSuffixOverride)).
+		SetGaugeSuffixOverride(c.parseSuffixOverride(c.GaugeSuffixOverride))
 
 	// Set stream options.
 	iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("stream"))

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -57,6 +57,15 @@ var (
 
 // AggregatorConfiguration contains aggregator configuration.
 type AggregatorConfiguration struct {
+	// Default aggregation types for counter metrics.
+	CounterAggregationTypes []policy.AggregationType `yaml:"counterAggregationTypes" validate:"nonzero"`
+
+	// Default aggregation types for timer metrics.
+	TimerAggregationTypes []policy.AggregationType `yaml:"timerAggregationTypes" validate:"nonzero"`
+
+	// Default aggregation types for gauge metrics.
+	GaugeAggregationTypes []policy.AggregationType `yaml:"gaugeAggregationTypes" validate:"nonzero"`
+
 	// Common metric prefix.
 	MetricPrefix string `yaml:"metricPrefix"`
 
@@ -65,6 +74,9 @@ type AggregatorConfiguration struct {
 
 	// Timer metric prefix.
 	TimerPrefix string `yaml:"timerPrefix"`
+
+	// Gauge metric suffix.
+	GaugePrefix string `yaml:"gaugePrefix"`
 
 	// Metric suffix for aggregation type last.
 	AggregationLastSuffix string `yaml:"aggregationLastSuffix"`
@@ -78,11 +90,11 @@ type AggregatorConfiguration struct {
 	// Metric suffix for aggregation type mean.
 	AggregationMeanSuffix string `yaml:"aggregationMeanSuffix"`
 
-	// Metric suffix for aggregation type lower.
-	AggregationLowerSuffix string `yaml:"aggregationLowerSuffix"`
+	// Metric suffix for aggregation type min.
+	AggregationMinSuffix string `yaml:"aggregationLowerSuffix"`
 
-	// Metric suffix for aggregation type upper.
-	AggregationUpperSuffix string `yaml:"aggregationUpperSuffix"`
+	// Metric suffix for aggregation type max.
+	AggregationMaxSuffix string `yaml:"aggregationUpperSuffix"`
 
 	// Metric suffix for aggregation type count.
 	AggregationCountSuffix string `yaml:"aggregationCountSuffix"`
@@ -93,14 +105,17 @@ type AggregatorConfiguration struct {
 	// Metric suffix for aggregation type median.
 	AggregationMedianSuffix string `yaml:"aggregationMedianSuffix"`
 
-	// Default aggregation types for timer metrics.
-	TimerAggregationTypes []policy.AggregationType `yaml:"timerAggregationTypes" validate:"nonzero"`
-
 	// Timer quantile suffix function type.
 	TimerQuantileSuffixFnType string `yaml:"timerQuantileSuffixFnType"`
 
-	// Gauge metric suffix.
-	GaugePrefix string `yaml:"gaugePrefix"`
+	// Counter suffix override.
+	CounterSuffixOverride map[policy.AggregationType]string `yaml:"counterSuffixOverride"`
+
+	// Timer suffix override.
+	TimerSuffixOverride map[policy.AggregationType]string `yaml:"timerSuffixOverride"`
+
+	// Gauge suffix override.
+	GaugeSuffixOverride map[policy.AggregationType]string `yaml:"gaugeSuffixOverride"`
 
 	// Stream configuration for computing quantiles.
 	Stream streamConfiguration `yaml:"stream"`
@@ -171,6 +186,10 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	scope := instrumentOpts.MetricsScope()
 	opts := aggregator.NewOptions().SetInstrumentOptions(instrumentOpts)
 
+	opts = opts.SetDefaultCounterAggregationTypes(c.CounterAggregationTypes)
+	opts = opts.SetDefaultTimerAggregationTypes(c.TimerAggregationTypes)
+	opts = opts.SetDefaultGaugeAggregationTypes(c.GaugeAggregationTypes)
+
 	// Set the prefix and suffix for metrics aggregations.
 	opts = setMetricPrefixOrSuffix(opts, c.MetricPrefix, opts.SetMetricPrefix)
 	opts = setMetricPrefixOrSuffix(opts, c.CounterPrefix, opts.SetCounterPrefix)
@@ -179,20 +198,23 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	opts = setMetricPrefixOrSuffix(opts, c.AggregationSumSuffix, opts.SetAggregationSumSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.AggregationSumSqSuffix, opts.SetAggregationSumSqSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.AggregationMeanSuffix, opts.SetAggregationMeanSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.AggregationLowerSuffix, opts.SetAggregationLowerSuffix)
-	opts = setMetricPrefixOrSuffix(opts, c.AggregationUpperSuffix, opts.SetAggregationUpperSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationMinSuffix, opts.SetAggregationMinSuffix)
+	opts = setMetricPrefixOrSuffix(opts, c.AggregationMaxSuffix, opts.SetAggregationMaxSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.AggregationCountSuffix, opts.SetAggregationCountSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.AggregationStdevSuffix, opts.SetAggregationStdevSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.AggregationMedianSuffix, opts.SetAggregationMedianSuffix)
 	opts = setMetricPrefixOrSuffix(opts, c.GaugePrefix, opts.SetGaugePrefix)
 
 	// Set timer quantiles and quantile suffix function.
-	opts = opts.SetDefaultTimerAggregationTypes(c.TimerAggregationTypes)
 	quantileSuffixFn, err := c.parseTimerQuantileSuffixFn(opts)
 	if err != nil {
 		return nil, err
 	}
 	opts = opts.SetTimerQuantileSuffixFn(quantileSuffixFn)
+
+	opts = opts.SetCounterSuffixOverride(c.parseSuffixOverride(c.CounterSuffixOverride))
+	opts = opts.SetTimerSuffixOverride(c.parseSuffixOverride(c.TimerSuffixOverride))
+	opts = opts.SetGaugeSuffixOverride(c.parseSuffixOverride(c.GaugeSuffixOverride))
 
 	// Set stream options.
 	iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("stream"))
@@ -339,6 +361,20 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	quantilesPool.Init()
 
 	return opts, nil
+}
+
+// parseSuffixOverride parses the suffix override map.
+func (c *AggregatorConfiguration) parseSuffixOverride(m map[policy.AggregationType]string) map[policy.AggregationType][]byte {
+	res := make(map[policy.AggregationType][]byte, len(m))
+	for aggType, s := range m {
+		var bytes []byte
+		if s != "" {
+			// NB(cw) []byte("") is empty with a cap of 8.
+			bytes = []byte(s)
+		}
+		res[aggType] = bytes
+	}
+	return res
 }
 
 // parseTimerQuantileSuffixFn parses the quantile suffix function type.

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -91,10 +91,10 @@ type AggregatorConfiguration struct {
 	AggregationMeanSuffix string `yaml:"aggregationMeanSuffix"`
 
 	// Metric suffix for aggregation type min.
-	AggregationMinSuffix string `yaml:"aggregationLowerSuffix"`
+	AggregationMinSuffix string `yaml:"aggregationMinSuffix"`
 
 	// Metric suffix for aggregation type max.
-	AggregationMaxSuffix string `yaml:"aggregationUpperSuffix"`
+	AggregationMaxSuffix string `yaml:"aggregationMaxSuffix"`
 
 	// Metric suffix for aggregation type count.
 	AggregationCountSuffix string `yaml:"aggregationCountSuffix"`


### PR DESCRIPTION
Reordered functions in aggregator.Options.
Allow suffix override through config per metrics type per aggregation type.

@xichen2020 