### PR TITLE
Provide keepAlive options for the aggregation server

### DIFF
--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -28,6 +28,8 @@ metrics:
 
 msgpack:
   listenAddress: 0.0.0.0:6000
+  keepAliveEnabled: true
+  keepAlivePeriod: 1m
   retry:
     initialBackoff: 5ms
     backoffFactor: 2.0
@@ -61,9 +63,9 @@ http:
   writeTimeout: 45s
 
 aggregator:
-  counterAggregationTypes: 
+  counterAggregationTypes:
     - Sum
-  timerAggregationTypes: 
+  timerAggregationTypes:
     - Sum
     - SumSq
     - Mean
@@ -75,7 +77,7 @@ aggregator:
     - P50
     - P95
     - P99
-  gaugeAggregationTypes: 
+  gaugeAggregationTypes:
     - Last
   counterSuffixOverride:
     Sum: ""

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 54b6c1be92030fd175c21b5fc4b09ce22acf8ff9369a66e84a9e1c8944007d37
-updated: 2017-06-27T10:18:04.766646707-04:00
+hash: 171baa487bff804651d7188376d143ee41fe2b43ff59cfaf092e4b11f15a88ab
+updated: 2017-06-27T11:14:08.024047537-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -77,7 +77,7 @@ imports:
   - policy
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: ee68369621a724c586ad4887eedd9729f0463613
+  version: f3fdee26896eff88aea63d585eceb6ac417f4530
   subpackages:
   - checked
   - clock

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 49a8c8dd8f37f2c9d591e05ac5d1244ec5d7a8959078198eb1a19e0f936bf1fb
-updated: 2017-06-27T09:16:17.234919943-04:00
+hash: 54b6c1be92030fd175c21b5fc4b09ce22acf8ff9369a66e84a9e1c8944007d37
+updated: 2017-06-27T10:18:04.766646707-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -77,7 +77,7 @@ imports:
   - policy
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: ddf3e948339b3a6ba5afc81dae26ba091d31b71c
+  version: ee68369621a724c586ad4887eedd9729f0463613
   subpackages:
   - checked
   - clock

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x
-  version: ee68369621a724c586ad4887eedd9729f0463613
+  version: f3fdee26896eff88aea63d585eceb6ac417f4530
 - package: github.com/uber-go/tally
   version: 3.0.0
 - package: github.com/golang/protobuf

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x
-  version: ddf3e948339b3a6ba5afc81dae26ba091d31b71c
+  version: ee68369621a724c586ad4887eedd9729f0463613
 - package: github.com/uber-go/tally
   version: 3.0.0
 - package: github.com/golang/protobuf

--- a/server/msgpack/options.go
+++ b/server/msgpack/options.go
@@ -21,11 +21,9 @@
 package msgpack
 
 import (
-	"time"
-
 	"github.com/m3db/m3metrics/protocol/msgpack"
 	"github.com/m3db/m3x/instrument"
-	"github.com/m3db/m3x/retry"
+	"github.com/m3db/m3x/server"
 )
 
 const (
@@ -41,23 +39,11 @@ type Options interface {
 	// InstrumentOptions returns the instrument options
 	InstrumentOptions() instrument.Options
 
-	// SetKeepAliveEnabled sets the keep alive state for tcp connections.
-	SetKeepAliveEnabled(value bool) Options
+	// SetServerOptions sets the server options.
+	SetServerOptions(value xserver.Options) Options
 
-	// KeepAliveEnabled returns the keep alive state for tcp connections.
-	KeepAliveEnabled() bool
-
-	// SetKeepAlivePeriod sets the keep alive period for tcp connections.
-	SetKeepAlivePeriod(value time.Duration) Options
-
-	// KeepAlivePeriod returns the keep alive period for tcp connections.
-	KeepAlivePeriod() time.Duration
-
-	// SetRetryOptions sets the retry options for accepting connections
-	SetRetryOptions(value xretry.Options) Options
-
-	// RetryOptions returns the retry options for accepting connections
-	RetryOptions() xretry.Options
+	// ServerOptiosn returns the server options.
+	ServerOptions() xserver.Options
 
 	// SetIteratorPool sets the iterator pool
 	SetIteratorPool(value msgpack.UnaggregatedIteratorPool) Options
@@ -67,11 +53,9 @@ type Options interface {
 }
 
 type options struct {
-	instrumentOpts   instrument.Options
-	keepAliveEnabled bool
-	keepAlivePeriod  time.Duration
-	retryOpts        xretry.Options
-	iteratorPool     msgpack.UnaggregatedIteratorPool
+	instrumentOpts instrument.Options
+	serverOpts     xserver.Options
+	iteratorPool   msgpack.UnaggregatedIteratorPool
 }
 
 // NewOptions creates a new set of server options
@@ -83,11 +67,9 @@ func NewOptions() Options {
 	})
 
 	return &options{
-		instrumentOpts:   instrument.NewOptions(),
-		keepAliveEnabled: defaultKeepAliveEnabled,
-		keepAlivePeriod:  defaultKeepAlivePeriod,
-		retryOpts:        xretry.NewOptions(),
-		iteratorPool:     iteratorPool,
+		instrumentOpts: instrument.NewOptions(),
+		serverOpts:     xserver.NewOptions(),
+		iteratorPool:   iteratorPool,
 	}
 }
 
