### PR TITLE
Pull in latest m3x and replace MD5 with 128-bit murmur3 for id hash

### DIFF
--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -39,7 +39,7 @@ var (
 
 type entryKey struct {
 	metricType unaggregated.Type
-	idHash     xid.Hash
+	idHash     xid.Hash128
 }
 
 type hashedEntry struct {
@@ -99,7 +99,7 @@ func (m *metricMap) AddMetricWithPoliciesList(
 ) error {
 	entryKey := entryKey{
 		metricType: mu.Type,
-		idHash:     xid.HashFn(mu.ID),
+		idHash:     xid.Murmur3Hash128(mu.ID),
 	}
 	e := m.findOrCreate(entryKey)
 	err := e.AddMetricWithPoliciesList(mu, pl)

--- a/aggregator/map_test.go
+++ b/aggregator/map_test.go
@@ -58,7 +58,7 @@ func TestMetricMapAddMetricWithPoliciesList(t *testing.T) {
 	// Add a counter metric and assert there is one entry afterwards.
 	key := entryKey{
 		metricType: unaggregated.CounterType,
-		idHash:     xid.HashFn(testCounterID),
+		idHash:     xid.Murmur3Hash128(testCounterID),
 	}
 	require.NoError(t, m.AddMetricWithPoliciesList(testCounter, policies))
 	require.Equal(t, 1, len(m.entries))
@@ -86,7 +86,7 @@ func TestMetricMapAddMetricWithPoliciesList(t *testing.T) {
 	// now two entries.
 	key2 := entryKey{
 		metricType: unaggregated.GaugeType,
-		idHash:     xid.HashFn(testCounterID),
+		idHash:     xid.Murmur3Hash128(testCounterID),
 	}
 	metricWithDifferentType := unaggregated.MetricUnion{
 		Type:     unaggregated.GaugeType,
@@ -152,7 +152,7 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 	for i := 0; i < numEntries; i++ {
 		key := entryKey{
 			metricType: unaggregated.CounterType,
-			idHash:     xid.HashFn([]byte(fmt.Sprintf("%d", i))),
+			idHash:     xid.Murmur3Hash128([]byte(fmt.Sprintf("%d", i))),
 		}
 		if i%2 == 0 {
 			m.entries[key] = m.entryList.PushBack(hashedEntry{

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1897c92bc403fd6145c37c8c463b7b64e9f2f312546f603b06dcf9abfdc0ac74
-updated: 2017-09-25T10:25:52.233412457-04:00
+hash: da55b350ed96c1678fe74cdf6f9e973ff35b295b91ecc279b48ecfbf8eca5a57
+updated: 2017-09-27T15:16:13.691186671-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -155,7 +155,7 @@ imports:
   - policy
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: 6e9713eca6718643e105f574be392f122bcc062e
+  version: 118fa2f66efa708eb1afdcd756c4da0ec6a8848e
   subpackages:
   - checked
   - clock

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x
-  version: 6e9713eca6718643e105f574be392f122bcc062e
+  version: 118fa2f66efa708eb1afdcd756c4da0ec6a8848e
 - package: github.com/uber-go/tally
   version: ^3.1.0
 - package: github.com/golang/protobuf


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR pulls in latest m3x and replaces MD5 with 128-bit murmur3 as the id hashing function for improved efficiency with equally good if not better collision rate.