### PR TITLE
Make a copy of the flushers to fix race condition during shutdown

### DIFF
--- a/aggregator/follower_flush_mgr.go
+++ b/aggregator/follower_flush_mgr.go
@@ -209,7 +209,7 @@ func (mgr *followerFlushManager) flushersFromKVUpdateWithLock(buckets []*flushBu
 	for i, bucket := range buckets {
 		flushersByInterval[i].interval = bucket.interval
 		flushersByInterval[i].duration = bucket.duration
-		flushersByInterval[i].flushers = make([]flusherWithTime, 0, defaultInitialFlushTimesCapacity)
+		flushersByInterval[i].flushers = make([]flusherWithTime, 0, defaultInitialFlushCapacity)
 		for _, flusher := range bucket.flushers {
 			shard := flusher.Shard()
 			shardFlushTimes, exists := mgr.received.ByShard[shard]
@@ -248,7 +248,7 @@ func (mgr *followerFlushManager) flushersFromForcedFlush(
 	for i, bucket := range buckets {
 		flushersByInterval[i].interval = bucket.interval
 		flushersByInterval[i].duration = bucket.duration
-		flushersByInterval[i].flushers = make([]flusherWithTime, 0, defaultInitialFlushTimesCapacity)
+		flushersByInterval[i].flushers = make([]flusherWithTime, 0, defaultInitialFlushCapacity)
 		for _, flusher := range bucket.flushers {
 			newFlushTarget := flusherWithTime{
 				flusher:          flusher,


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR makes a shallow copy of the flushers slice so that if the original slice is modified during task execution (e.g., new flusher is registered or old flusher is unregistered), it won't cause a race condition.