### PR TITLE
[travis] Add go 1.8 and 1.9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.8
+  - 1.7.6
+  - 1.8.3
   - 1.9
 install: make install-ci
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - 1.7
+  - 1.8
+  - 1.9
 install: make install-ci
 env:
  # Set higher timeouts and package name for travis


### PR DESCRIPTION
This PR adds Go 1.8 and 1.9 to the versions of Go we test against in Travis.