### PR TITLE
Rate limiting new metric insertions after warmup

### DIFF
--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -117,7 +117,7 @@ func TestEntryBatchTimerRateLimiting(t *testing.T) {
 	limitPerSecond := 100
 	runtimeOpts := runtime.NewOptions().SetWriteValuesPerMetricLimitPerSecond(int64(limitPerSecond))
 	e.SetRuntimeOptions(runtimeOpts)
-	require.Equal(t, errEntryRateLimitExceeded, e.AddMetricWithPoliciesList(bt, policy.DefaultPoliciesList))
+	require.Equal(t, errWriteValueRateLimitExceeded, e.AddMetricWithPoliciesList(bt, policy.DefaultPoliciesList))
 
 	// Reset limit to enable a rate limit of 1000/s.
 	limitPerSecond = 1000
@@ -126,7 +126,7 @@ func TestEntryBatchTimerRateLimiting(t *testing.T) {
 	require.NoError(t, e.AddMetricWithPoliciesList(bt, policy.DefaultPoliciesList))
 
 	// Adding a new batch will exceed the limit.
-	require.Equal(t, errEntryRateLimitExceeded, e.AddMetricWithPoliciesList(bt, policy.DefaultPoliciesList))
+	require.Equal(t, errWriteValueRateLimitExceeded, e.AddMetricWithPoliciesList(bt, policy.DefaultPoliciesList))
 
 	// Advancing the time will reset the quota.
 	*now = (*now).Add(time.Second)
@@ -148,7 +148,7 @@ func TestEntryCounterRateLimiting(t *testing.T) {
 	for i := 0; i < limitPerSecond; i++ {
 		require.NoError(t, e.AddMetricWithPoliciesList(testCounter, policy.DefaultPoliciesList))
 	}
-	require.Equal(t, errEntryRateLimitExceeded, e.AddMetricWithPoliciesList(testCounter, policy.DefaultPoliciesList))
+	require.Equal(t, errWriteValueRateLimitExceeded, e.AddMetricWithPoliciesList(testCounter, policy.DefaultPoliciesList))
 
 	// Reset limit to enable a rate limit of 100/s.
 	limitPerSecond = 100
@@ -157,7 +157,7 @@ func TestEntryCounterRateLimiting(t *testing.T) {
 	for i := 0; i < limitPerSecond; i++ {
 		require.NoError(t, e.AddMetricWithPoliciesList(testCounter, policy.DefaultPoliciesList))
 	}
-	require.Equal(t, errEntryRateLimitExceeded, e.AddMetricWithPoliciesList(testCounter, policy.DefaultPoliciesList))
+	require.Equal(t, errWriteValueRateLimitExceeded, e.AddMetricWithPoliciesList(testCounter, policy.DefaultPoliciesList))
 
 	// Advancing the time will reset the quota.
 	*now = (*now).Add(time.Second)

--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -369,6 +369,8 @@ func (m *metricMap) applyNewMetricRateLimitWithLock(now time.Time) error {
 	if m.rateLimiter == nil {
 		return nil
 	}
+	// If we are still in the warmup phase and possibly ingesting a large amount
+	// of new metrics, no rate limit is applied.
 	noLimitWarmupDuration := m.runtimeOpts.WriteNewMetricNoLimitWarmupDuration()
 	if warmupEnd := m.firstInsertAt.Add(noLimitWarmupDuration); now.Before(warmupEnd) {
 		m.metrics.noRateLimitWarmup.Inc(1)

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -63,7 +63,7 @@ runtimeOptions:
     environment: production
   writeValuesPerMetricLimitPerSecondKey: write-values-per-metric-limit-per-second
   writeValuesPerMetricLimitPerSecond: 0
-  writeNewMetricLimitClusterPerSecondKey: write-new-metric-limit-per-second
+  writeNewMetricLimitClusterPerSecondKey: write-new-metric-limit-cluster-per-second
   writeNewMetricLimitClusterPerSecond: 0
   writeNewMetricNoLimitWarmupDuration: 0
 

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -57,6 +57,16 @@ msgpack:
     iteratorPool:
       size: 4096
 
+runtimeOptions:
+  kvConfig:
+    namespace: /m3aggregator
+    environment: production
+  writeValuesPerMetricLimitPerSecondKey: write-values-per-metric-limit-per-second
+  writeValuesPerMetricLimitPerSecond: 0
+  writeNewMetricLimitClusterPerSecondKey: write-new-metric-limit-per-second
+  writeNewMetricLimitClusterPerSecond: 0
+  writeNewMetricNoLimitWarmupDuration: 0
+
 http:
   listenAddress: 0.0.0.0:6001
   readTimeout: 45s
@@ -92,12 +102,6 @@ aggregator:
           capacity: 32
         - count: 1024
           capacity: 64
-  runtimeOptions:
-    kvConfig:
-      namespace: /m3aggregator
-      environment: production
-    writeValuesPerMetricLimitPerSecondKey: write-values-per-metric-limit-per-second
-    writeValuesPerMetricLimitPerSecond: 0
   placementManager:
     kvConfig:
       namespace: /m3aggregator

--- a/runtime/options_test.go
+++ b/runtime/options_test.go
@@ -18,33 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package runtime
 
 import (
-	"github.com/m3db/m3x/instrument"
-	"github.com/m3db/m3x/log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Configuration contains top-level configuration.
-type Configuration struct {
-	// Logging configuration.
-	Logging log.Configuration `yaml:"logging"`
+func TestOptions(t *testing.T) {
+	opts := NewOptions().
+		SetWriteValuesPerMetricLimitPerSecond(20).
+		SetWriteNewMetricLimitPerShardPerSecond(10).
+		SetWriteNewMetricNoLimitWarmupDuration(time.Second)
 
-	// Metrics configuration.
-	Metrics instrument.MetricsConfiguration `yaml:"metrics"`
-
-	// Msgpack server configuration.
-	Msgpack MsgpackServerConfiguration `yaml:"msgpack"`
-
-	// HTTP server configuration.
-	HTTP HTTPServerConfiguration `yaml:"http"`
-
-	// Client configuration for key value store.
-	KVClient KVClientConfiguration `yaml:"kvClient" validate:"nonzero"`
-
-	// Runtime options configuration.
-	RuntimeOptions RuntimeOptionsConfiguration `yaml:"runtimeOptions"`
-
-	// Aggregator configuration.
-	Aggregator AggregatorConfiguration `yaml:"aggregator"`
+	require.Equal(t, int64(20), opts.WriteValuesPerMetricLimitPerSecond())
+	require.Equal(t, int64(10), opts.WriteNewMetricLimitPerShardPerSecond())
+	require.Equal(t, time.Second, opts.WriteNewMetricNoLimitWarmupDuration())
 }

--- a/services/m3aggregator/config/aggregator_test.go
+++ b/services/m3aggregator/config/aggregator_test.go
@@ -24,12 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3cluster/client"
-	"github.com/m3db/m3cluster/generated/proto/commonpb"
-	"github.com/m3db/m3cluster/kv/mem"
-	"github.com/m3db/m3x/log"
-
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -62,52 +56,5 @@ func TestJitterBuckets(t *testing.T) {
 	}
 	for _, input := range inputs {
 		require.Equal(t, input.expectedMaxJitter, maxJitterFn(input.interval))
-	}
-}
-
-func TestRuntimeOptionsConfigurationNewRuntimeOptionsManager(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	config := `
-kvConfig:
-  environment: production
-writeValuesPerMetricLimitPerSecondKey: rate-limit-key
-writeValuesPerMetricLimitPerSecond: 0
-`
-	var runtimeOptionsCfg runtimeOptionsConfiguration
-	require.NoError(t, yaml.Unmarshal([]byte(config), &runtimeOptionsCfg))
-
-	initialLimit := int64(100)
-	proto := &commonpb.Int64Proto{Value: initialLimit}
-	memStore := mem.NewStore()
-	_, err := memStore.Set("rate-limit-key", proto)
-	require.NoError(t, err)
-
-	logger := log.NewLevelLogger(log.SimpleLogger, log.LevelInfo)
-	mockClient := client.NewMockClient(ctrl)
-	mockClient.EXPECT().Store(gomock.Any()).Return(memStore, nil)
-	runtimeOptsManager, err := runtimeOptionsCfg.NewRuntimeOptionsManager(mockClient, logger)
-	require.NoError(t, err)
-	require.Equal(t, initialLimit, runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond())
-
-	newLimit := int64(1000)
-	proto.Value = newLimit
-	_, err = memStore.Set("rate-limit-key", proto)
-	require.NoError(t, err)
-	for {
-		if runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond() == newLimit {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	_, err = memStore.Delete("rate-limit-key")
-	require.NoError(t, err)
-	for {
-		if runtimeOptsManager.RuntimeOptions().WriteValuesPerMetricLimitPerSecond() == 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/services/m3aggregator/config/kv.go
+++ b/services/m3aggregator/config/kv.go
@@ -21,30 +21,24 @@
 package config
 
 import (
+	"github.com/m3db/m3cluster/client"
+	etcdclient "github.com/m3db/m3cluster/client/etcd"
 	"github.com/m3db/m3x/instrument"
-	"github.com/m3db/m3x/log"
 )
 
-// Configuration contains top-level configuration.
-type Configuration struct {
-	// Logging configuration.
-	Logging log.Configuration `yaml:"logging"`
+// KVClientConfiguration configures the client for the key-value store.
+// TODO(xichen): add configuration for in-memory client with pre-populated data
+// for different namespaces so we can start up m3aggregator without a real etcd cluster.
+type KVClientConfiguration struct {
+	Etcd *etcdclient.Configuration `yaml:"etcd"`
+}
 
-	// Metrics configuration.
-	Metrics instrument.MetricsConfiguration `yaml:"metrics"`
-
-	// Msgpack server configuration.
-	Msgpack MsgpackServerConfiguration `yaml:"msgpack"`
-
-	// HTTP server configuration.
-	HTTP HTTPServerConfiguration `yaml:"http"`
-
-	// Client configuration for key value store.
-	KVClient KVClientConfiguration `yaml:"kvClient" validate:"nonzero"`
-
-	// Runtime options configuration.
-	RuntimeOptions RuntimeOptionsConfiguration `yaml:"runtimeOptions"`
-
-	// Aggregator configuration.
-	Aggregator AggregatorConfiguration `yaml:"aggregator"`
+// NewKVClient creates a new KV client.
+func (c *KVClientConfiguration) NewKVClient(
+	instrumentOpts instrument.Options,
+) (client.Client, error) {
+	if c.Etcd == nil {
+		return nil, errNoKVClientConfiguration
+	}
+	return c.Etcd.NewClient(instrumentOpts)
 }

--- a/services/m3aggregator/config/runtime.go
+++ b/services/m3aggregator/config/runtime.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"math"
+	"time"
+
+	"github.com/m3db/m3aggregator/aggregator"
+	"github.com/m3db/m3aggregator/runtime"
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/kv"
+	kvutil "github.com/m3db/m3cluster/kv/util"
+	"github.com/m3db/m3x/log"
+)
+
+// RuntimeOptionsConfiguration configures runtime options.
+type RuntimeOptionsConfiguration struct {
+	KVConfig                               kv.Configuration `yaml:"kvConfig"`
+	WriteValuesPerMetricLimitPerSecondKey  string           `yaml:"writeValuesPerMetricLimitPerSecondKey" validate:"nonzero"`
+	WriteValuesPerMetricLimitPerSecond     int64            `yaml:"writeValuesPerMetricLimitPerSecond"`
+	WriteNewMetricLimitClusterPerSecondKey string           `yaml:"writeNewMetricLimitClusterPerSecondKey" validate:"nonzero"`
+	WriteNewMetricLimitClusterPerSecond    int64            `yaml:"writeNewMetricLimitClusterPerSecond"`
+	WriteNewMetricNoLimitWarmupDuration    time.Duration    `yaml:"writeNewMetricNoLimitWarmupDuration"`
+}
+
+// NewRuntimeOptionsManager creates a new runtime options manager.
+func (c RuntimeOptionsConfiguration) NewRuntimeOptionsManager() runtime.OptionsManager {
+	initRuntimeOpts := runtime.NewOptions().
+		SetWriteValuesPerMetricLimitPerSecond(c.WriteValuesPerMetricLimitPerSecond).
+		SetWriteNewMetricNoLimitWarmupDuration(c.WriteNewMetricNoLimitWarmupDuration)
+	return runtime.NewOptionsManager(initRuntimeOpts)
+}
+
+// WatchRuntimeOptionChanges watches runtime option updates.
+func (c RuntimeOptionsConfiguration) WatchRuntimeOptionChanges(
+	client client.Client,
+	runtimeOptsManager runtime.OptionsManager,
+	placementManager aggregator.PlacementManager,
+	logger log.Logger,
+) {
+	kvOpts, err := c.KVConfig.NewOptions()
+	if err != nil {
+		logger.Errorf("unable to create kv config options: %v", err)
+		return
+	}
+	store, err := client.Store(kvOpts)
+	if err != nil {
+		logger.Errorf("unable to create kv store: %v", err)
+		return
+	}
+
+	var (
+		valueLimitKey                = c.WriteValuesPerMetricLimitPerSecondKey
+		defaultValueLimit            = c.WriteValuesPerMetricLimitPerSecond
+		valueLimit                   int64
+		valueLimitCh                 <-chan struct{}
+		newMetricClusterLimitKey     = c.WriteNewMetricLimitClusterPerSecondKey
+		defaultNewMetricClusterLimit = c.WriteNewMetricLimitClusterPerSecond
+		newMetricClusterLimit        int64
+		newMetricPerShardLimit       int64
+		newMetricLimitCh             <-chan struct{}
+	)
+	valueLimit, err = retrieveLimit(valueLimitKey, store, defaultValueLimit)
+	if err != nil {
+		logger.Errorf("unable to retrieve per-metric write value limit from kv: %v", err)
+	}
+	logger.Infof("current write value limit per second is: %d", valueLimit)
+
+	newMetricClusterLimit, err = retrieveLimit(newMetricClusterLimitKey, store, defaultNewMetricClusterLimit)
+	if err == nil {
+		newMetricPerShardLimit, err = clusterLimitToPerShardLimit(newMetricClusterLimit, placementManager)
+	}
+	if err != nil {
+		logger.Errorf("unable to determine per-shard write new metric limit: %v", err)
+	}
+	logger.Infof("current write new metric limit per shard per second is: %d", newMetricPerShardLimit)
+
+	runtimeOpts := runtime.NewOptions().
+		SetWriteNewMetricNoLimitWarmupDuration(c.WriteNewMetricNoLimitWarmupDuration).
+		SetWriteValuesPerMetricLimitPerSecond(valueLimit).
+		SetWriteNewMetricLimitPerShardPerSecond(newMetricPerShardLimit)
+	runtimeOptsManager.SetRuntimeOptions(runtimeOpts)
+
+	valueLimitWatch, err := store.Watch(valueLimitKey)
+	if err != nil {
+		logger.Errorf("unable to watch per-metric write value limit: %v", err)
+	} else {
+		valueLimitCh = valueLimitWatch.C()
+	}
+	newMetricLimitWatch, err := store.Watch(newMetricClusterLimitKey)
+	if err != nil {
+		logger.Errorf("unable to watch cluster-wide write new metric limit: %v", err)
+	} else {
+		newMetricLimitCh = newMetricLimitWatch.C()
+	}
+	// If watch creation failed for both, we return immediately.
+	if valueLimitCh == nil && newMetricLimitCh == nil {
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case <-valueLimitCh:
+				valueLimitVal := valueLimitWatch.Get()
+				newValueLimit, err := kvutil.Int64FromValue(valueLimitVal, valueLimitKey, defaultValueLimit, nil)
+				if err != nil {
+					logger.Errorf("unable to determine per-metric write value limit: %v", err)
+					continue
+				}
+				if newValueLimit == valueLimit {
+					logger.Infof("per-metric write value limit %d is unchanged, skipping", newValueLimit)
+					continue
+				}
+				logger.Infof("updating per-metric write value limit from %d to %d", valueLimit, newValueLimit)
+				runtimeOpts = runtimeOpts.SetWriteValuesPerMetricLimitPerSecond(newValueLimit)
+				runtimeOptsManager.SetRuntimeOptions(runtimeOpts)
+			case <-newMetricLimitCh:
+				newMetricLimitVal := newMetricLimitWatch.Get()
+				var newNewMetricPerShardLimit int64
+				newNewMetricClusterLimit, err := kvutil.Int64FromValue(newMetricLimitVal, newMetricClusterLimitKey, defaultNewMetricClusterLimit, nil)
+				if err == nil {
+					newNewMetricPerShardLimit, err = clusterLimitToPerShardLimit(newNewMetricClusterLimit, placementManager)
+				}
+				if err != nil {
+					logger.Errorf("unable to determine per-shard new metric limit: %v", err)
+					continue
+				}
+				if newNewMetricPerShardLimit == newMetricPerShardLimit {
+					logger.Infof("per-shard write new metric limit %d is unchanged, skipping", newNewMetricPerShardLimit)
+					continue
+				}
+				logger.Infof("updating per-shard write new metric limit from %d to %d", newMetricPerShardLimit, newNewMetricPerShardLimit)
+				runtimeOpts = runtimeOpts.SetWriteNewMetricLimitPerShardPerSecond(newNewMetricPerShardLimit)
+				runtimeOptsManager.SetRuntimeOptions(runtimeOpts)
+			}
+		}
+	}()
+}
+
+func clusterLimitToPerShardLimit(
+	clusterLimit int64,
+	placementManager aggregator.PlacementManager,
+) (int64, error) {
+	if clusterLimit < 1 {
+		return 0, nil
+	}
+	_, placement, err := placementManager.Placement()
+	if err != nil {
+		return clusterLimit, err
+	}
+	numShardsPerReplica := placement.NumShards()
+	numShards := numShardsPerReplica * placement.ReplicaFactor()
+	if numShards < 1 {
+		return clusterLimit, nil
+	}
+	perShardLimit := int64(math.Ceil(float64(clusterLimit) / float64(numShards)))
+	return perShardLimit, nil
+}
+
+func retrieveLimit(key string, store kv.Store, defaultLimit int64) (int64, error) {
+	limit := defaultLimit
+	value, err := store.Get(key)
+	if err == nil {
+		limit, err = kvutil.Int64FromValue(value, key, defaultLimit, nil)
+	}
+	return limit, err
+}

--- a/services/m3aggregator/config/runtime.go
+++ b/services/m3aggregator/config/runtime.go
@@ -127,11 +127,12 @@ func (c RuntimeOptionsConfiguration) WatchRuntimeOptionChanges(
 					logger.Errorf("unable to determine per-metric write value limit: %v", err)
 					continue
 				}
-				if newValueLimit == valueLimit {
+				currValueLimit := runtimeOpts.WriteValuesPerMetricLimitPerSecond()
+				if newValueLimit == currValueLimit {
 					logger.Infof("per-metric write value limit %d is unchanged, skipping", newValueLimit)
 					continue
 				}
-				logger.Infof("updating per-metric write value limit from %d to %d", valueLimit, newValueLimit)
+				logger.Infof("updating per-metric write value limit from %d to %d", currValueLimit, newValueLimit)
 				runtimeOpts = runtimeOpts.SetWriteValuesPerMetricLimitPerSecond(newValueLimit)
 				runtimeOptsManager.SetRuntimeOptions(runtimeOpts)
 			case <-newMetricLimitCh:
@@ -145,11 +146,12 @@ func (c RuntimeOptionsConfiguration) WatchRuntimeOptionChanges(
 					logger.Errorf("unable to determine per-shard new metric limit: %v", err)
 					continue
 				}
-				if newNewMetricPerShardLimit == newMetricPerShardLimit {
+				currNewMetricPerShardLimit := runtimeOpts.WriteNewMetricLimitPerShardPerSecond()
+				if newNewMetricPerShardLimit == currNewMetricPerShardLimit {
 					logger.Infof("per-shard write new metric limit %d is unchanged, skipping", newNewMetricPerShardLimit)
 					continue
 				}
-				logger.Infof("updating per-shard write new metric limit from %d to %d", newMetricPerShardLimit, newNewMetricPerShardLimit)
+				logger.Infof("updating per-shard write new metric limit from %d to %d", currNewMetricPerShardLimit, newNewMetricPerShardLimit)
 				runtimeOpts = runtimeOpts.SetWriteNewMetricLimitPerShardPerSecond(newNewMetricPerShardLimit)
 				runtimeOptsManager.SetRuntimeOptions(runtimeOpts)
 			}

--- a/services/m3aggregator/config/runtime_test.go
+++ b/services/m3aggregator/config/runtime_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/m3db/m3aggregator/aggregator"
+	"github.com/m3db/m3aggregator/runtime"
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/generated/proto/commonpb"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3cluster/placement"
+	"github.com/m3db/m3x/log"
+
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestRuntimeOptionsConfigurationNewRuntimeOptionsManager(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	config := `
+kvConfig:
+  zone: test
+  environment: production
+writeValuesPerMetricLimitPerSecondKey: rate-limit-key
+writeValuesPerMetricLimitPerSecond: 0
+writeNewMetricLimitClusterPerSecondKey: new-metric-limit-key
+writeNewMetricLimitClusterPerSecond: 0
+writeNewMetricNoLimitWarmupDuration: 10m
+`
+	var cfg RuntimeOptionsConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(config), &cfg))
+	require.Equal(t, "test", cfg.KVConfig.Zone)
+	require.Equal(t, "production", cfg.KVConfig.Environment)
+	require.Equal(t, "rate-limit-key", cfg.WriteValuesPerMetricLimitPerSecondKey)
+	require.Equal(t, int64(0), cfg.WriteValuesPerMetricLimitPerSecond)
+	require.Equal(t, "new-metric-limit-key", cfg.WriteNewMetricLimitClusterPerSecondKey)
+	require.Equal(t, int64(0), cfg.WriteNewMetricLimitClusterPerSecond)
+	require.Equal(t, 10*time.Minute, cfg.WriteNewMetricNoLimitWarmupDuration)
+
+	initialValueLimit := int64(100)
+	proto := &commonpb.Int64Proto{Value: initialValueLimit}
+	memStore := mem.NewStore()
+	_, err := memStore.Set("rate-limit-key", proto)
+	require.NoError(t, err)
+
+	initialNewMetricLimit := int64(32)
+	proto = &commonpb.Int64Proto{Value: initialNewMetricLimit}
+	_, err = memStore.Set("new-metric-limit-key", proto)
+	require.NoError(t, err)
+
+	runtimeOptsManager := cfg.NewRuntimeOptionsManager()
+	testShards := []uint32{0, 1, 2, 3}
+	testPlacement := placement.NewPlacement().SetReplicaFactor(2).SetShards(testShards)
+	mockPlacementManager := &mockPlacementManager{
+		placementFn: func() (placement.ActiveStagedPlacement, placement.Placement, error) {
+			return nil, testPlacement, nil
+		},
+	}
+	mockClient := client.NewMockClient(ctrl)
+	mockClient.EXPECT().Store(gomock.Any()).Return(memStore, nil)
+	logger := log.NewLevelLogger(log.SimpleLogger, log.LevelInfo)
+	cfg.WatchRuntimeOptionChanges(mockClient, runtimeOptsManager, mockPlacementManager, logger)
+	runtimeOpts := runtimeOptsManager.RuntimeOptions()
+	expectedOpts := runtime.NewOptions().
+		SetWriteValuesPerMetricLimitPerSecond(initialValueLimit).
+		SetWriteNewMetricLimitPerShardPerSecond(4).
+		SetWriteNewMetricNoLimitWarmupDuration(10 * time.Minute)
+	require.Equal(t, expectedOpts, runtimeOpts)
+
+	newValueLimit := int64(1000)
+	proto.Value = newValueLimit
+	_, err = memStore.Set("rate-limit-key", proto)
+	require.NoError(t, err)
+	expectedOpts = runtime.NewOptions().
+		SetWriteValuesPerMetricLimitPerSecond(1000).
+		SetWriteNewMetricLimitPerShardPerSecond(4).
+		SetWriteNewMetricNoLimitWarmupDuration(10 * time.Minute)
+	for {
+		runtimeOpts = runtimeOptsManager.RuntimeOptions()
+		if compareRuntimeOptions(expectedOpts, runtimeOpts) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	newNewMetricLimit := int64(128)
+	proto.Value = newNewMetricLimit
+	_, err = memStore.Set("new-metric-limit-key", proto)
+	require.NoError(t, err)
+	expectedOpts = runtime.NewOptions().
+		SetWriteValuesPerMetricLimitPerSecond(1000).
+		SetWriteNewMetricLimitPerShardPerSecond(16).
+		SetWriteNewMetricNoLimitWarmupDuration(10 * time.Minute)
+	for {
+		runtimeOpts = runtimeOptsManager.RuntimeOptions()
+		if compareRuntimeOptions(expectedOpts, runtimeOpts) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func compareRuntimeOptions(expected, actual runtime.Options) bool {
+	return expected.WriteNewMetricLimitPerShardPerSecond() == actual.WriteNewMetricLimitPerShardPerSecond() &&
+		expected.WriteNewMetricNoLimitWarmupDuration() == actual.WriteNewMetricNoLimitWarmupDuration() &&
+		expected.WriteValuesPerMetricLimitPerSecond() == actual.WriteValuesPerMetricLimitPerSecond()
+}
+
+type placementFn func() (placement.ActiveStagedPlacement, placement.Placement, error)
+
+type mockPlacementManager struct {
+	aggregator.PlacementManager
+
+	placementFn placementFn
+}
+
+func (m *mockPlacementManager) Placement() (placement.ActiveStagedPlacement, placement.Placement, error) {
+	return m.placementFn()
+}


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds rate limiting for new metric insertions after a configurable warmup period so that if a user started sending a large amount of high-cardinality metrics within a short time, the new entry creation requests will be rate limited to protect the aggregation tier from being overwhelmed.