### PR TITLE
Retain flush times seen for KV persistence

### DIFF
--- a/aggregator/follower_flush_mgr.go
+++ b/aggregator/follower_flush_mgr.go
@@ -33,10 +33,6 @@ import (
 	"github.com/uber-go/tally"
 )
 
-const (
-	defaultInitialFlushTimesCapacity = 16
-)
-
 type followerFlushManagerMetrics struct {
 	watchCreateErrors    tally.Counter
 	shardNotFound        tally.Counter

--- a/aggregator/follower_flush_mgr_test.go
+++ b/aggregator/follower_flush_mgr_test.go
@@ -55,7 +55,7 @@ func TestFollowerFlushManagerOpen(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	require.Equal(t, testFlushTimes, mgr.proto)
+	require.Equal(t, testFlushTimes, mgr.received)
 	close(doneCh)
 	mgr.Close()
 }
@@ -87,7 +87,7 @@ func TestFollowerFlushManagerCanNotLeadFlushWindowsNotEnded(t *testing.T) {
 	}
 	opts := NewFlushManagerOptions().SetElectionManager(electionManager)
 	mgr := newFollowerFlushManager(doneCh, opts).(*followerFlushManager)
-	mgr.proto = testFlushTimes
+	mgr.processed = testFlushTimes
 	mgr.openedAt = time.Unix(3624, 0)
 	require.False(t, mgr.CanLead())
 }
@@ -100,7 +100,7 @@ func TestFollowerFlushManagerCanLead(t *testing.T) {
 	opts := NewFlushManagerOptions().SetElectionManager(electionManager)
 	mgr := newFollowerFlushManager(doneCh, opts).(*followerFlushManager)
 	mgr.flushTimesState = flushTimesProcessed
-	mgr.proto = testFlushTimes
+	mgr.processed = testFlushTimes
 	mgr.openedAt = time.Unix(3599, 0)
 	require.True(t, mgr.CanLead())
 }
@@ -135,7 +135,7 @@ func TestFollowerFlushManagerPrepareFlushTimesUpdated(t *testing.T) {
 	mgr := newFollowerFlushManager(doneCh, opts).(*followerFlushManager)
 	mgr.nowFn = nowFn
 	mgr.flushTimesState = flushTimesUpdated
-	mgr.proto = testFlushTimes
+	mgr.received = testFlushTimes
 
 	flushTask, dur := mgr.Prepare(testFlushBuckets)
 
@@ -278,7 +278,7 @@ func TestFollowerFlushManagerWatchFlushTimes(t *testing.T) {
 	require.NoError(t, err)
 	for {
 		mgr.RLock()
-		proto := mgr.proto
+		proto := mgr.received
 		flushTimesState := mgr.flushTimesState
 		mgr.RUnlock()
 		if flushTimesState == flushTimesUpdated {


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds logic to retain flush times seen for kv persistence to fix a race condition during a topology change in which the leader instance closes a leaving shard and updates the persisted flush times before the follower instance gets a chance to process the persisted flush times in order to close the leaving shard.

The PR also refactored the follower flush manager and distinguishes between received flush times and process times, the latter of which is used to determine whether the follower instance can take over leadership, which is safer than using received times for that purpose.