### PR TITLE
Retain bucket during reset and add shard set id metrics

### DIFF
--- a/aggregator/flush_mgr.go
+++ b/aggregator/flush_mgr.go
@@ -238,10 +238,11 @@ func (mgr *flushManager) Close() error {
 func (mgr *flushManager) resetWithLock() {
 	mgr.state = flushManagerNotOpen
 	mgr.doneCh = make(chan struct{})
-	mgr.buckets = nil
 	mgr.electionState = FollowerState
 	mgr.leaderMgr = newLeaderFlushManager(mgr.doneCh, mgr.leaderOpts)
+	mgr.leaderMgr.Init(mgr.buckets)
 	mgr.followerMgr = newFollowerFlushManager(mgr.doneCh, mgr.followerOpts)
+	mgr.followerMgr.Init(mgr.buckets)
 }
 
 func (mgr *flushManager) findOrCreateBucketWithLock(l PeriodicFlusher) (*flushBucket, error) {
@@ -263,9 +264,6 @@ func (mgr *flushManager) findOrCreateBucketWithLock(l PeriodicFlusher) (*flushBu
 }
 
 func (mgr *flushManager) findBucketWithLock(l PeriodicFlusher) (*flushBucket, error) {
-	if mgr.state != flushManagerOpen {
-		return nil, errFlushManagerNotOpenOrClosed
-	}
 	flushInterval := l.FlushInterval()
 	for _, bucket := range mgr.buckets {
 		if bucket.interval == flushInterval {

--- a/aggregator/flush_mgr_test.go
+++ b/aggregator/flush_mgr_test.go
@@ -69,12 +69,6 @@ func TestFlushManagerOpenSuccess(t *testing.T) {
 	require.NoError(t, mgr.Open())
 }
 
-func TestFlushManagerRegisterClosed(t *testing.T) {
-	mgr, _ := testFlushManager(t)
-	mgr.state = flushManagerClosed
-	require.Equal(t, errFlushManagerNotOpenOrClosed, mgr.Register(nil))
-}
-
 func TestFlushManagerRegisterSuccess(t *testing.T) {
 	mgr, now := testFlushManager(t)
 	*now = time.Unix(1234, 0)
@@ -129,12 +123,6 @@ func TestFlushManagerRegisterSuccess(t *testing.T) {
 		require.Equal(t, expectedBuckets[i].interval, buckets[i].interval)
 		require.Equal(t, expectedBuckets[i].flushers, buckets[i].flushers)
 	}
-}
-
-func TestFlushManagerUnregisterClosed(t *testing.T) {
-	mgr, _ := testFlushManager(t)
-	mgr.state = flushManagerClosed
-	require.Equal(t, errFlushManagerNotOpenOrClosed, mgr.Unregister(nil))
 }
 
 func TestFlushManagerUnregisterBucketNotFound(t *testing.T) {


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR retains the flush bucket when reseting the shard set id associated with an instance so that after reset, the flush manager will continue flushing buckets that have been registered.