### PR TITLE
Support including encoding time when writing aggregated metrics

### DIFF
--- a/aggregator/handler/config.go
+++ b/aggregator/handler/config.go
@@ -105,25 +105,18 @@ type writerConfiguration struct {
 	// Pool of buffered encoders.
 	BufferedEncoderPool pool.ObjectPoolConfiguration `yaml:"bufferedEncoderPool"`
 
-	// Whether to include encoding time in the payload.
-	IncludeEncodingTime *bool `yaml:"includeEncodingTime"`
-
 	// How frequent is the encoding time sampled and included in the payload.
-	EncodingTimeSamplingRate float64 `yaml:"encodingTimeSamplingRate"`
+	EncodingTimeSamplingRate float64 `yaml:"encodingTimeSamplingRate" validate:"min=0.0,max=1.0"`
 }
 
 func (c *writerConfiguration) NewWriterOptions(
 	instrumentOpts instrument.Options,
 ) writer.Options {
-	opts := writer.NewOptions().SetInstrumentOptions(instrumentOpts)
+	opts := writer.NewOptions().
+		SetInstrumentOptions(instrumentOpts).
+		SetEncodingTimeSamplingRate(c.EncodingTimeSamplingRate)
 	if c.MaxBufferSize > 0 {
 		opts = opts.SetMaxBufferSize(c.MaxBufferSize)
-	}
-	if c.IncludeEncodingTime != nil {
-		opts = opts.SetIncludeEncodingTime(*c.IncludeEncodingTime)
-	}
-	if c.EncodingTimeSamplingRate != 0 {
-		opts = opts.SetEncodingTimeSamplingRate(c.EncodingTimeSamplingRate)
 	}
 
 	// Set buffered encoder pool.

--- a/aggregator/handler/config.go
+++ b/aggregator/handler/config.go
@@ -104,6 +104,12 @@ type writerConfiguration struct {
 
 	// Pool of buffered encoders.
 	BufferedEncoderPool pool.ObjectPoolConfiguration `yaml:"bufferedEncoderPool"`
+
+	// Whether to include encoding time in the payload.
+	IncludeEncodingTime *bool `yaml:"includeEncodingTime"`
+
+	// How frequently is the encoding time included in the payload.
+	IncludeEncodingTimeEveryN int `yaml:"includeEncodingTimeEveryN"`
 }
 
 func (c *writerConfiguration) NewWriterOptions(
@@ -112,6 +118,12 @@ func (c *writerConfiguration) NewWriterOptions(
 	opts := writer.NewOptions().SetInstrumentOptions(instrumentOpts)
 	if c.MaxBufferSize > 0 {
 		opts = opts.SetMaxBufferSize(c.MaxBufferSize)
+	}
+	if c.IncludeEncodingTime != nil {
+		opts = opts.SetIncludeEncodingTime(*c.IncludeEncodingTime)
+	}
+	if c.IncludeEncodingTimeEveryN != 0 {
+		opts = opts.SetIncludeEncodingTimeEveryN(c.IncludeEncodingTimeEveryN)
 	}
 
 	// Set buffered encoder pool.

--- a/aggregator/handler/config.go
+++ b/aggregator/handler/config.go
@@ -108,8 +108,8 @@ type writerConfiguration struct {
 	// Whether to include encoding time in the payload.
 	IncludeEncodingTime *bool `yaml:"includeEncodingTime"`
 
-	// How frequently is the encoding time included in the payload.
-	IncludeEncodingTimeEveryN int `yaml:"includeEncodingTimeEveryN"`
+	// How frequent is the encoding time sampled and included in the payload.
+	EncodingTimeSamplingRate float64 `yaml:"encodingTimeSamplingRate"`
 }
 
 func (c *writerConfiguration) NewWriterOptions(
@@ -122,8 +122,8 @@ func (c *writerConfiguration) NewWriterOptions(
 	if c.IncludeEncodingTime != nil {
 		opts = opts.SetIncludeEncodingTime(*c.IncludeEncodingTime)
 	}
-	if c.IncludeEncodingTimeEveryN != 0 {
-		opts = opts.SetIncludeEncodingTimeEveryN(c.IncludeEncodingTimeEveryN)
+	if c.EncodingTimeSamplingRate != 0 {
+		opts = opts.SetEncodingTimeSamplingRate(c.EncodingTimeSamplingRate)
 	}
 
 	// Set buffered encoder pool.

--- a/aggregator/handler/writer/options.go
+++ b/aggregator/handler/writer/options.go
@@ -28,8 +28,7 @@ import (
 
 const (
 	defaultMaxBufferSize            = 1440
-	defaultIncludeEncodingTime      = false
-	defaultEncodingTimeSamplingRate = 0.01
+	defaultEncodingTimeSamplingRate = 0
 )
 
 // Options provide a set of options for the writer.
@@ -58,24 +57,14 @@ type Options interface {
 	// BufferedEncoderPool returns the buffered encoder pool.
 	BufferedEncoderPool() msgpack.BufferedEncoderPool
 
-	// SetIncludeEncodingTime sets whether the time at which metrics and policies are
-	// encoded is included alongside the encoded data. Such encoding time can be used
-	// to compute end-to-end latencies for example.
-	SetIncludeEncodingTime(value bool) Options
-
-	// IncludeEncodingTime returns whether the time at which metrics and policies are
-	// encoded is included alongside the encoded data. Such encoding time can be used
-	// to compute end-to-end latencies for example.
-	IncludeEncodingTime() bool
-
 	// SetEncodingTimeSampleRate sets the sampling rate at which the encoding time is
-	// included in the encoded data. This option only applies when including encoding
-	// time is enabled.
+	// included in the encoded data. A value of 0 means the encoding time is never included,
+	// and a value of 1 means the encoding time is always included.
 	SetEncodingTimeSamplingRate(value float64) Options
 
 	// EncodingTimeSamplingRate returns the sampling rate at which the encoding time is
-	// included in the encoded data. This option only applies when including encoding
-	// time is enabled.
+	// included in the encoded data. A value of 0 means the encoding time is never included,
+	// and a value of 1 means the encoding time is always included.
 	EncodingTimeSamplingRate() float64
 }
 
@@ -84,7 +73,6 @@ type options struct {
 	instrumentOpts           instrument.Options
 	maxBufferSize            int
 	bufferedEncoderPool      msgpack.BufferedEncoderPool
-	includeEncodingTime      bool
 	encodingTimeSamplingRate float64
 }
 
@@ -99,7 +87,6 @@ func NewOptions() Options {
 		instrumentOpts:           instrument.NewOptions(),
 		maxBufferSize:            defaultMaxBufferSize,
 		bufferedEncoderPool:      bufferedEncoderPool,
-		includeEncodingTime:      defaultIncludeEncodingTime,
 		encodingTimeSamplingRate: defaultEncodingTimeSamplingRate,
 	}
 }
@@ -142,16 +129,6 @@ func (o *options) SetBufferedEncoderPool(value msgpack.BufferedEncoderPool) Opti
 
 func (o *options) BufferedEncoderPool() msgpack.BufferedEncoderPool {
 	return o.bufferedEncoderPool
-}
-
-func (o *options) SetIncludeEncodingTime(value bool) Options {
-	opts := *o
-	opts.includeEncodingTime = value
-	return &opts
-}
-
-func (o *options) IncludeEncodingTime() bool {
-	return o.includeEncodingTime
 }
 
 func (o *options) SetEncodingTimeSamplingRate(value float64) Options {

--- a/aggregator/handler/writer/options.go
+++ b/aggregator/handler/writer/options.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	defaultMaxBufferSize             = 1440
-	defaultIncludeEncodingTime       = false
-	defaultIncludeEncodingTimeEveryN = 100
+	defaultMaxBufferSize            = 1440
+	defaultIncludeEncodingTime      = false
+	defaultEncodingTimeSamplingRate = 0.01
 )
 
 // Options provide a set of options for the writer.
@@ -68,24 +68,24 @@ type Options interface {
 	// to compute end-to-end latencies for example.
 	IncludeEncodingTime() bool
 
-	// SetIncludeEncodingTimeEveryN sets the value that determines that the encoding
-	// time is included every N writes. This option only applies when including encoding
+	// SetEncodingTimeSampleRate sets the sampling rate at which the encoding time is
+	// included in the encoded data. This option only applies when including encoding
 	// time is enabled.
-	SetIncludeEncodingTimeEveryN(value int) Options
+	SetEncodingTimeSamplingRate(value float64) Options
 
-	// IncludeEncodingTimeEveryN returns the value that determines that the encoding
-	// time is included every N writes. This option only applies when including encoding
+	// EncodingTimeSamplingRate returns the sampling rate at which the encoding time is
+	// included in the encoded data. This option only applies when including encoding
 	// time is enabled.
-	IncludeEncodingTimeEveryN() int
+	EncodingTimeSamplingRate() float64
 }
 
 type options struct {
-	clockOpts                 clock.Options
-	instrumentOpts            instrument.Options
-	maxBufferSize             int
-	bufferedEncoderPool       msgpack.BufferedEncoderPool
-	includeEncodingTime       bool
-	includeEncodingTimeEveryN int
+	clockOpts                clock.Options
+	instrumentOpts           instrument.Options
+	maxBufferSize            int
+	bufferedEncoderPool      msgpack.BufferedEncoderPool
+	includeEncodingTime      bool
+	encodingTimeSamplingRate float64
 }
 
 // NewOptions provide a set of writer options.
@@ -95,12 +95,12 @@ func NewOptions() Options {
 		return msgpack.NewPooledBufferedEncoder(bufferedEncoderPool)
 	})
 	return &options{
-		clockOpts:                 clock.NewOptions(),
-		instrumentOpts:            instrument.NewOptions(),
-		maxBufferSize:             defaultMaxBufferSize,
-		bufferedEncoderPool:       bufferedEncoderPool,
-		includeEncodingTime:       defaultIncludeEncodingTime,
-		includeEncodingTimeEveryN: defaultIncludeEncodingTimeEveryN,
+		clockOpts:                clock.NewOptions(),
+		instrumentOpts:           instrument.NewOptions(),
+		maxBufferSize:            defaultMaxBufferSize,
+		bufferedEncoderPool:      bufferedEncoderPool,
+		includeEncodingTime:      defaultIncludeEncodingTime,
+		encodingTimeSamplingRate: defaultEncodingTimeSamplingRate,
 	}
 }
 
@@ -154,12 +154,12 @@ func (o *options) IncludeEncodingTime() bool {
 	return o.includeEncodingTime
 }
 
-func (o *options) SetIncludeEncodingTimeEveryN(value int) Options {
+func (o *options) SetEncodingTimeSamplingRate(value float64) Options {
 	opts := *o
-	opts.includeEncodingTimeEveryN = value
+	opts.encodingTimeSamplingRate = value
 	return &opts
 }
 
-func (o *options) IncludeEncodingTimeEveryN() int {
-	return o.includeEncodingTimeEveryN
+func (o *options) EncodingTimeSamplingRate() float64 {
+	return o.encodingTimeSamplingRate
 }

--- a/aggregator/handler/writer/sharded.go
+++ b/aggregator/handler/writer/sharded.go
@@ -22,6 +22,7 @@ package writer
 
 import (
 	"errors"
+	"math/rand"
 
 	"github.com/m3db/m3aggregator/aggregator"
 	"github.com/m3db/m3aggregator/aggregator/handler/common"
@@ -58,6 +59,7 @@ func newShardedWriterMetrics(scope tally.Scope) shardedWriterMetrics {
 }
 
 type shardFn func(chunkedID id.ChunkedID) uint32
+type randFn func() float64
 
 // shardedWriter encodes data in a shard-aware fashion and routes them to the backend.
 // shardedWriter is not thread safe.
@@ -65,17 +67,18 @@ type shardedWriter struct {
 	sharding.AggregatedSharder
 	common.Router
 
-	nowFn                     clock.NowFn
-	maxBufferSize             int
-	bufferedEncoderPool       msgpack.BufferedEncoderPool
-	includeEncodingTime       bool
-	includeEncodingTimeEveryN int
+	nowFn                    clock.NowFn
+	maxBufferSize            int
+	bufferedEncoderPool      msgpack.BufferedEncoderPool
+	includeEncodingTime      bool
+	encodingTimeSamplingRate float64
 
 	closed          bool
-	numWritten      int
+	rand            *rand.Rand
 	encodersByShard []msgpack.AggregatedEncoder
 	metrics         shardedWriterMetrics
 	shardFn         shardFn
+	randFn          randFn
 }
 
 // NewShardedWriter creates a new sharded writer.
@@ -89,19 +92,22 @@ func NewShardedWriter(
 		return nil, err
 	}
 	numShards := sharderID.NumShards()
+	nowFn := opts.ClockOptions().NowFn()
 	instrumentOpts := opts.InstrumentOptions()
 	w := &shardedWriter{
-		AggregatedSharder:         sharder,
-		Router:                    router,
-		nowFn:                     opts.ClockOptions().NowFn(),
-		maxBufferSize:             opts.MaxBufferSize(),
-		bufferedEncoderPool:       opts.BufferedEncoderPool(),
-		includeEncodingTime:       opts.IncludeEncodingTime(),
-		includeEncodingTimeEveryN: opts.IncludeEncodingTimeEveryN(),
-		encodersByShard:           make([]msgpack.AggregatedEncoder, numShards),
-		metrics:                   newShardedWriterMetrics(instrumentOpts.MetricsScope()),
+		AggregatedSharder:        sharder,
+		Router:                   router,
+		nowFn:                    nowFn,
+		maxBufferSize:            opts.MaxBufferSize(),
+		bufferedEncoderPool:      opts.BufferedEncoderPool(),
+		includeEncodingTime:      opts.IncludeEncodingTime(),
+		encodingTimeSamplingRate: opts.EncodingTimeSamplingRate(),
+		rand:            rand.New(rand.NewSource(nowFn().UnixNano())),
+		encodersByShard: make([]msgpack.AggregatedEncoder, numShards),
+		metrics:         newShardedWriterMetrics(instrumentOpts.MetricsScope()),
 	}
 	w.shardFn = w.Shard
+	w.randFn = w.rand.Float64
 	return w, nil
 }
 
@@ -170,12 +176,8 @@ func (w *shardedWriter) encode(
 		includeEncodingTime bool
 		err                 error
 	)
-	if w.includeEncodingTime {
-		w.numWritten++
-		if w.numWritten >= w.includeEncodingTimeEveryN {
-			w.numWritten = 0
-			includeEncodingTime = true
-		}
+	if w.includeEncodingTime && w.randFn() < w.encodingTimeSamplingRate {
+		includeEncodingTime = true
 	}
 	if !includeEncodingTime {
 		err = encoder.EncodeChunkedMetricWithStoragePolicy(mp)

--- a/aggregator/handler/writer/sharded_test.go
+++ b/aggregator/handler/writer/sharded_test.go
@@ -152,7 +152,7 @@ func TestShardedWriterWriteWithEncodeTimeNoFlush(t *testing.T) {
 		SetClockOptions(clock.NewOptions().SetNowFn(nowFn)).
 		SetMaxBufferSize(math.MaxInt64).
 		SetIncludeEncodingTime(true).
-		SetIncludeEncodingTimeEveryN(2)
+		SetEncodingTimeSamplingRate(0.5)
 	writer := testShardedWriter(t, opts)
 	writer.shardFn = func(chunkedID id.ChunkedID) uint32 {
 		if isSameChunkedID(chunkedID, testChunkedID) {
@@ -163,6 +163,14 @@ func TestShardedWriterWriteWithEncodeTimeNoFlush(t *testing.T) {
 		}
 		require.Fail(t, "unexpected chunked id %v", chunkedID)
 		return 0
+	}
+	var iter int
+	writer.randFn = func() float64 {
+		iter++
+		if iter%2 == 0 {
+			return 0.1
+		}
+		return 0.9
 	}
 
 	inputs := []aggregated.ChunkedMetricWithStoragePolicy{

--- a/aggregator/handler/writer/sharded_test.go
+++ b/aggregator/handler/writer/sharded_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/protocol/msgpack"
+	"github.com/m3db/m3x/clock"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/require"
@@ -80,7 +81,7 @@ func TestShardedWriterWriteClosed(t *testing.T) {
 	require.Equal(t, errWriterClosed, writer.Write(testChunkedMetricWithStoragePolicy))
 }
 
-func TestShardedWriterWriteNoFlush(t *testing.T) {
+func TestShardedWriterWriteNoEncodeTimeNoFlush(t *testing.T) {
 	opts := NewOptions().SetMaxBufferSize(math.MaxInt64)
 	writer := testShardedWriter(t, opts)
 	writer.shardFn = func(chunkedID id.ChunkedID) uint32 {
@@ -106,26 +107,26 @@ func TestShardedWriterWriteNoFlush(t *testing.T) {
 
 	expectedData := []struct {
 		shard   uint32
-		written []aggregated.ChunkedMetricWithStoragePolicy
+		written []encodeData
 	}{
 		{
 			shard: 1,
-			written: []aggregated.ChunkedMetricWithStoragePolicy{
-				testChunkedMetricWithStoragePolicy,
-				testChunkedMetricWithStoragePolicy,
+			written: []encodeData{
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy},
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy},
 			},
 		},
 		{
 			shard: 2,
-			written: []aggregated.ChunkedMetricWithStoragePolicy{
-				testChunkedMetricWithStoragePolicy2,
-				testChunkedMetricWithStoragePolicy2,
+			written: []encodeData{
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2},
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2},
 			},
 		},
 	}
 	for shard, encoder := range writer.encodersByShard {
 		var (
-			expectedWritten []aggregated.ChunkedMetricWithStoragePolicy
+			expectedWritten []encodeData
 			found           bool
 		)
 		for _, expected := range expectedData {
@@ -144,7 +145,90 @@ func TestShardedWriterWriteNoFlush(t *testing.T) {
 	}
 }
 
-func TestShardedWriterWriteWithFlush(t *testing.T) {
+func TestShardedWriterWriteWithEncodeTimeNoFlush(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
+	opts := NewOptions().
+		SetClockOptions(clock.NewOptions().SetNowFn(nowFn)).
+		SetMaxBufferSize(math.MaxInt64).
+		SetIncludeEncodingTime(true).
+		SetIncludeEncodingTimeEveryN(2)
+	writer := testShardedWriter(t, opts)
+	writer.shardFn = func(chunkedID id.ChunkedID) uint32 {
+		if isSameChunkedID(chunkedID, testChunkedID) {
+			return 1
+		}
+		if isSameChunkedID(chunkedID, testChunkedID2) {
+			return 2
+		}
+		require.Fail(t, "unexpected chunked id %v", chunkedID)
+		return 0
+	}
+
+	inputs := []aggregated.ChunkedMetricWithStoragePolicy{
+		testChunkedMetricWithStoragePolicy,
+		testChunkedMetricWithStoragePolicy2,
+		testChunkedMetricWithStoragePolicy2,
+		testChunkedMetricWithStoragePolicy,
+	}
+	for _, input := range inputs {
+		require.NoError(t, writer.Write(input))
+	}
+
+	encodedAtNanos := now.UnixNano()
+	expectedData := []struct {
+		shard   uint32
+		written []encodeData
+	}{
+		{
+			shard: 1,
+			written: []encodeData{
+				{
+					ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy,
+					encodedAtNanos:                 0,
+				},
+				{
+					ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy,
+					encodedAtNanos:                 encodedAtNanos,
+				},
+			},
+		},
+		{
+			shard: 2,
+			written: []encodeData{
+				{
+					ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2,
+					encodedAtNanos:                 encodedAtNanos,
+				},
+				{
+					ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2,
+					encodedAtNanos:                 0,
+				},
+			},
+		},
+	}
+	for shard, encoder := range writer.encodersByShard {
+		var (
+			expectedWritten []encodeData
+			found           bool
+		)
+		for _, expected := range expectedData {
+			if expected.shard == uint32(shard) {
+				expectedWritten = expected.written
+				found = true
+				break
+			}
+		}
+		if found {
+			actual := []*common.RefCountedBuffer{common.NewRefCountedBuffer(encoder.Encoder())}
+			validateWritten(t, expectedWritten, actual)
+		} else {
+			require.Nil(t, encoder)
+		}
+	}
+}
+
+func TestShardedWriterWriteNoEncodeTimeWithFlush(t *testing.T) {
 	flushed := make(map[uint32][]*common.RefCountedBuffer)
 	router := &mockRouter{
 		routeFn: func(shard uint32, buf *common.RefCountedBuffer) error {
@@ -178,20 +262,20 @@ func TestShardedWriterWriteWithFlush(t *testing.T) {
 
 	expectedData := []struct {
 		shard   uint32
-		written []aggregated.ChunkedMetricWithStoragePolicy
+		written []encodeData
 	}{
 		{
 			shard: 1,
-			written: []aggregated.ChunkedMetricWithStoragePolicy{
-				testChunkedMetricWithStoragePolicy,
-				testChunkedMetricWithStoragePolicy,
+			written: []encodeData{
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy},
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy},
 			},
 		},
 		{
 			shard: 2,
-			written: []aggregated.ChunkedMetricWithStoragePolicy{
-				testChunkedMetricWithStoragePolicy2,
-				testChunkedMetricWithStoragePolicy2,
+			written: []encodeData{
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2},
+				{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2},
 			},
 		},
 	}
@@ -236,12 +320,12 @@ func TestShardedWriterFlush(t *testing.T) {
 	// Shard 2 has a buffer with good data.
 	bufferedEncoder = msgpack.NewBufferedEncoder()
 	writer.encodersByShard[2] = msgpack.NewAggregatedEncoder(bufferedEncoder)
-	inputs := []aggregated.ChunkedMetricWithStoragePolicy{
-		testChunkedMetricWithStoragePolicy,
-		testChunkedMetricWithStoragePolicy2,
+	inputs := []encodeData{
+		{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy},
+		{ChunkedMetricWithStoragePolicy: testChunkedMetricWithStoragePolicy2},
 	}
 	for _, input := range inputs {
-		require.NoError(t, writer.encodersByShard[2].EncodeChunkedMetricWithStoragePolicy(input))
+		require.NoError(t, writer.encodersByShard[2].EncodeChunkedMetricWithStoragePolicy(input.ChunkedMetricWithStoragePolicy))
 	}
 
 	require.Error(t, writer.Flush())
@@ -271,21 +355,25 @@ func isSameChunkedID(id1, id2 id.ChunkedID) bool {
 
 func validateWritten(
 	t *testing.T,
-	expected []aggregated.ChunkedMetricWithStoragePolicy,
+	expected []encodeData,
 	actual []*common.RefCountedBuffer,
 ) {
-	var decoded []aggregated.MetricWithStoragePolicy
+	var decoded []decodeData
 	it := msgpack.NewAggregatedIterator(nil, nil)
 	for _, b := range actual {
 		it.Reset(b.Buffer().Buffer())
 		for it.Next() {
-			rm, sp := it.Value()
+			rm, sp, encodedAtNanos := it.Value()
 			m, err := rm.Metric()
 			require.NoError(t, err)
-			decoded = append(decoded, aggregated.MetricWithStoragePolicy{
-				Metric:        m,
-				StoragePolicy: sp,
-			})
+			res := decodeData{
+				MetricWithStoragePolicy: aggregated.MetricWithStoragePolicy{
+					Metric:        m,
+					StoragePolicy: sp,
+				},
+				encodedAtNanos: encodedAtNanos,
+			}
+			decoded = append(decoded, res)
 		}
 		b.DecRef()
 		require.Equal(t, io.EOF, it.Err())
@@ -303,6 +391,7 @@ func validateWritten(
 		require.Equal(t, expected[i].TimeNanos, decoded[i].TimeNanos)
 		require.Equal(t, expected[i].Value, decoded[i].Value)
 		require.Equal(t, expected[i].StoragePolicy, decoded[i].StoragePolicy)
+		require.Equal(t, expected[i].encodedAtNanos, decoded[i].encodedAtNanos)
 	}
 }
 
@@ -311,6 +400,18 @@ func testShardedWriter(t *testing.T, opts Options) *shardedWriter {
 	writer, err := NewShardedWriter(sharderID, nil, opts)
 	require.NoError(t, err)
 	return writer.(*shardedWriter)
+}
+
+type encodeData struct {
+	aggregated.ChunkedMetricWithStoragePolicy
+
+	encodedAtNanos int64
+}
+
+type decodeData struct {
+	aggregated.MetricWithStoragePolicy
+
+	encodedAtNanos int64
 }
 
 type routeFn func(shard uint32, buf *common.RefCountedBuffer) error

--- a/aggregator/handler/writer/sharded_test.go
+++ b/aggregator/handler/writer/sharded_test.go
@@ -151,7 +151,6 @@ func TestShardedWriterWriteWithEncodeTimeNoFlush(t *testing.T) {
 	opts := NewOptions().
 		SetClockOptions(clock.NewOptions().SetNowFn(nowFn)).
 		SetMaxBufferSize(math.MaxInt64).
-		SetIncludeEncodingTime(true).
 		SetEncodingTimeSamplingRate(0.5)
 	writer := testShardedWriter(t, opts)
 	writer.shardFn = func(chunkedID id.ChunkedID) uint32 {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f6d7a5598b8c8de86c3295a659ed13921c49c629d4b5252dcaa16c98b42d5fbc
-updated: 2017-09-16T17:18:21.531274261-04:00
+hash: 1897c92bc403fd6145c37c8c463b7b64e9f2f312546f603b06dcf9abfdc0ac74
+updated: 2017-09-25T10:25:52.233412457-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -146,7 +146,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 8f664bcaa26b6a844a479a71aa98d014eaaba748
+  version: c45bed752fb0d4e16bf56322adedfb4a03c29972
   subpackages:
   - generated/proto/schema
   - metric/aggregated

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
 - package: github.com/m3db/m3cluster
   version: 3ca6883175651960ca2f93ba91198bbb9a84f5be
 - package: github.com/m3db/m3metrics
-  version: 8f664bcaa26b6a844a479a71aa98d014eaaba748
+  version: c45bed752fb0d4e16bf56322adedfb4a03c29972
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x


### PR DESCRIPTION
cc @jeromefroe @cw9 @prateek 

This PR adds logic to support including encoding time when writing aggregate metrics, which allows us to compute end-to-end latency metrics (e.g., prior to ingest).