@@ -101,34 +83,14 @@ func (o *options) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
 }
 
-func (o *options) SetKeepAliveEnabled(value bool) Options {
+func (o *options) SetServerOptions(value xserver.Options) Options {
 	opts := *o
-	opts.keepAliveEnabled = value
+	opts.serverOpts = value
 	return &opts
 }
 
-func (o *options) KeepAliveEnabled() bool {
-	return o.keepAliveEnabled
-}
-
-func (o *options) SetKeepAlivePeriod(value time.Duration) Options {
-	opts := *o
-	opts.keepAlivePeriod = value
-	return &opts
-}
-
-func (o *options) KeepAlivePeriod() time.Duration {
-	return o.keepAlivePeriod
-}
-
-func (o *options) SetRetryOptions(value xretry.Options) Options {
-	opts := *o
-	opts.retryOpts = value
-	return &opts
-}
-
-func (o *options) RetryOptions() xretry.Options {
-	return o.retryOpts
+func (o *options) ServerOptions() xserver.Options {
+	return o.serverOpts
 }
 
 func (o *options) SetIteratorPool(value msgpack.UnaggregatedIteratorPool) Options {

--- a/server/msgpack/options.go
+++ b/server/msgpack/options.go
@@ -21,9 +21,16 @@
 package msgpack
 
 import (
+	"time"
+
 	"github.com/m3db/m3metrics/protocol/msgpack"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/retry"
+)
+
+const (
+	defaultKeepAliveEnabled = true
+	defaultKeepAlivePeriod  = 0
 )
 
 // Options provide a set of server options
@@ -33,6 +40,18 @@ type Options interface {
 
 	// InstrumentOptions returns the instrument options
 	InstrumentOptions() instrument.Options
+
+	// SetKeepAliveEnabled sets the keep alive state for tcp connections.
+	SetKeepAliveEnabled(value bool) Options
+
+	// KeepAliveEnabled returns the keep alive state for tcp connections.
+	KeepAliveEnabled() bool
+
+	// SetKeepAlivePeriod sets the keep alive period for tcp connections.
+	SetKeepAlivePeriod(value time.Duration) Options
+
+	// KeepAlivePeriod returns the keep alive period for tcp connections.
+	KeepAlivePeriod() time.Duration
 
 	// SetRetryOptions sets the retry options for accepting connections
 	SetRetryOptions(value xretry.Options) Options
@@ -48,9 +67,11 @@ type Options interface {
 }
 
 type options struct {
-	instrumentOpts instrument.Options
-	retryOpts      xretry.Options
-	iteratorPool   msgpack.UnaggregatedIteratorPool
+	instrumentOpts   instrument.Options
+	keepAliveEnabled bool
+	keepAlivePeriod  time.Duration
+	retryOpts        xretry.Options
+	iteratorPool     msgpack.UnaggregatedIteratorPool
 }
 
 // NewOptions creates a new set of server options
@@ -62,9 +83,11 @@ func NewOptions() Options {
 	})
 
 	return &options{
-		instrumentOpts: instrument.NewOptions(),
-		retryOpts:      xretry.NewOptions(),
-		iteratorPool:   iteratorPool,
+		instrumentOpts:   instrument.NewOptions(),
+		keepAliveEnabled: defaultKeepAliveEnabled,
+		keepAlivePeriod:  defaultKeepAlivePeriod,
+		retryOpts:        xretry.NewOptions(),
+		iteratorPool:     iteratorPool,
 	}
 }
 
@@ -76,6 +99,26 @@ func (o *options) SetInstrumentOptions(value instrument.Options) Options {
 
 func (o *options) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
+}
+
+func (o *options) SetKeepAliveEnabled(value bool) Options {
+	opts := *o
+	opts.keepAliveEnabled = value
+	return &opts
+}
+
+func (o *options) KeepAliveEnabled() bool {
+	return o.keepAliveEnabled
+}
+
+func (o *options) SetKeepAlivePeriod(value time.Duration) Options {
+	opts := *o
+	opts.keepAlivePeriod = value
+	return &opts
+}
+
+func (o *options) KeepAlivePeriod() time.Duration {
+	return o.keepAlivePeriod
 }
 
 func (o *options) SetRetryOptions(value xretry.Options) Options {

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -40,19 +40,9 @@ const (
 // NewServer creates a new msgpack server.
 func NewServer(address string, aggregator aggregator.Aggregator, opts Options) xserver.Server {
 	iOpts := opts.InstrumentOptions()
-	scope := iOpts.MetricsScope()
-
-	handlerInstrumentOpts := iOpts.SetMetricsScope(scope.Tagged(map[string]string{"handler": "msgpack"}))
-	handler := NewHandler(aggregator, opts.SetInstrumentOptions(handlerInstrumentOpts))
-
-	serverInstrumentOpts := iOpts.SetMetricsScope(scope.Tagged(map[string]string{"server": "msgpack"}))
-	serverOpts := xserver.NewOptions().
-		SetInstrumentOptions(serverInstrumentOpts).
-		SetTCPConnectionKeepAlive(opts.KeepAliveEnabled()).
-		SetTCPConnectionKeepAlivePeriod(opts.KeepAlivePeriod()).
-		SetRetryOptions(opts.RetryOptions())
-
-	return xserver.NewServer(address, handler, serverOpts)
+	handlerScope := iOpts.MetricsScope().Tagged(map[string]string{"handler": "msgpack"})
+	handler := NewHandler(aggregator, opts.SetInstrumentOptions(iOpts.SetMetricsScope(handlerScope)))
+	return xserver.NewServer(address, handler, opts.ServerOptions())
 }
 
 type handlerMetrics struct {

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -46,7 +46,11 @@ func NewServer(address string, aggregator aggregator.Aggregator, opts Options) x
 	handler := NewHandler(aggregator, opts.SetInstrumentOptions(handlerInstrumentOpts))
 
 	serverInstrumentOpts := iOpts.SetMetricsScope(scope.Tagged(map[string]string{"server": "msgpack"}))
-	serverOpts := xserver.NewOptions().SetInstrumentOptions(serverInstrumentOpts).SetRetryOptions(opts.RetryOptions())
+	serverOpts := xserver.NewOptions().
+		SetInstrumentOptions(serverInstrumentOpts).
+		SetTCPConnectionKeepAlive(opts.KeepAliveEnabled()).
+		SetTCPConnectionKeepAlivePeriod(opts.KeepAlivePeriod()).
+		SetRetryOptions(opts.RetryOptions())
 
 	return xserver.NewServer(address, handler, serverOpts)
 }

--- a/server/msgpack/server_test.go
+++ b/server/msgpack/server_test.go
@@ -93,7 +93,7 @@ func testServerOptions() Options {
 	opts := NewOptions()
 	return opts.
 		SetIteratorPool(iteratorPool).
-		SetRetryOptions(xretry.NewOptions().SetMaxRetries(2)).
+		SetServerOptions(xserver.NewOptions().SetRetryOptions(xretry.NewOptions().SetMaxRetries(2))).
 		SetInstrumentOptions(opts.InstrumentOptions().SetReportInterval(time.Second))
 }
 

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -36,6 +36,12 @@ type MsgpackServerConfiguration struct {
 	// Msgpack server listening address.
 	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
 
+	// Whether keep alives are enabled on connections.
+	KeepAliveEnabled *bool `yaml:"keepAliveEnabled"`
+
+	// KeepAlive period.
+	KeepAlivePeriod time.Duration `yaml:"keepAlivePeriod"`
+
 	// Retry mechanism configuration.
 	Retry xretry.Configuration `yaml:"retry"`
 
@@ -52,6 +58,14 @@ func (c *MsgpackServerConfiguration) NewMsgpackServerOptions(
 	// Set retry options.
 	retryOpts := c.Retry.NewOptions(instrumentOpts.MetricsScope())
 	opts = opts.SetRetryOptions(retryOpts)
+
+	// Set keep alive options.
+	if c.KeepAliveEnabled != nil {
+		opts = opts.SetKeepAliveEnabled(*c.KeepAliveEnabled)
+	}
+	if c.KeepAlivePeriod != 0 {
+		opts = opts.SetKeepAlivePeriod(c.KeepAlivePeriod)
+	}
 
 	// Set unaggregated iterator pool.
 	iteratorPool := c.Iterator.NewUnaggregatedIteratorPool(instrumentOpts)

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -55,17 +55,17 @@ func (c *MsgpackServerConfiguration) NewMsgpackServerOptions(
 ) msgpack.Options {
 	opts := msgpack.NewOptions().SetInstrumentOptions(instrumentOpts)
 
-	// Set retry options.
-	retryOpts := c.Retry.NewOptions(instrumentOpts.MetricsScope())
-	opts = opts.SetRetryOptions(retryOpts)
-
-	// Set keep alive options.
+	// Set server options.
+	serverOpts := xserver.NewOptions().
+		SetInstrumentOptions(instrumentOpts).
+		SetRetryOptions(c.Retry.NewOptions(instrumentOpts.MetricsScope()))
 	if c.KeepAliveEnabled != nil {
-		opts = opts.SetKeepAliveEnabled(*c.KeepAliveEnabled)
+		serverOpts = serverOpts.SetKeepAliveEnabled(*c.KeepAliveEnabled)
 	}
 	if c.KeepAlivePeriod != 0 {
-		opts = opts.SetKeepAlivePeriod(c.KeepAlivePeriod)
+		serverOpts = serverOpts.SetKeepAlivePeriod(c.KeepAlivePeriod)
 	}
+	opts = opts.SetServerOptions(serverOpts)
 
 	// Set unaggregated iterator pool.
 	iteratorPool := c.Iterator.NewUnaggregatedIteratorPool(instrumentOpts)

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/retry"
+	"github.com/m3db/m3x/server"
 )
 
 // MsgpackServerConfiguration contains msgpack server configuration.
@@ -60,10 +61,10 @@ func (c *MsgpackServerConfiguration) NewMsgpackServerOptions(
 		SetInstrumentOptions(instrumentOpts).
 		SetRetryOptions(c.Retry.NewOptions(instrumentOpts.MetricsScope()))
 	if c.KeepAliveEnabled != nil {
-		serverOpts = serverOpts.SetKeepAliveEnabled(*c.KeepAliveEnabled)
+		serverOpts = serverOpts.SetTCPConnectionKeepAlive(*c.KeepAliveEnabled)
 	}
 	if c.KeepAlivePeriod != 0 {
-		serverOpts = serverOpts.SetKeepAlivePeriod(c.KeepAlivePeriod)
+		serverOpts = serverOpts.SetTCPConnectionKeepAlivePeriod(c.KeepAlivePeriod)
 	}
 	opts = opts.SetServerOptions(serverOpts)
 

--- a/services/m3aggregator/main/main.go
+++ b/services/m3aggregator/main/main.go
@@ -76,12 +76,14 @@ func main() {
 
 	// Create the msgpack server options.
 	msgpackAddr := cfg.Msgpack.ListenAddress
-	iOpts := instrumentOpts.SetMetricsScope(scope.SubScope("msgpack-server"))
+	msgpackServerScope := scope.SubScope("msgpack-server").Tagged(map[string]string{"server": "msgpack"})
+	iOpts := instrumentOpts.SetMetricsScope(msgpackServerScope)
 	msgpackServerOpts := cfg.Msgpack.NewMsgpackServerOptions(iOpts)
 
 	// Create the http server options.
 	httpAddr := cfg.HTTP.ListenAddress
-	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("http-server"))
+	httpServerScope := scope.SubScope("http-server").Tagged(map[string]string{"server": "http"})
+	iOpts = instrumentOpts.SetMetricsScope(httpServerScope)
 	httpServerOpts := cfg.HTTP.NewHTTPServerOptions(iOpts)
 
 	// Create the aggregator.


### PR DESCRIPTION
cc @cw9 @prateek @jeromefroe 

This PR adds keepAlive options for the aggregation server to actively close out connections that have been closed by the client.

Fixes #34 .