### PR TITLE
Verify pending follower only sets follower state

### DIFF
--- a/aggregator/election_mgr_options.go
+++ b/aggregator/election_mgr_options.go
@@ -21,8 +21,6 @@
 package aggregator
 
 import (
-	"time"
-
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
@@ -30,8 +28,7 @@ import (
 )
 
 const (
-	defaultElectionKeyFormat   = "/shardset/%d/lock"
-	defaultChangeVerifyTimeout = 10 * time.Second
+	defaultElectionKeyFormat = "/shardset/%d/lock"
 )
 
 // ElectionManagerOptions provide a set of options for the election manager.
@@ -83,36 +80,28 @@ type ElectionManagerOptions interface {
 
 	// LeaderService returns the leader service.
 	LeaderService() services.LeaderService
-
-	// SetChangeVerifyTimeout sets the change verification timeout.
-	SetChangeVerifyTimeout(value time.Duration) ElectionManagerOptions
-
-	// ChangeVerifyTimeout returns the change verification timeout.
-	ChangeVerifyTimeout() time.Duration
 }
 
 type electionManagerOptions struct {
-	clockOpts           clock.Options
-	instrumentOpts      instrument.Options
-	electionOpts        services.ElectionOptions
-	campaignOpts        services.CampaignOptions
-	campaignRetryOpts   xretry.Options
-	changeRetryOpts     xretry.Options
-	electionKeyFmt      string
-	leaderService       services.LeaderService
-	changeVerifyTimeout time.Duration
+	clockOpts         clock.Options
+	instrumentOpts    instrument.Options
+	electionOpts      services.ElectionOptions
+	campaignOpts      services.CampaignOptions
+	campaignRetryOpts xretry.Options
+	changeRetryOpts   xretry.Options
+	electionKeyFmt    string
+	leaderService     services.LeaderService
 }
 
 // NewElectionManagerOptions create a new set of options for the election manager.
 func NewElectionManagerOptions() ElectionManagerOptions {
 	return &electionManagerOptions{
-		clockOpts:           clock.NewOptions(),
-		instrumentOpts:      instrument.NewOptions(),
-		electionOpts:        services.NewElectionOptions(),
-		campaignRetryOpts:   xretry.NewOptions(),
-		changeRetryOpts:     xretry.NewOptions(),
-		electionKeyFmt:      defaultElectionKeyFormat,
-		changeVerifyTimeout: defaultChangeVerifyTimeout,
+		clockOpts:         clock.NewOptions(),
+		instrumentOpts:    instrument.NewOptions(),
+		electionOpts:      services.NewElectionOptions(),
+		campaignRetryOpts: xretry.NewOptions(),
+		changeRetryOpts:   xretry.NewOptions(),
+		electionKeyFmt:    defaultElectionKeyFormat,
 	}
 }
 
@@ -194,14 +183,4 @@ func (o *electionManagerOptions) SetLeaderService(value services.LeaderService) 
 
 func (o *electionManagerOptions) LeaderService() services.LeaderService {
 	return o.leaderService
-}
-
-func (o *electionManagerOptions) SetChangeVerifyTimeout(value time.Duration) ElectionManagerOptions {
-	opts := *o
-	opts.changeVerifyTimeout = value
-	return &opts
-}
-
-func (o *electionManagerOptions) ChangeVerifyTimeout() time.Duration {
-	return o.changeVerifyTimeout
 }

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -548,13 +548,12 @@ func (t shardFnType) ShardFn() (aggregator.ShardFn, error) {
 }
 
 type electionManagerConfiguration struct {
-	Election            electionConfiguration  `yaml:"election"`
-	ServiceID           serviceIDConfiguration `yaml:"serviceID"`
-	LeaderValue         string                 `yaml:"leaderValue"`
-	ElectionKeyFmt      string                 `yaml:"electionKeyFmt" validate:"nonzero"`
-	CampaignRetrier     xretry.Configuration   `yaml:"campaignRetrier"`
-	ChangeRetrier       xretry.Configuration   `yaml:"changeRetrier"`
-	ChangeVerifyTimeout time.Duration          `yaml:"changeVerifyTimeout"`
+	Election        electionConfiguration  `yaml:"election"`
+	ServiceID       serviceIDConfiguration `yaml:"serviceID"`
+	LeaderValue     string                 `yaml:"leaderValue"`
+	ElectionKeyFmt  string                 `yaml:"electionKeyFmt" validate:"nonzero"`
+	CampaignRetrier xretry.Configuration   `yaml:"campaignRetrier"`
+	ChangeRetrier   xretry.Configuration   `yaml:"changeRetrier"`
 }
 
 func (c electionManagerConfiguration) NewElectionManager(
@@ -595,9 +594,6 @@ func (c electionManagerConfiguration) NewElectionManager(
 		SetChangeRetryOptions(changeRetryOpts).
 		SetElectionKeyFmt(c.ElectionKeyFmt).
 		SetLeaderService(leaderService)
-	if c.ChangeVerifyTimeout != 0 {
-		opts = opts.SetChangeVerifyTimeout(c.ChangeVerifyTimeout)
-	}
 	electionManager := aggregator.NewElectionManager(opts)
 	return electionManager, nil
 }


### PR DESCRIPTION
cc @jeromefroe @cw9  @martin-mao 

This PR removes the verify timeout and make the goroutine that verifies pending follower state only responsible for setting follower state. 

Previously when the verification times out, the goroutine may set the election state to the leader state if the current instance is the leader, however there was a race condition where if the leader changes right after timing out, the election state was incorrectly set to leader. This PR fixed the issue by only allowing the verification goroutine to set election state to follower state iff the state has not changed since verification starts. Also added unit tests. 