### PR TITLE
Remove deferred return and func for CPU savings

### DIFF
--- a/aggregator/placement_mgr.go
+++ b/aggregator/placement_mgr.go
@@ -209,6 +209,9 @@ func (mgr *placementManager) placementWithLock() (placement.Placement, error) {
 	if mgr.state != placementManagerOpen {
 		return nil, errPlacementManagerNotOpenOrClosed
 	}
+
+	// NB(xichen): avoid using defer here because this is called on the write path
+	// for every incoming metric and defered return and func execution is expensive.
 	stagedPlacement, onStagedPlacementDoneFn, err := mgr.placementWatcher.ActiveStagedPlacement()
 	if err != nil {
 		mgr.metrics.activeStagedPlacementErrors.Inc(1)

--- a/aggregator/placement_mgr.go
+++ b/aggregator/placement_mgr.go
@@ -214,14 +214,14 @@ func (mgr *placementManager) placementWithLock() (placement.Placement, error) {
 		mgr.metrics.activeStagedPlacementErrors.Inc(1)
 		return nil, err
 	}
-	defer onStagedPlacementDoneFn()
-
 	placement, onPlacementDoneFn, err := stagedPlacement.ActivePlacement()
 	if err != nil {
+		onStagedPlacementDoneFn()
 		mgr.metrics.activePlacementErrors.Inc(1)
 		return nil, err
 	}
-	defer onPlacementDoneFn()
+	onPlacementDoneFn()
+	onStagedPlacementDoneFn()
 	return placement, nil
 }
 


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR removes deferred return and func execution in `Placement` on the hot path to save 2% CPU.