### PR TITLE
Update m3cluster and m3metrics

### DIFF
--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -101,7 +101,6 @@ aggregator:
           capacity: 32
         - count: 1024
           capacity: 64
-  electionKVNamespace: /r2/m3aggregator
   kvConfig:
     namespace: /r2/m3aggregator
     environment: production

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -101,7 +101,10 @@ aggregator:
           capacity: 32
         - count: 1024
           capacity: 64
-  kvNamespace: /r2/m3aggregator
+  electionKVNamespace: /r2/m3aggregator
+  kvConfig:
+    namespace: /r2/m3aggregator
+    environment: production
   placementManager:
     placementWatcher:
       key: placement

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dd6ec7151ea97dd16f73f4ec8e71ddb8bd198e36424bad0a835217b58c0c722b
-updated: 2017-09-28T10:39:56.542873781-04:00
+hash: c44d4ae50c7bd0c6c041964ca9442def9398debcdb28573732c8981796be3f91
+updated: 2017-09-29T17:42:36.458843873-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -122,7 +122,7 @@ imports:
 - name: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
 - name: github.com/m3db/m3cluster
-  version: c08a9f9c8ed09f2419fa16718db294bd3121a484
+  version: d9fd14a38efe2eaf43b9a52350055fbd2dac06ec
   subpackages:
   - client
   - client/etcd
@@ -146,7 +146,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: c45bed752fb0d4e16bf56322adedfb4a03c29972
+  version: 82d18cdd2a24502c6a170b6bfea01c30685e5b26
   subpackages:
   - generated/proto/schema
   - metric/aggregated
@@ -252,8 +252,6 @@ imports:
   - trace
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
-  subpackages:
-  - unix
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,9 +4,9 @@ import:
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
 - package: github.com/m3db/m3cluster
-  version: c08a9f9c8ed09f2419fa16718db294bd3121a484
+  version: d9fd14a38efe2eaf43b9a52350055fbd2dac06ec
 - package: github.com/m3db/m3metrics
-  version: c45bed752fb0d4e16bf56322adedfb4a03c29972
+  version: 82d18cdd2a24502c6a170b6bfea01c30685e5b26
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 - package: github.com/m3db/m3x

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -120,9 +120,6 @@ type AggregatorConfiguration struct {
 	// Client configuration for key value store.
 	KVClient kvClientConfiguration `yaml:"kvClient" validate:"nonzero"`
 
-	// Election KV namespace.
-	ElectionKVNamespace string `yaml:"electionKVNamespace" validate:"nonzero"`
-
 	// KV configuration.
 	KVConfig kv.Configuration `yaml:"kvConfig"`
 
@@ -294,7 +291,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	electionManager, err := c.ElectionManager.NewElectionManager(
 		client,
 		instanceID,
-		c.ElectionKVNamespace,
+		c.KVConfig.Namespace,
 		placementManager,
 		flushTimesManager,
 		iOpts,

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -120,8 +120,11 @@ type AggregatorConfiguration struct {
 	// Client configuration for key value store.
 	KVClient kvClientConfiguration `yaml:"kvClient" validate:"nonzero"`
 
-	// KV namespace.
-	KVNamespace string `yaml:"kvNamespace" validate:"nonzero"`
+	// Election KV namespace.
+	ElectionKVNamespace string `yaml:"electionKVNamespace" validate:"nonzero"`
+
+	// KV configuration.
+	KVConfig kv.Configuration `yaml:"kvConfig"`
 
 	// Placement manager.
 	PlacementManager placementManagerConfiguration `yaml:"placementManager"`
@@ -245,7 +248,9 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	if err != nil {
 		return nil, err
 	}
-	store, err := client.Store(c.KVNamespace)
+
+	// The store is shared between placement manager and flush times manager.
+	store, err := client.Store(c.KVConfig.NewOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +294,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	electionManager, err := c.ElectionManager.NewElectionManager(
 		client,
 		instanceID,
-		c.KVNamespace,
+		c.ElectionKVNamespace,
 		placementManager,
 		flushTimesManager,
 		iOpts,


### PR DESCRIPTION
Use kv configuration from m3cluster
Decouple the election kv namespace with the kv config, so they don't have to be the same namespace(although they still can)

@xichen2020 @jeromefroe 