### PR TITLE
Rate limit error logging

### DIFF
--- a/server/msgpack/options.go
+++ b/server/msgpack/options.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	defaultErrorLogSamplingRate = 1.0
+	// A default limit value of 0 means error log rate limiting is disabled.
+	defaultErrorLogLimitPerSecond = 0
 )
 
 // Options provide a set of server options.
@@ -45,11 +46,11 @@ type Options interface {
 	// InstrumentOptions returns the instrument options.
 	InstrumentOptions() instrument.Options
 
-	// SetErrorLogSamplingRate sets the error log sampling rate.
-	SetErrorLogSamplingRate(value float64) Options
+	// SetErrorLogLimitPerSecond sets the error log limit per second.
+	SetErrorLogLimitPerSecond(value int64) Options
 
-	// ErrorLogSamplingRate returns the error log sampling rate.
-	ErrorLogSamplingRate() float64
+	// ErrorLogLimitPerSecond returns the error log limit per second.
+	ErrorLogLimitPerSecond() int64
 
 	// SetServerOptions sets the server options.
 	SetServerOptions(value server.Options) Options
@@ -65,11 +66,11 @@ type Options interface {
 }
 
 type options struct {
-	clockOpts          clock.Options
-	instrumentOpts     instrument.Options
-	errLogSamplingRate float64
-	serverOpts         server.Options
-	iteratorPool       msgpack.UnaggregatedIteratorPool
+	clockOpts            clock.Options
+	instrumentOpts       instrument.Options
+	errLogLimitPerSecond int64
+	serverOpts           server.Options
+	iteratorPool         msgpack.UnaggregatedIteratorPool
 }
 
 // NewOptions creates a new set of server options.
@@ -81,11 +82,11 @@ func NewOptions() Options {
 	})
 
 	return &options{
-		clockOpts:          clock.NewOptions(),
-		instrumentOpts:     instrument.NewOptions(),
-		errLogSamplingRate: defaultErrorLogSamplingRate,
-		serverOpts:         server.NewOptions(),
-		iteratorPool:       iteratorPool,
+		clockOpts:            clock.NewOptions(),
+		instrumentOpts:       instrument.NewOptions(),
+		errLogLimitPerSecond: defaultErrorLogLimitPerSecond,
+		serverOpts:           server.NewOptions(),
+		iteratorPool:         iteratorPool,
 	}
 }
 
@@ -109,14 +110,14 @@ func (o *options) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
 }
 
