### PR TITLE
[gometalinter] Add build tags to gometalinter subcommands

### DIFF
--- a/.metalinter.json
+++ b/.metalinter.json
@@ -1,4 +1,8 @@
 {
+  "Linters": {
+    "deadcode":  { "Command": "deadcode  -tags integration" },
+    "varcheck":  { "Command": "varcheck  -tags integration" },
+    "megacheck": { "Command": "megacheck -tags integration" } },
   "Enable":
     [ "deadcode"
     , "varcheck"

--- a/integration/client.go
+++ b/integration/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/m3db/m3metrics/protocol/msgpack"
 )
 
-// nolint: megacheck
 type client struct {
 	address        string
 	batchSize      int
@@ -39,7 +38,6 @@ type client struct {
 	conn           net.Conn
 }
 
-// nolint: megacheck
 func newClient(address string, batchSize int, connectTimeout time.Duration) *client {
 	return &client{
 		address:        address,

--- a/integration/data.go
+++ b/integration/data.go
@@ -37,7 +37,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint: megacheck, varcheck, deadcode
 var (
 	testCounterVal     = int64(123)
 	testBatchTimerVals = []float64{1.5, 2.5, 3.5, 4.5, 5.5}
@@ -62,23 +61,8 @@ var (
 			},
 		),
 	}
-
-	testDefaultTimerAggregationTypes = policy.AggregationTypes{
-		policy.Sum,
-		policy.SumSq,
-		policy.Mean,
-		policy.Min,
-		policy.Max,
-		policy.Count,
-		policy.Stdev,
-		policy.Median,
-		policy.P50,
-		policy.P95,
-		policy.P99,
-	}
 )
 
-// nolint: megacheck
 type byTimeIDPolicyAscending []aggregated.MetricWithStoragePolicy
 
 func (a byTimeIDPolicyAscending) Len() int      { return len(a) }
@@ -99,37 +83,32 @@ func (a byTimeIDPolicyAscending) Less(i, j int) bool {
 	return retention1 < retention2
 }
 
-// nolint: megacheck
 type metricKey struct {
 	id  string
 	typ unaggregated.Type
 }
 
-type valuesByTime map[int64]interface{}        // nolint: megacheck
-type datapointsByID map[metricKey]valuesByTime // nolint: megacheck
+type valuesByTime map[int64]interface{}
+type datapointsByID map[metricKey]valuesByTime
 
-// nolint: megacheck
 type dataForPolicy struct {
 	aggTypes policy.AggregationTypes
 	data     datapointsByID
 }
 
-type metricsByPolicy map[policy.Policy]*dataForPolicy           // nolint: megacheck
-type metricTypeFn func(ts time.Time, idx int) unaggregated.Type // nolint: megacheck
+type metricsByPolicy map[policy.Policy]*dataForPolicy
+type metricTypeFn func(ts time.Time, idx int) unaggregated.Type
 
-// nolint: megacheck
 type testData struct {
 	timestamp time.Time
 	metrics   []unaggregated.MetricUnion
 }
 
-// nolint: megacheck
 type testDatasetWithPoliciesList struct {
 	dataset      []testData
 	policiesList policy.PoliciesList
 }
 
-// nolint: megacheck, deadcode
 func roundRobinMetricTypeFn(_ time.Time, idx int) unaggregated.Type {
 	switch idx % 3 {
 	case 0:
@@ -141,12 +120,10 @@ func roundRobinMetricTypeFn(_ time.Time, idx int) unaggregated.Type {
 	}
 }
 
-// nolint: megacheck, deadcode
 func constantMetryTypeFnFactory(typ unaggregated.Type) metricTypeFn {
 	return func(time.Time, int) unaggregated.Type { return typ }
 }
 
-// nolint: megacheck, deadcode
 func generateTestIDs(prefix string, numIDs int) []string {
 	ids := make([]string, numIDs)
 	for i := 0; i < numIDs; i++ {
@@ -155,7 +132,6 @@ func generateTestIDs(prefix string, numIDs int) []string {
 	return ids
 }
 
-// nolint: megacheck, deadcode
 func generateTestData(
 	start, stop time.Time,
 	interval time.Duration,
@@ -211,7 +187,6 @@ func generateTestData(
 	}
 }
 
-// nolint: megacheck, deadcode
 func toExpectedResults(
 	t *testing.T,
 	now time.Time,
@@ -332,7 +307,6 @@ func toExpectedResults(
 	return expected
 }
 
-// nolint: megacheck
 func toAggregatedMetrics(
 	t *testing.T,
 	key metricKey,

--- a/integration/election.go
+++ b/integration/election.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint: megacheck
 var (
 	testClusterSize     = 1
 	testEnvironment     = "testEnv"
@@ -40,13 +39,11 @@ var (
 	testElectionTTLSecs = 5
 )
 
-// nolint: megacheck
 type testCluster struct {
 	t       *testing.T
 	cluster *integration.ClusterV3
 }
 
-// nolint: megacheck
 func newTestCluster(t *testing.T) *testCluster {
 	return &testCluster{
 		t: t,

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -24,10 +24,8 @@ import (
 	"time"
 )
 
-// nolint: megacheck
 type conditionFn func() bool
 
-// nolint: megacheck
 func waitUntil(fn conditionFn, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/integration/options.go
+++ b/integration/options.go
@@ -28,7 +28,6 @@ import (
 	"github.com/m3db/m3cluster/kv/mem"
 )
 
-// nolint: megacheck
 const (
 	defaultServerStateChangeTimeout   = 5 * time.Second
 	defaultClientBatchSize            = 1440
@@ -44,7 +43,6 @@ const (
 	defaultJitterEnabled              = true
 )
 
-// nolint: megacheck
 type testOptions interface {
 	// SetMsgpackAddr sets the msgpack server address.
 	SetMsgpackAddr(value string) testOptions
@@ -143,7 +141,6 @@ type testOptions interface {
 	MaxJitterFn() aggregator.FlushJitterFn
 }
 
-// nolint: megacheck
 type options struct {
 	msgpackAddr                string
 	httpAddr                   string
@@ -163,7 +160,6 @@ type options struct {
 	maxJitterFn                aggregator.FlushJitterFn
 }
 
-// nolint: megacheck
 func newTestOptions() testOptions {
 	return &options{
 		instanceID:                 defaultInstanceID,
@@ -343,7 +339,6 @@ func (o *options) MaxJitterFn() aggregator.FlushJitterFn {
 	return o.maxJitterFn
 }
 
-// nolint: megacheck
 func defaultMaxJitterFn(interval time.Duration) time.Duration {
 	return time.Duration(0.75 * float64(interval))
 }

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -45,20 +45,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint: megacheck, varcheck, deadcode
 var (
-	msgpackAddrArg                = flag.String("msgpackAddr", "0.0.0.0:6000", "msgpack server address")
-	httpAddrArg                   = flag.String("httpAddr", "0.0.0.0:6001", "http server address")
-	errServerStartTimedOut        = errors.New("server took too long to start")
-	errServerStopTimedOut         = errors.New("server took too long to stop")
-	errElectionStateChangeTimeout = errors.New("server took too long to change election state")
+	msgpackAddrArg         = flag.String("msgpackAddr", "0.0.0.0:6000", "msgpack server address")
+	httpAddrArg            = flag.String("httpAddr", "0.0.0.0:6001", "http server address")
+	errServerStartTimedOut = errors.New("server took too long to start")
 )
 
 // nowSetterFn is the function that sets the current time.
-// nolint: megacheck
 type nowSetterFn func(t time.Time)
 
-// nolint: megacheck
 type testSetup struct {
 	opts              testOptions
 	msgpackAddr       string
@@ -83,7 +78,6 @@ type testSetup struct {
 	closedCh chan struct{}
 }
 
-// nolint: megacheck, deadcode
 func newTestSetup(t *testing.T, opts testOptions) *testSetup {
 	if opts == nil {
 		opts = newTestOptions()


### PR DESCRIPTION
@prateek reminded me in a different PR that we need to include build tags to some of the `gometalinter` subcommands so they lint the `integration` package properly. This diff adds those build flags and updates the package accordingly to remove the `nolint` flags which are now unnecessary.

cc @xichen2020 @prateek 