### PR TITLE
Initialize LastFlushedNanos during list initialization

### DIFF
--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -126,20 +126,29 @@ func newMetricList(shard uint32, resolution time.Duration, opts Options) (*metri
 	if minFlushInterval := opts.MinFlushInterval(); flushInterval < minFlushInterval {
 		flushInterval = minFlushInterval
 	}
+
+	// All elements in the list will have timestamps no earlier than when the list
+	// is created, so it's safe to assume everything before then has been flushed.
+	// This establishes a lower bound on the timestamps of elements in the list.
+	nowFn := opts.ClockOptions().NowFn()
+	lastFlushedNanos := truncatedNanos(nowFn().UnixNano(), resolution)
+
 	l := &metricList{
-		shard:         shard,
-		opts:          opts,
-		nowFn:         opts.ClockOptions().NowFn(),
-		log:           opts.InstrumentOptions().Logger(),
-		timeLock:      opts.TimeLock(),
-		flushHandler:  flushHandler,
-		flushWriter:   flushWriter,
-		resolution:    resolution,
-		flushInterval: flushInterval,
-		flushMgr:      opts.FlushManager(),
-		aggregations:  list.New(),
-		metrics:       newMetricListMetrics(scope),
+		shard:            shard,
+		opts:             opts,
+		nowFn:            nowFn,
+		log:              opts.InstrumentOptions().Logger(),
+		timeLock:         opts.TimeLock(),
+		flushHandler:     flushHandler,
+		flushWriter:      flushWriter,
+		resolution:       resolution,
+		flushInterval:    flushInterval,
+		flushMgr:         opts.FlushManager(),
+		aggregations:     list.New(),
+		lastFlushedNanos: lastFlushedNanos,
+		metrics:          newMetricListMetrics(scope),
 	}
+
 	l.flushBeforeFn = l.flushBefore
 	l.consumeAggMetricFn = l.consumeAggregatedMetric
 	l.discardAggMetricFn = l.discardAggregatedMetric
@@ -254,7 +263,7 @@ func (l *metricList) DiscardBefore(beforeNanos int64) {
 // flushBefore flushes or discards data before a given time based on the flush type.
 // It is not thread-safe.
 func (l *metricList) flushBefore(beforeNanos int64, flushType flushType) {
-	alignedBeforeNanos := time.Unix(0, beforeNanos).Truncate(l.resolution).UnixNano()
+	alignedBeforeNanos := truncatedNanos(beforeNanos, l.resolution)
 	if l.LastFlushedNanos() >= alignedBeforeNanos {
 		l.metrics.flushBeforeStale.Inc(1)
 		return
@@ -344,6 +353,10 @@ func (l *metricList) discardAggregatedMetric(
 	sp policy.StoragePolicy,
 ) {
 	l.metrics.flushMetricDiscarded.Inc(1)
+}
+
+func truncatedNanos(nowNanos int64, alignedBy time.Duration) int64 {
+	return time.Unix(0, nowNanos).Truncate(alignedBy).UnixNano()
 }
 
 type newMetricListFn func(

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -37,6 +37,26 @@ import (
 	"github.com/uber-go/tally"
 )
 
+func NewMetricList(t *testing.T) {
+	inputs := []struct {
+		nowNanos int64
+		dur      time.Duration
+		expected int64
+	}{
+		{nowNanos: 999999999, dur: time.Second, expected: 0},
+		{nowNanos: 1000000000, dur: time.Second, expected: 1000000000},
+		{nowNanos: 1000000001, dur: time.Second, expected: 1000000000},
+	}
+
+	for _, input := range inputs {
+		nowFn := func() time.Time { return time.Unix(0, input.nowNanos) }
+		opts := testOptions().SetClockOptions(clock.NewOptions().SetNowFn(nowFn))
+		l, err := newMetricList(testShard, input.dur, opts)
+		require.NoError(t, err)
+		require.Equal(t, input.expected, l.LastFlushedNanos())
+	}
+}
+
 func TestMetricListPushBack(t *testing.T) {
 	l, err := newMetricList(testShard, time.Second, testOptions())
 	require.NoError(t, err)
@@ -344,6 +364,22 @@ func TestMetricListFlushBeforeStale(t *testing.T) {
 	l.lastFlushedNanos = 1234
 	l.flushBefore(1000, discardType)
 	require.Equal(t, int64(1234), l.LastFlushedNanos())
+}
+
+func TestTruncatedNanos(t *testing.T) {
+	inputs := []struct {
+		nowNanos int64
+		dur      time.Duration
+		expected int64
+	}{
+		{nowNanos: 999999999, dur: time.Second, expected: 0},
+		{nowNanos: 1000000000, dur: time.Second, expected: 1000000000},
+		{nowNanos: 1000000001, dur: time.Second, expected: 1000000000},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, truncatedNanos(input.nowNanos, input.dur))
+	}
 }
 
 func TestMetricLists(t *testing.T) {

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/uber-go/tally"
 )
 
-func NewMetricList(t *testing.T) {
+func TestNewMetricList(t *testing.T) {
 	inputs := []struct {
 		nowNanos int64
 		dur      time.Duration


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR initializes the `lastFlushedNanos` to establish a more accurate lower bound on the timestamps of elements in the list. This is a slight optimization to speed up deployment in the case where a leader just performed a flush and a new list is created immediately afterwards due to a new metric coming in with a new shard/resolution combination, and the follower wouldn't resign until the leader performs the next flush for the new list.