-func (o *options) SetErrorLogSamplingRate(value float64) Options {
+func (o *options) SetErrorLogLimitPerSecond(value int64) Options {
 	opts := *o
-	opts.errLogSamplingRate = value
+	opts.errLogLimitPerSecond = value
 	return &opts
 }
 
-func (o *options) ErrorLogSamplingRate() float64 {
-	return o.errLogSamplingRate
+func (o *options) ErrorLogLimitPerSecond() int64 {
+	return o.errLogLimitPerSecond
 }
 
 func (o *options) SetServerOptions(value server.Options) Options {

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -103,6 +103,7 @@ func (s *handler) Handle(conn net.Conn) {
 		metric := it.Metric()
 		policiesList := it.PoliciesList()
 		if err := s.aggregator.AddMetricWithPoliciesList(metric, policiesList); err != nil {
+			s.metrics.addMetricErrors.Inc(1)
 			// We rate limit the error log here because the error rate may scale with
 			// the metrics incoming rate and consume lots of cpu cycles.
 			if s.errLogRateLimiter != nil && !s.errLogRateLimiter.IsAllowed(1) {
@@ -115,7 +116,6 @@ func (s *handler) Handle(conn net.Conn) {
 				log.NewField("policies", policiesList),
 				log.NewErrField(err),
 			).Errorf("error adding metric with policies")
-			s.metrics.addMetricErrors.Inc(1)
 		}
 	}
 

--- a/server/msgpack/server.go
+++ b/server/msgpack/server.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 
 	"github.com/m3db/m3aggregator/aggregator"
+	"github.com/m3db/m3aggregator/rate"
 	"github.com/m3db/m3metrics/protocol/msgpack"
 	"github.com/m3db/m3x/log"
 	xserver "github.com/m3db/m3x/server"
@@ -47,24 +48,26 @@ func NewServer(address string, aggregator aggregator.Aggregator, opts Options) x
 }
 
 type handlerMetrics struct {
-	addMetricErrors tally.Counter
-	decodeErrors    tally.Counter
+	addMetricErrors   tally.Counter
+	decodeErrors      tally.Counter
+	errLogRateLimited tally.Counter
 }
 
 func newHandlerMetrics(scope tally.Scope) handlerMetrics {
 	return handlerMetrics{
-		addMetricErrors: scope.Counter("add-metric-errors"),
-		decodeErrors:    scope.Counter("decode-errors"),
+		addMetricErrors:   scope.Counter("add-metric-errors"),
+		decodeErrors:      scope.Counter("decode-errors"),
+		errLogRateLimited: scope.Counter("error-log-rate-limited"),
 	}
 }
 
 type handler struct {
 	sync.Mutex
 
-	opts               Options
-	log                log.Logger
-	errLogSamplingRate float64
-	iteratorPool       msgpack.UnaggregatedIteratorPool
+	opts              Options
+	log               log.Logger
+	errLogRateLimiter *rate.Limiter
+	iteratorPool      msgpack.UnaggregatedIteratorPool
 
 	aggregator aggregator.Aggregator
 	rand       *rand.Rand
@@ -75,14 +78,18 @@ type handler struct {
 func NewHandler(aggregator aggregator.Aggregator, opts Options) xserver.Handler {
 	nowFn := opts.ClockOptions().NowFn()
 	iOpts := opts.InstrumentOptions()
+	var limiter *rate.Limiter
+	if rateLimit := opts.ErrorLogLimitPerSecond(); rateLimit != 0 {
+		limiter = rate.NewLimiter(rateLimit, nowFn)
+	}
 	return &handler{
-		opts:               opts,
-		log:                iOpts.Logger(),
-		errLogSamplingRate: opts.ErrorLogSamplingRate(),
-		iteratorPool:       opts.IteratorPool(),
-		aggregator:         aggregator,
-		rand:               rand.New(rand.NewSource(nowFn().UnixNano())),
-		metrics:            newHandlerMetrics(iOpts.MetricsScope()),
+		opts:              opts,
+		log:               iOpts.Logger(),
+		errLogRateLimiter: limiter,
+		iteratorPool:      opts.IteratorPool(),
+		aggregator:        aggregator,
+		rand:              rand.New(rand.NewSource(nowFn().UnixNano())),
+		metrics:           newHandlerMetrics(iOpts.MetricsScope()),
 	}
 }
 
@@ -96,17 +103,18 @@ func (s *handler) Handle(conn net.Conn) {
 		metric := it.Metric()
 		policiesList := it.PoliciesList()
 		if err := s.aggregator.AddMetricWithPoliciesList(metric, policiesList); err != nil {
-			// We sample the error log here because the error rate may scale with
+			// We rate limit the error log here because the error rate may scale with
 			// the metrics incoming rate and consume lots of cpu cycles.
-			// TODO(xichen): need to sample this in case there's a large number of errors
-			// due to rate limiting etc.
-			if s.rand.Float64() < s.errLogSamplingRate {
-				s.log.WithFields(
-					log.NewField("metric", metric.String()),
-					log.NewField("policies", policiesList),
-					log.NewErrField(err),
-				).Errorf("error adding metric with policies")
+			if s.errLogRateLimiter != nil && !s.errLogRateLimiter.IsAllowed(1) {
+				s.metrics.errLogRateLimited.Inc(1)
+				continue
 			}
+			s.log.WithFields(
+				log.NewField("type", metric.Type.String()),
+				log.NewField("id", metric.ID.String()),
+				log.NewField("policies", policiesList),
+				log.NewErrField(err),
+			).Errorf("error adding metric with policies")
 			s.metrics.addMetricErrors.Inc(1)
 		}
 	}

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -37,8 +37,8 @@ type MsgpackServerConfiguration struct {
 	// Msgpack server listening address.
 	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
 
-	// Error log sampling rate.
-	ErrorLogSamplingRate *float64 `yaml:"errorLogSamplingRate"`
+	// Error log limit per second.
+	ErrorLogLimitPerSecond int64 `yaml:"errorLogLimitPerSecond"`
 
 	// Whether keep alives are enabled on connections.
 	KeepAliveEnabled *bool `yaml:"keepAliveEnabled"`
@@ -57,12 +57,9 @@ type MsgpackServerConfiguration struct {
 func (c *MsgpackServerConfiguration) NewMsgpackServerOptions(
 	instrumentOpts instrument.Options,
 ) msgpack.Options {
-	opts := msgpack.NewOptions().SetInstrumentOptions(instrumentOpts)
-
-	// Set error log sampling rate.
-	if c.ErrorLogSamplingRate != nil {
-		opts = opts.SetErrorLogSamplingRate(*c.ErrorLogSamplingRate)
-	}
+	opts := msgpack.NewOptions().
+		SetInstrumentOptions(instrumentOpts).
+		SetErrorLogLimitPerSecond(c.ErrorLogLimitPerSecond)
 
 	// Set server options.
 	serverOpts := xserver.NewOptions().


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds rate limiting for error logs, so that for cases where we rate limit writes, the error logs are limited to a fix number of logs / second, instead of the full set.