### PR TITLE
Pull in latest m3metrics to enable tcp keepalives

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d6a3000359f9e9392786be732758ef986c48ad1538d139b21960a994823317ff
-updated: 2017-06-20T17:16:26.293154859-04:00
+hash: 49a8c8dd8f37f2c9d591e05ac5d1244ec5d7a8959078198eb1a19e0f936bf1fb
+updated: 2017-06-27T09:16:17.234919943-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -77,7 +77,7 @@ imports:
   - policy
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: 9e66dd6d48a872bae1bdddb9bf85a33e99129267
+  version: ddf3e948339b3a6ba5afc81dae26ba091d31b71c
   subpackages:
   - checked
   - clock

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x
-  version: 9e66dd6d48a872bae1bdddb9bf85a33e99129267
+  version: ddf3e948339b3a6ba5afc81dae26ba091d31b71c
 - package: github.com/uber-go/tally
   version: 3.0.0
 - package: github.com/golang/protobuf


### PR DESCRIPTION
cc @cw9 

This PR pulls in latest m3metrics to enable TCP keepalives for the agg server.