### PR TITLE
Rate limiting per-metric writes

### DIFF
--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -496,6 +496,11 @@ func (e *Entry) resetRateLimiterWithLock(runtimeOpts runtime.Options) {
 		e.rateLimiter = nil
 		return
 	}
+	if e.rateLimiter == nil {
+		nowFn := e.opts.ClockOptions().NowFn()
+		e.rateLimiter = rate.NewLimiter(newLimit, nowFn)
+		return
+	}
 	e.rateLimiter.Reset(newLimit)
 }
 

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/m3db/m3aggregator/rate"
+	"github.com/m3db/m3aggregator/runtime"
 	metricid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
@@ -37,12 +39,15 @@ import (
 )
 
 var (
-	errEmptyPoliciesList = errors.New("empty policies list")
-	errEntryClosed       = errors.New("entry is closed")
+	errEmptyPoliciesList      = errors.New("empty policies list")
+	errEntryClosed            = errors.New("entry is closed")
+	errEntryRateLimitExceeded = errors.New("entry rate limit is exceeded")
 )
 
 type entryMetrics struct {
 	emptyPoliciesList tally.Counter
+	rateLimitExceeded tally.Counter
+	droppedValues     tally.Counter
 	stalePolicy       tally.Counter
 	futurePolicy      tally.Counter
 	tombstonedPolicy  tally.Counter
@@ -52,6 +57,8 @@ type entryMetrics struct {
 func newEntryMetrics(scope tally.Scope) entryMetrics {
 	return entryMetrics{
 		emptyPoliciesList: scope.Counter("empty-policies-list"),
+		rateLimitExceeded: scope.Counter("rate-limit-exceeded"),
+		droppedValues:     scope.Counter("dropped-values"),
 		stalePolicy:       scope.Counter("stale-policy"),
 		futurePolicy:      scope.Counter("future-policy"),
 		tombstonedPolicy:  scope.Counter("tombstoned-policy"),
@@ -65,6 +72,7 @@ type Entry struct {
 
 	closed                 bool
 	opts                   Options
+	rateLimiter            *rate.Limiter
 	hasDefaultPoliciesList bool
 	useDefaultPolicies     bool
 	cutoverNanos           int64
@@ -79,14 +87,14 @@ type Entry struct {
 }
 
 // NewEntry creates a new entry.
-func NewEntry(lists *metricLists, opts Options) *Entry {
+func NewEntry(lists *metricLists, runtimeOpts runtime.Options, opts Options) *Entry {
 	scope := opts.InstrumentOptions().MetricsScope().SubScope("entry")
 	e := &Entry{
 		aggregations: make(map[policy.Policy]*list.Element),
 		metrics:      newEntryMetrics(scope),
 		decompressor: policy.NewPooledAggregationIDDecompressor(opts.AggregationTypesOptions().AggregationTypesPool()),
 	}
-	e.ResetSetData(lists, opts)
+	e.ResetSetData(lists, runtimeOpts, opts)
 	return e
 }
 
@@ -99,15 +107,29 @@ func (e *Entry) DecWriter() { atomic.AddInt32(&e.numWriters, -1) }
 // ResetSetData resets the entry and sets initial data.
 // NB(xichen): we need to reset the options here to use the correct
 // time lock contained in the options.
-func (e *Entry) ResetSetData(lists *metricLists, opts Options) {
+func (e *Entry) ResetSetData(lists *metricLists, runtimeOpts runtime.Options, opts Options) {
+	e.Lock()
 	e.closed = false
 	e.opts = opts
+	e.resetRateLimiterWithLock(runtimeOpts)
 	e.hasDefaultPoliciesList = false
 	e.useDefaultPolicies = false
 	e.cutoverNanos = uninitializedCutoverNanos
 	e.lists = lists
 	e.numWriters = 0
 	e.recordLastAccessed(e.opts.ClockOptions().NowFn()())
+	e.Unlock()
+}
+
+// SetRuntimeOptions updates the parameters of the rate limiter.
+func (e *Entry) SetRuntimeOptions(opts runtime.Options) {
+	e.Lock()
+	if e.closed {
+		e.Unlock()
+		return
+	}
+	e.resetRateLimiterWithLock(opts)
+	e.Unlock()
 }
 
 // AddMetricWithPoliciesList adds a metric along with applicable policies list.
@@ -117,12 +139,19 @@ func (e *Entry) AddMetricWithPoliciesList(
 ) error {
 	switch mu.Type {
 	case unaggregated.BatchTimerType:
-		err := e.writeBatchTimerWithPoliciesList(mu, pl)
+		var err error
+		if err = e.applyRateLimit(int64(len(mu.BatchTimerVal))); err == nil {
+			err = e.writeBatchTimerWithPoliciesList(mu, pl)
+		}
 		if mu.BatchTimerVal != nil && mu.TimerValPool != nil {
 			mu.TimerValPool.Put(mu.BatchTimerVal)
 		}
 		return err
 	default:
+		// For counters and gauges, there is a single value in the metric union.
+		if err := e.applyRateLimit(1); err != nil {
+			return err
+		}
 		return e.addMetricWithPoliciesList(mu, pl)
 	}
 }
@@ -459,4 +488,28 @@ func (e *Entry) shouldExpire(now time.Time) bool {
 	// Only expire the entry if there are no active writers
 	// and it has reached its ttl since last accessed.
 	return e.writerCount() == 0 && now.After(e.lastAccessed().Add(e.opts.EntryTTL()))
+}
+
+func (e *Entry) resetRateLimiterWithLock(runtimeOpts runtime.Options) {
+	newLimit := runtimeOpts.WriteValuesPerMetricLimitPerSecond()
+	if newLimit <= 0 {
+		e.rateLimiter = nil
+		return
+	}
+	e.rateLimiter.Reset(newLimit)
+}
+
+func (e *Entry) applyRateLimit(numValues int64) error {
+	e.RLock()
+	rateLimiter := e.rateLimiter
+	e.RUnlock()
+	if rateLimiter == nil {
+		return nil
+	}
+	if rateLimiter.IsAllowed(numValues) {
+		return nil
+	}
+	e.metrics.rateLimitExceeded.Inc(1)
+	e.metrics.droppedValues.Inc(numValues)
+	return errEntryRateLimitExceeded
 }

--- a/aggregator/entry_pool_test.go
+++ b/aggregator/entry_pool_test.go
@@ -23,21 +23,23 @@ package aggregator
 import (
 	"testing"
 
+	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3x/pool"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestEntryPool(t *testing.T) {
+	runtimeOpts := runtime.NewOptions()
 	p := NewEntryPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *Entry {
-		return NewEntry(nil, testOptions())
+		return NewEntry(nil, runtimeOpts, testOptions())
 	})
 
 	// Retrieve an entry from the pool.
 	entry := p.Get()
 	lists := &metricLists{}
-	entry.ResetSetData(&metricLists{}, testOptions())
+	entry.ResetSetData(&metricLists{}, runtimeOpts, testOptions())
 	require.Equal(t, lists, entry.lists)
 
 	// Put the entry back to pool.

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
@@ -57,7 +58,7 @@ var (
 )
 
 func TestEntryIncDecWriter(t *testing.T) {
-	e := NewEntry(nil, testOptions())
+	e := NewEntry(nil, runtime.NewOptions(), testOptions())
 	require.Equal(t, int32(0), e.numWriters)
 
 	var (
@@ -669,7 +670,7 @@ func TestEntryMaybeExpireWithExpiry(t *testing.T) {
 }
 
 func TestShouldUpdatePoliciesWithLock(t *testing.T) {
-	e := NewEntry(nil, testOptions())
+	e := NewEntry(nil, runtime.NewOptions(), testOptions())
 	currTimeNanos := time.Now().UnixNano()
 	inputs := []struct {
 		cutoverNanos int64
@@ -720,8 +721,9 @@ func testEntry() (*Entry, *metricLists, *time.Time) {
 		return newMetricList(testShard, 0, opts)
 	}
 
-	e := NewEntry(nil, opts)
-	e.ResetSetData(lists, opts)
+	runtimeOpts := runtime.NewOptions()
+	e := NewEntry(nil, runtimeOpts, opts)
+	e.ResetSetData(lists, runtimeOpts, opts)
 
 	return e, lists, &now
 }

--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -22,19 +22,28 @@ package aggregator
 
 import (
 	"container/list"
+	"errors"
 	"math"
 	"sync"
 	"time"
 
+	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/close"
 	xid "github.com/m3db/m3x/id"
 	"github.com/uber-go/tally"
 )
 
+const (
+	defaultSoftDeadlineCheckEvery = 128
+	defaultExpireBatchSize        = 1024
+)
+
 var (
-	emptyHashedEntry hashedEntry
+	emptyHashedEntry   hashedEntry
+	errMetricMapClosed = errors.New("metric map is already closed")
 )
 
 type entryKey struct {
@@ -68,18 +77,21 @@ type metricMap struct {
 	entryPool    EntryPool
 	batchPercent float64
 
-	metricLists *metricLists
-	entries     map[entryKey]*list.Element
-	entryList   *list.List
-	sleepFn     sleepFn
-	metrics     metricMapMetrics
+	closed            bool
+	metricLists       *metricLists
+	entries           map[entryKey]*list.Element
+	entryList         *list.List
+	entryListDelLock  sync.Mutex // Must be held when deleting elements from the entry list
+	runtimeOpts       runtime.Options
+	runtimeOptsCloser close.SimpleCloser
+	sleepFn           sleepFn
+	metrics           metricMapMetrics
 }
 
 func newMetricMap(shard uint32, opts Options) *metricMap {
 	metricLists := newMetricLists(shard, opts)
 	scope := opts.InstrumentOptions().MetricsScope().SubScope("map")
-
-	return &metricMap{
+	m := &metricMap{
 		shard:        shard,
 		opts:         opts,
 		nowFn:        opts.ClockOptions().NowFn(),
@@ -91,6 +103,13 @@ func newMetricMap(shard uint32, opts Options) *metricMap {
 		sleepFn:      time.Sleep,
 		metrics:      newMetricMapMetrics(scope),
 	}
+
+	// Register the metric map as a runtime options watcher.
+	runtimeOptsManager := opts.RuntimeOptionsManager()
+	closer := runtimeOptsManager.RegisterWatcher(m)
+	m.runtimeOptsCloser = closer
+
+	return m
 }
 
 func (m *metricMap) AddMetricWithPoliciesList(
@@ -101,9 +120,12 @@ func (m *metricMap) AddMetricWithPoliciesList(
 		metricType: mu.Type,
 		idHash:     xid.Murmur3Hash128(mu.ID),
 	}
-	e := m.findOrCreate(entryKey)
-	err := e.AddMetricWithPoliciesList(mu, pl)
-	e.DecWriter()
+	entry, err := m.findOrCreate(entryKey)
+	if err != nil {
+		return err
+	}
+	err = entry.AddMetricWithPoliciesList(mu, pl)
+	entry.DecWriter()
 	return err
 }
 
@@ -123,88 +145,62 @@ func (m *metricMap) Tick(target time.Duration) tickResult {
 	}
 }
 
+func (m *metricMap) SetRuntimeOptions(opts runtime.Options) {
+	m.Lock()
+	m.runtimeOpts = opts
+	m.Unlock()
+
+	// NB(xichen): we hold onto the entry list deletion lock here to ensure no
+	// entries get deleted while we iterate over the list, otherwise we may update
+	// entries that have expired. This only affects the ticking goroutine as that's
+	// the only goroutine deleting entries from the list, which is not performance
+	// sensitive. Entries can still be inserted into the map and the entry list in
+	// the meantime. The entry list deletion lock must be held before the map lock
+	// to avoid deadlocks.
+	m.entryListDelLock.Lock()
+	m.forEachEntry(func(entry hashedEntry) {
+		entry.entry.SetRuntimeOptions(opts)
+	})
+	m.entryListDelLock.Unlock()
+}
+
 func (m *metricMap) Close() {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.closed {
+		return
+	}
+	m.runtimeOptsCloser.Close()
 	m.metricLists.Close()
+	m.closed = true
 }
 
-func (m *metricMap) deleteExpired(target time.Duration) int {
-	now := m.nowFn()
-
-	// Determine batch size.
+func (m *metricMap) findOrCreate(key entryKey) (*Entry, error) {
 	m.RLock()
-	elemsLen := m.entryList.Len()
-	if elemsLen == 0 {
-		// If the list is empty, nothing to do.
+	if m.closed {
 		m.RUnlock()
-		return 0
+		return nil, errMetricMapClosed
 	}
-	batchSize := int(math.Max(1.0, math.Ceil(m.batchPercent*float64(elemsLen))))
-	numBatches := int(math.Ceil(float64(elemsLen) / float64(batchSize)))
-	targetPerBatch := target / time.Duration(numBatches)
-	currElem := m.entryList.Front()
-	m.RUnlock()
-
-	// NB(xichen): if this runs frequently enough, stash the expired buffer
-	// in the map object and reuse the buffer.
-	var (
-		numExpired int
-		expired    = make([]hashedEntry, 0, batchSize)
-		batchIdx   int
-	)
-	for currElem != nil {
-		m.RLock()
-		for numChecked := 0; numChecked < batchSize && currElem != nil; numChecked++ {
-			nextElem := currElem.Next()
-			hashedEntry := currElem.Value.(hashedEntry)
-			if hashedEntry.entry.ShouldExpire(now) {
-				expired = append(expired, hashedEntry)
-			}
-			currElem = nextElem
-		}
-		m.RUnlock()
-
-		// Actually purging the expired entries.
-		if len(expired) >= batchSize {
-			numExpired += m.purgeExpired(now, expired)
-			for i := range expired {
-				expired[i] = emptyHashedEntry
-			}
-			expired = expired[:0]
-		}
-
-		batchIdx++
-		targetTime := now.Add(time.Duration(batchIdx) * targetPerBatch)
-		currTime := m.nowFn()
-		if currTime.Before(targetTime) {
-			m.sleepFn(targetTime.Sub(currTime))
-		}
-	}
-
-	// Purge if there are remaining expired entries.
-	numExpired += m.purgeExpired(now, expired)
-	for i := range expired {
-		expired[i] = emptyHashedEntry
-	}
-	return numExpired
-}
-
-func (m *metricMap) findOrCreate(key entryKey) *Entry {
-	m.RLock()
 	if entry, found := m.lookupEntryWithLock(key); found {
 		// NB(xichen): it is important to increase number of writers
 		// within a lock so we can account for active writers
 		// when deleting expired entries.
 		entry.IncWriter()
 		m.RUnlock()
-		return entry
+		return entry, nil
 	}
 	m.RUnlock()
 
 	m.Lock()
+	if m.closed {
+		m.Unlock()
+		return nil, errMetricMapClosed
+	}
 	entry, found := m.lookupEntryWithLock(key)
 	if !found {
 		entry = m.entryPool.Get()
-		entry.ResetSetData(m.metricLists, m.opts)
+		entry.ResetSetData(m.metricLists, m.runtimeOpts, m.opts)
 		m.entries[key] = m.entryList.PushBack(hashedEntry{
 			key:   key,
 			entry: entry,
@@ -214,7 +210,7 @@ func (m *metricMap) findOrCreate(key entryKey) *Entry {
 	entry.IncWriter()
 	m.Unlock()
 
-	return entry
+	return entry, nil
 }
 
 func (m *metricMap) lookupEntryWithLock(key entryKey) (*Entry, bool) {
@@ -225,11 +221,57 @@ func (m *metricMap) lookupEntryWithLock(key entryKey) (*Entry, bool) {
 	return elem.Value.(hashedEntry).entry, true
 }
 
+func (m *metricMap) deleteExpired(target time.Duration) int {
+	// Determine batch size.
+	m.RLock()
+	numEntries := m.entryList.Len()
+	m.RUnlock()
+	if numEntries == 0 {
+		return 0
+	}
+
+	var (
+		start                = m.nowFn()
+		perEntrySoftDeadline = target / time.Duration(numEntries)
+		expired              []hashedEntry
+		numExpired           int
+		entryIdx             int
+	)
+	m.forEachEntry(func(entry hashedEntry) {
+		now := m.nowFn()
+		if entryIdx > 0 && entryIdx%defaultSoftDeadlineCheckEvery == 0 {
+			targetDeadline := start.Add(time.Duration(entryIdx) * perEntrySoftDeadline)
+			if now.Before(targetDeadline) {
+				m.sleepFn(targetDeadline.Sub(now))
+			}
+		}
+		if entry.entry.ShouldExpire(now) {
+			expired = append(expired, entry)
+		}
+		if len(expired) >= defaultExpireBatchSize {
+			numExpired += m.purgeExpired(now, expired)
+			for i := range expired {
+				expired[i] = emptyHashedEntry
+			}
+			expired = expired[:0]
+		}
+		entryIdx++
+	})
+
+	// Purge remaining expired entries.
+	numExpired += m.purgeExpired(m.nowFn(), expired)
+	for i := range expired {
+		expired[i] = emptyHashedEntry
+	}
+	return numExpired
+}
+
 func (m *metricMap) purgeExpired(now time.Time, entries []hashedEntry) int {
 	if len(entries) == 0 {
 		return 0
 	}
 	var numExpired int
+	m.entryListDelLock.Lock()
 	m.Lock()
 	for i := range entries {
 		if entries[i].entry.TryExpire(now) {
@@ -241,5 +283,42 @@ func (m *metricMap) purgeExpired(now time.Time, entries []hashedEntry) int {
 		}
 	}
 	m.Unlock()
+	m.entryListDelLock.Unlock()
 	return numExpired
 }
+
+func (m *metricMap) forEachEntry(entryFn hashedEntryFn) {
+	// Determine batch size.
+	m.RLock()
+	elemsLen := m.entryList.Len()
+	if elemsLen == 0 {
+		// If the list is empty, nothing to do.
+		m.RUnlock()
+		return
+	}
+	batchSize := int(math.Max(1.0, math.Ceil(m.batchPercent*float64(elemsLen))))
+	currElem := m.entryList.Front()
+	m.RUnlock()
+
+	currEntries := make([]hashedEntry, 0, batchSize)
+	for currElem != nil {
+		m.RLock()
+		for numChecked := 0; numChecked < batchSize && currElem != nil; numChecked++ {
+			nextElem := currElem.Next()
+			hashedEntry := currElem.Value.(hashedEntry)
+			currEntries = append(currEntries, hashedEntry)
+			currElem = nextElem
+		}
+		m.RUnlock()
+
+		for _, entry := range currEntries {
+			entryFn(entry)
+		}
+		for i := range currEntries {
+			currEntries[i] = emptyHashedEntry
+		}
+		currEntries = currEntries[:0]
+	}
+}
+
+type hashedEntryFn func(hashedEntry)

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
+	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 
@@ -117,6 +118,12 @@ func TestSetStreamOptions(t *testing.T) {
 	value := cm.NewOptions()
 	o := NewOptions().SetStreamOptions(value)
 	require.Equal(t, value, o.StreamOptions())
+}
+
+func TestSetRuntimeOptionsManager(t *testing.T) {
+	value := runtime.NewOptionsManager(runtime.NewOptions())
+	o := NewOptions().SetRuntimeOptionsManager(value)
+	require.Equal(t, value, o.RuntimeOptionsManager())
 }
 
 func TestSetTimeLock(t *testing.T) {

--- a/aggregator/types.go
+++ b/aggregator/types.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
+	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3aggregator/sharding"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/policy"
@@ -172,6 +173,12 @@ type Options interface {
 
 	// StreamOptions returns the stream options
 	StreamOptions() cm.Options
+
+	// SetRuntimeOptionsManager sets the runtime options manager.
+	SetRuntimeOptionsManager(value runtime.OptionsManager) Options
+
+	// RuntimeOptionsManager returns the runtime options manager.
+	RuntimeOptionsManager() runtime.OptionsManager
 
 	// SetPlacementManager sets the placement manager.
 	SetPlacementManager(value PlacementManager) Options

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -97,7 +97,7 @@ aggregator:
       namespace: /m3aggregator
       environment: production
     writeValuesPerMetricLimitPerSecondKey: write-values-per-metric-limit-per-second
-    WriteValuesPerMetricLimitPerSecond: 0
+    writeValuesPerMetricLimitPerSecond: 0
   placementManager:
     kvConfig:
       namespace: /m3aggregator

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -92,6 +92,12 @@ aggregator:
           capacity: 32
         - count: 1024
           capacity: 64
+  runtimeOptions:
+    kvConfig:
+      namespace: /m3aggregator
+      environment: production
+    writeValuesPerMetricLimitPerSecondKey: write-values-per-metric-limit-per-second
+    WriteValuesPerMetricLimitPerSecond: 0
   placementManager:
     kvConfig:
       namespace: /m3aggregator

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2624d975a0deecfd7f724138b03592b300b17a5fb27100409fd4696d5f93f54f
-updated: 2017-10-27T10:42:18.909801706-04:00
+hash: ac54e6a48785818dc577e5052ad2e0d5de0c67ae6294aeb185319f9af19b81c1
+updated: 2017-11-14T13:01:00.610845883-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -122,11 +122,12 @@ imports:
 - name: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
 - name: github.com/m3db/m3cluster
-  version: c4d51f0f5087606ca27680e816d318bdd6c6a9bf
+  version: 0a2ae629245846795d5a745c6b611ace641d7363
   subpackages:
   - client
   - client/etcd
   - etcd/watchmanager
+  - generated/proto/commonpb
   - generated/proto/metadatapb
   - generated/proto/placementpb
   - kv
@@ -253,6 +254,8 @@ imports:
   - trace
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  subpackages:
+  - unix
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ac54e6a48785818dc577e5052ad2e0d5de0c67ae6294aeb185319f9af19b81c1
-updated: 2017-11-14T13:01:00.610845883-05:00
+updated: 2017-11-14T16:11:53.226401058-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -133,6 +133,7 @@ imports:
   - kv
   - kv/etcd
   - kv/mem
+  - kv/util
   - kv/util/runtime
   - placement
   - placement/algo
@@ -239,6 +240,8 @@ imports:
   version: 988f4f24992fc745de53c42df0da6581e42a6686
 - name: github.com/xiang90/probing
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
+- name: go.uber.org/atomic
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
 - package: github.com/m3db/m3cluster
-  version: c4d51f0f5087606ca27680e816d318bdd6c6a9bf
+  version: 0a2ae629245846795d5a745c6b611ace641d7363
 - package: github.com/m3db/m3metrics
   version: de92bc7d4f57cdfc084f3ebd76c9ec599ef8dc11
 - package: google.golang.org/appengine

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3aggregator/aggregator"
+	"github.com/m3db/m3aggregator/runtime"
 	httpserver "github.com/m3db/m3aggregator/server/http"
 	msgpackserver "github.com/m3db/m3aggregator/server/msgpack"
 	"github.com/m3db/m3aggregator/services/m3aggregator/serve"
@@ -122,9 +123,10 @@ func newTestSetup(t *testing.T, opts testOptions) *testSetup {
 	aggregatorOpts := aggregator.NewOptions()
 	clockOpts := aggregatorOpts.ClockOptions()
 	aggregatorOpts = aggregatorOpts.SetClockOptions(clockOpts.SetNowFn(getNowFn))
+	runtimeOpts := runtime.NewOptions()
 	entryPool := aggregator.NewEntryPool(nil)
 	entryPool.Init(func() *aggregator.Entry {
-		return aggregator.NewEntry(nil, aggregatorOpts)
+		return aggregator.NewEntry(nil, runtimeOpts, aggregatorOpts)
 	})
 	aggregatorOpts = aggregatorOpts.SetEntryPool(entryPool)
 

--- a/rate/limiter.go
+++ b/rate/limiter.go
@@ -60,6 +60,10 @@ func (l *Limiter) Limit() int64 {
 }
 
 // IsAllowed returns whether n events may happen now.
+// NB(xichen): If a large request comes in, this could potentially block following
+// requests in the same second from going through. This is a non-issue if the limit
+// is much bigger than the typical batch size, which is indeed the case in the aggregation
+// layer as each batch size is usually fairly small.
 func (l *Limiter) IsAllowed(n int64) bool {
 	alignedNow := l.nowFn().Truncate(time.Second)
 	l.RLock()

--- a/rate/limiter.go
+++ b/rate/limiter.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rate
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+)
+
+var (
+	zeroTime = time.Unix(0, 0)
+)
+
+// Limiter is a simple rate limiter to control how frequently events are allowed to happen.
+type Limiter struct {
+	sync.RWMutex
+
+	limitPerSecond int64
+	nowFn          clock.NowFn
+
+	alignedLast time.Time
+	allowed     int64
+}
+
+// NewLimiter creates a new rate limiter.
+func NewLimiter(l int64, fn clock.NowFn) *Limiter {
+	return &Limiter{
+		limitPerSecond: l,
+		nowFn:          fn,
+	}
+}
+
+// IsAllowed returns whether n events may happen now.
+func (l *Limiter) IsAllowed(n int64) bool {
+	alignedNow := l.nowFn().Truncate(time.Second)
+	l.RLock()
+	if !alignedNow.After(l.alignedLast) {
+		isAllowed := atomic.AddInt64(&l.allowed, n) <= l.limitPerSecond
+		l.RUnlock()
+		return isAllowed
+	}
+	l.RUnlock()
+
+	l.Lock()
+	if !alignedNow.After(l.alignedLast) {
+		isAllowed := atomic.AddInt64(&l.allowed, n) <= l.limitPerSecond
+		l.Unlock()
+		return isAllowed
+	}
+	l.alignedLast = alignedNow
+	l.allowed = n
+	isAllowed := l.allowed <= l.limitPerSecond
+	l.Unlock()
+	return isAllowed
+}
+
+// Reset resets the internal state.
+func (l *Limiter) Reset(limit int64) {
+	l.Lock()
+	l.alignedLast = zeroTime
+	l.allowed = 0
+	l.limitPerSecond = limit
+	l.Unlock()
+}

--- a/rate/limiter.go
+++ b/rate/limiter.go
@@ -51,6 +51,14 @@ func NewLimiter(l int64, fn clock.NowFn) *Limiter {
 	}
 }
 
+// Limit returns the current limit.
+func (l *Limiter) Limit() int64 {
+	l.RLock()
+	limit := l.limitPerSecond
+	l.RUnlock()
+	return limit
+}
+
 // IsAllowed returns whether n events may happen now.
 func (l *Limiter) IsAllowed(n int64) bool {
 	alignedNow := l.nowFn().Truncate(time.Second)

--- a/rate/limiter_test.go
+++ b/rate/limiter_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiterLimit(t *testing.T) {
+	allowedPerSecond := int64(10)
+	now := time.Now().Truncate(time.Second)
+	nowFn := func() time.Time { return now }
+
+	limiter := NewLimiter(allowedPerSecond, nowFn)
+	require.Equal(t, allowedPerSecond, limiter.Limit())
+}
+
+func TestLimiterIsAllowed(t *testing.T) {
+	allowedPerSecond := int64(10)
+	now := time.Now().Truncate(time.Second)
+	nowFn := func() time.Time { return now }
+
+	limiter := NewLimiter(allowedPerSecond, nowFn)
+	require.True(t, limiter.IsAllowed(5))
+	for i := 0; i < 5; i++ {
+		now = now.Add(100 * time.Millisecond)
+		require.True(t, limiter.IsAllowed(1))
+	}
+	require.False(t, limiter.IsAllowed(1))
+
+	// Advance time to the next second and confirm the quota is reset.
+	now = now.Add(time.Second)
+	require.True(t, limiter.IsAllowed(5))
+}
+
+func TestLimiterReset(t *testing.T) {
+	allowedPerSecond := int64(10)
+	now := time.Now().Truncate(time.Second)
+	nowFn := func() time.Time { return now }
+
+	limiter := NewLimiter(allowedPerSecond, nowFn)
+	require.False(t, limiter.IsAllowed(20))
+
+	// Resetting to a higher limit and confirm all requests are allowed.
+	limiter.Reset(20)
+	require.True(t, limiter.IsAllowed(20))
+}

--- a/runtime/options.go
+++ b/runtime/options.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+const (
+	// A default rate limit value of 0 means rate limiting is disabled.
+	defaultWriteValuesPerMetricLimitPerSecond = 0
+)
+
+// Options provide a set of options that are configurable at runtime.
+type Options interface {
+	// SetWriteValuesPerMetricLimitPerSecond sets the rate limit used
+	// to cap the maximum number of values allowed to be written per second.
+	SetWriteValuesPerMetricLimitPerSecond(value int64) Options
+
+	// WriteValuesPerMetricLimitPerSecond returns the rate limit used
+	// to cap the maximum number of values allowed to be written per second.
+	WriteValuesPerMetricLimitPerSecond() int64
+}
+
+type options struct {
+	writeValuesPerMetricLimitPerSecond int64
+}
+
+// NewOptions creates a new set of runtime options.
+func NewOptions() Options {
+	return &options{
+		writeValuesPerMetricLimitPerSecond: defaultWriteValuesPerMetricLimitPerSecond,
+	}
+}
+
+func (o *options) SetWriteValuesPerMetricLimitPerSecond(value int64) Options {
+	opts := *o
+	opts.writeValuesPerMetricLimitPerSecond = value
+	return &opts
+}
+
+func (o *options) WriteValuesPerMetricLimitPerSecond() int64 {
+	return o.writeValuesPerMetricLimitPerSecond
+}

--- a/runtime/options_manager.go
+++ b/runtime/options_manager.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+import (
+	"github.com/m3db/m3x/close"
+	"github.com/m3db/m3x/watch"
+)
+
+// OptionsManager manages runtime options.
+type OptionsManager interface {
+	// SetRuntimeOptions sets the runtime options.
+	SetRuntimeOptions(value Options)
+
+	// RuntimeOptions returns the current runtime options.
+	RuntimeOptions() Options
+
+	// RegisterWatcher registers a watcher that watches updates to runtime options.
+	// When an update arrives, the manager will deliver the update to all registered
+	// watchers.
+	RegisterWatcher(l OptionsWatcher) close.SimpleCloser
+
+	// Close closes the watcher and all descendent watches
+	Close()
+}
+
+// OptionsWatcher watches for updates to runtime options.
+type OptionsWatcher interface {
+	// SetRuntimeOptions is called for registerer watchers when the runtime options
+	// are updated, passing in the updated options as the argument.
+	SetRuntimeOptions(value Options)
+}
+
+type optionsManager struct {
+	watchable watch.Watchable
+}
+
+// NewOptionsManager creates a new runtime options manager.
+func NewOptionsManager(initialValue Options) OptionsManager {
+	watchable := watch.NewWatchable()
+	watchable.Update(initialValue)
+	return &optionsManager{
+		watchable: watchable,
+	}
+}
+
+func (w *optionsManager) SetRuntimeOptions(value Options) {
+	w.watchable.Update(value)
+}
+
+func (w *optionsManager) RuntimeOptions() Options {
+	return w.watchable.Get().(Options)
+}
+
+func (w *optionsManager) RegisterWatcher(
+	watcher OptionsWatcher,
+) close.SimpleCloser {
+	_, watch, _ := w.watchable.Watch()
+
+	// The watchable is always initialized so it's okay to do a blocking read.
+	<-watch.C()
+
+	// Deliver the current runtime options.
+	watcher.SetRuntimeOptions(watch.Get().(Options))
+
+	// Spawn a new goroutine that will terminate when the
+	// watchable terminates on the close of the runtime options manager.
+	go func() {
+		for range watch.C() {
+			watcher.SetRuntimeOptions(watch.Get().(Options))
+		}
+	}()
+
+	return watch
+}
+
+func (w *optionsManager) Close() {
+	w.watchable.Close()
+}

--- a/runtime/options_manager_test.go
+++ b/runtime/options_manager_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuntimeOptionsManagerUpdate(t *testing.T) {
+	limit := int64(100)
+	opts := NewOptions().SetWriteValuesPerMetricLimitPerSecond(limit)
+	mgr := NewOptionsManager(opts)
+
+	assert.Equal(t, limit, mgr.RuntimeOptions().WriteValuesPerMetricLimitPerSecond())
+
+	w := &mockWatcher{}
+	assert.Nil(t, w.value)
+
+	// Ensure immediately sets the value.
+	mgr.RegisterWatcher(w)
+	assert.Equal(t, opts, w.runtimeOptions())
+
+	// Update and verify.
+	newLimit := int64(200)
+	mgr.SetRuntimeOptions(opts.SetWriteValuesPerMetricLimitPerSecond(newLimit))
+
+	// Verify watcher receives update.
+	for {
+		if w.runtimeOptions().WriteValuesPerMetricLimitPerSecond() == newLimit {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type mockWatcher struct {
+	sync.RWMutex
+
+	value Options
+}
+
+func (m *mockWatcher) SetRuntimeOptions(value Options) {
+	m.Lock()
+	m.value = value
+	m.Unlock()
+}
+
+func (m *mockWatcher) runtimeOptions() Options {
+	m.RLock()
+	value := m.value
+	m.RUnlock()
+	return value
+}

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -98,6 +98,8 @@ func (s *handler) Handle(conn net.Conn) {
 		if err := s.aggregator.AddMetricWithPoliciesList(metric, policiesList); err != nil {
 			// We sample the error log here because the error rate may scale with
 			// the metrics incoming rate and consume lots of cpu cycles.
+			// TODO(xichen): need to sample this in case there's a large number of errors
+			// due to rate limiting etc.
 			if s.rand.Float64() < s.errLogSamplingRate {
 				s.log.WithFields(
 					log.NewField("metric", metric.String()),

--- a/services/m3aggregator/config/aggregator_test.go
+++ b/services/m3aggregator/config/aggregator_test.go
@@ -87,7 +87,7 @@ writeValuesPerMetricLimitPerSecond: 0
 	logger := log.NewLevelLogger(log.SimpleLogger, log.LevelInfo)
 	mockClient := client.NewMockClient(ctrl)
 	mockClient.EXPECT().Store(gomock.Any()).Return(memStore, nil)
-	_, runtimeOptsManager, err := runtimeOptionsCfg.NewRuntimeOptionsManager(mockClient, logger)
+	runtimeOptsManager, err := runtimeOptionsCfg.NewRuntimeOptionsManager(mockClient, logger)
 	require.NoError(t, err)
 	require.Equal(t, initialLimit, runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond())
 
@@ -97,6 +97,15 @@ writeValuesPerMetricLimitPerSecond: 0
 	require.NoError(t, err)
 	for {
 		if runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond() == newLimit {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_, err = memStore.Delete("rate-limit-key")
+	require.NoError(t, err)
+	for {
+		if runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond() == 0 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/services/m3aggregator/config/aggregator_test.go
+++ b/services/m3aggregator/config/aggregator_test.go
@@ -24,6 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/generated/proto/commonpb"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3x/log"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -56,5 +62,43 @@ func TestJitterBuckets(t *testing.T) {
 	}
 	for _, input := range inputs {
 		require.Equal(t, input.expectedMaxJitter, maxJitterFn(input.interval))
+	}
+}
+
+func TestRuntimeOptionsConfigurationNewRuntimeOptionsManager(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	config := `
+kvConfig:
+  environment: production
+writeValuesPerMetricLimitPerSecondKey: rate-limit-key
+writeValuesPerMetricLimitPerSecond: 0
+`
+	var runtimeOptionsCfg runtimeOptionsConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(config), &runtimeOptionsCfg))
+
+	initialLimit := int64(100)
+	proto := &commonpb.Int64Proto{Value: initialLimit}
+	memStore := mem.NewStore()
+	_, err := memStore.Set("rate-limit-key", proto)
+	require.NoError(t, err)
+
+	logger := log.NewLevelLogger(log.SimpleLogger, log.LevelInfo)
+	mockClient := client.NewMockClient(ctrl)
+	mockClient.EXPECT().Store(gomock.Any()).Return(memStore, nil)
+	_, runtimeOptsManager, err := runtimeOptionsCfg.NewRuntimeOptionsManager(mockClient, logger)
+	require.NoError(t, err)
+	require.Equal(t, initialLimit, runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond())
+
+	newLimit := int64(1000)
+	proto.Value = newLimit
+	_, err = memStore.Set("rate-limit-key", proto)
+	require.NoError(t, err)
+	for {
+		if runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond() == newLimit {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds rate limiting logic to limit the write rate per metric. The limit is backed by KV and disabled by default. This protects aggregation tier from being overwhelmed with high frequency metric emissions, and in extreme cases will allow us to perform load shedding to selectively drop values high-frequency metrics when the aggregation tier performance is suffering.