### PR TITLE
Do not close the nil queue for partial shardset

### DIFF
--- a/aggregator/handler/common/router.go
+++ b/aggregator/handler/common/router.go
@@ -103,7 +103,11 @@ func (r *shardedRouter) Route(shard uint32, buffer *RefCountedBuffer) error {
 
 func (r *shardedRouter) Close() {
 	for _, queue := range r.queues {
-		queue.Close()
+		// If the backend is associated with a subset of shards instead of the
+		// full shardset, the unused shards will not have an associated queue.
+		if queue != nil {
+			queue.Close()
+		}
 	}
 }
 


### PR DESCRIPTION
cc @cw9 @richardartoul 

This PR adds logic to protect the aggregator from closing the nil queue if the backend is only associated with a partial shardset. 