### PR TITLE
Pull latest m3* packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 go:
-  - 1.7.6
   - 1.8.3
-  - 1.9
+  - 1.9.2
 install: make install-ci
 env:
  # Set higher timeouts and package name for travis

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f9596bcc60043da3e1e7d4dd3ab08975311cbdd0ca7fed36e788522c8a1e1353
-updated: 2017-12-14T12:51:53.31333548-05:00
+hash: 0c2226b4120caac45b74457079ff1760f4d3d7219a67d6792742c3cff22c2327
+updated: 2018-03-09T15:15:20.525972185-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -11,8 +11,12 @@ imports:
   - quantile
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+- name: github.com/cockroachdb/cmux
+  version: 112f0506e7743d64a6eb8fedbcff13d9979bbf92
+- name: github.com/coreos/bbolt
+  version: 32c383e75ce054674c53b5a07e55de85332aee14
 - name: github.com/coreos/etcd
-  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
+  version: 694728c496e22dfa5719c78ff23cc982e15bcb2f
   subpackages:
   - alarm
   - auth
@@ -20,17 +24,29 @@ imports:
   - client
   - clientv3
   - clientv3/concurrency
+  - clientv3/namespace
+  - clientv3/naming
   - compactor
   - discovery
+  - embed
   - error
   - etcdserver
   - etcdserver/api
+  - etcdserver/api/etcdhttp
   - etcdserver/api/v2http
   - etcdserver/api/v2http/httptypes
+  - etcdserver/api/v3client
+  - etcdserver/api/v3election
+  - etcdserver/api/v3election/v3electionpb
+  - etcdserver/api/v3election/v3electionpb/gw
+  - etcdserver/api/v3lock
+  - etcdserver/api/v3lock/v3lockpb
+  - etcdserver/api/v3lock/v3lockpb/gw
   - etcdserver/api/v3rpc
   - etcdserver/api/v3rpc/rpctypes
   - etcdserver/auth
   - etcdserver/etcdserverpb
+  - etcdserver/etcdserverpb/gw
   - etcdserver/membership
   - etcdserver/stats
   - integration
@@ -42,7 +58,10 @@ imports:
   - mvcc/mvccpb
   - pkg/adt
   - pkg/contention
+  - pkg/cors
+  - pkg/cpuutil
   - pkg/crc
+  - pkg/debugutil
   - pkg/fileutil
   - pkg/httputil
   - pkg/idutil
@@ -54,12 +73,14 @@ imports:
   - pkg/pbutil
   - pkg/runtime
   - pkg/schedule
+  - pkg/srv
   - pkg/testutil
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
   - pkg/wait
   - proxy/grpcproxy
+  - proxy/grpcproxy/adapter
   - proxy/grpcproxy/cache
   - raft
   - raft/raftpb
@@ -86,6 +107,8 @@ imports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/dgrijalva/jwt-go
+  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/ghodss/yaml
@@ -95,24 +118,34 @@ imports:
   subpackages:
   - oleutil
 - name: github.com/gogo/protobuf
-  version: 909568be09de550ed094403c2bf8a261b5bb730a
+  version: 100ba4e885062801d56799d78530b73b178a78f3
   subpackages:
   - proto
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  version: 13f360950a79f5864a972c786a10a50e44b69541
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
+  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
   subpackages:
   - jsonpb
   - proto
+  - protoc-gen-go/descriptor
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/struct
+  - ptypes/timestamp
 - name: github.com/google/btree
   version: 925471ac9e2131377a91e1595defec898166fe49
 - name: github.com/grpc-ecosystem/go-grpc-prometheus
   version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 - name: github.com/grpc-ecosystem/grpc-gateway
-  version: 84398b94e188ee336f307779b57b3aa91af7063c
+  version: 8cc3a55af3bcf171a1c23a90c4df9cf591706104
   subpackages:
   - runtime
   - runtime/internal
@@ -122,7 +155,7 @@ imports:
 - name: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
 - name: github.com/m3db/m3cluster
-  version: 4b25af16e37d029b79bae754d35655e6be382f94
+  version: 6b9b5a7eae36b0f3fc23823250d4536f6518332f
   subpackages:
   - client
   - client/etcd
@@ -148,7 +181,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 70615bfe9d5c94021e6b4d19810b193b57462f9a
+  version: 1ed6b292f4f6a1dfa4d6bfcb4fa5cb98578bf7e8
   subpackages:
   - generated/proto/schema
   - metric
@@ -158,20 +191,22 @@ imports:
   - policy
   - protocol/msgpack
 - name: github.com/m3db/m3x
-  version: dbdbd564ff2f64388a641ce61f541eceb7d2e416
+  version: a3695ff2d9696fcd9fffca878b9b544e68c4b1ef
   subpackages:
   - checked
   - clock
   - close
   - config
+  - context
   - errors
-  - id
+  - ident
   - instrument
   - log
   - net
   - pool
   - pprof
   - process
+  - resource
   - retry
   - server
   - sync
@@ -226,7 +261,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 6c4631652c6aab57c64f65c2e0aaec2e9aae3a64
+  version: 522328b48efad0c6034dba92bf39228694e9d31f
   subpackages:
   - m3
   - m3/customtransports
@@ -258,17 +293,28 @@ imports:
   - bcrypt
   - blowfish
 - name: golang.org/x/net
-  version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
+  version: ab5485076ff3407ad2d02db054635913f017b0ed
+  repo: https://github.com/golang/net
+  vcs: git
   subpackages:
   - context
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
+  - lex/httplex
   - trace
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: 4ee4af566555f5fbe026368b75596286a312663a
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:
@@ -284,16 +330,30 @@ imports:
   - internal/log
   - internal/modules
   - internal/remote_api
-- name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
   subpackages:
+  - googleapis/api/annotations
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 401e0e00e4bb830a10496d64cd95e068c5bf50de
+  subpackages:
+  - balancer
   - codes
+  - connectivity
   - credentials
+  - grpclb/grpc_lb_v1/messages
   - grpclog
+  - health/grpc_health_v1
   - internal
+  - keepalive
   - metadata
   - naming
   - peer
+  - resolver
+  - stats
+  - status
+  - tap
   - transport
 - name: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,91 +1,136 @@
 package: github.com/m3db/m3aggregator
 
 import:
+- package: github.com/m3db/m3x
+  version: a3695ff2d9696fcd9fffca878b9b544e68c4b1ef
+
+- package: github.com/m3db/m3cluster
+  version: 6b9b5a7eae36b0f3fc23823250d4536f6518332f
+
+- package: github.com/m3db/m3metrics
+  version: 1ed6b292f4f6a1dfa4d6bfcb4fa5cb98578bf7e8
+
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
-- package: github.com/m3db/m3cluster
-  version: 4b25af16e37d029b79bae754d35655e6be382f94
-- package: github.com/m3db/m3metrics
-  version: 70615bfe9d5c94021e6b4d19810b193b57462f9a
+
 - package: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
-- package: github.com/m3db/m3x
-  version: dbdbd564ff2f64388a641ce61f541eceb7d2e416
+
 - package: github.com/uber-go/tally
   version: ^3.1.0
+
 - package: github.com/golang/protobuf
-  version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
+  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
+
 - package: golang.org/x/net
-  version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
+  version: ab5485076ff3407ad2d02db054635913f017b0ed
+  repo: https://github.com/golang/net
+  vcs: git
+
 - package: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
+
 - package: github.com/prometheus/common
   version: 3e6a7635bac6573d43f49f97b47eb9bda195dba8
+
 - package: github.com/sirupsen/logrus
   version: cd7d1bbe41066b6c1f19780f895901052150a575
+
 - package: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+
 - package: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+
 - package: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
+
 - package: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
+
 - package: github.com/shirou/gopsutil
   version: b62e301a8b9958eebb7299683eb57fab229a9501
+
 - package: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
+
 - package: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
+
 - package: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
+
 - package: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+
 - package: github.com/coreos/etcd
-  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
+  version: 3.2.10
+
 - package: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+
 - package: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  version: ^1
+
 - package: github.com/grpc-ecosystem/go-grpc-prometheus
   version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+
 - package: github.com/grpc-ecosystem/grpc-gateway
-  version: 84398b94e188ee336f307779b57b3aa91af7063c
+  version: 1.3
+
 - package: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+
 - package: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
+
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+
 - package: github.com/prometheus/procfs
   version: 1878d9fbb537119d24b21ca07effd591627cd160
+
 - package: github.com/spaolacci/murmur3
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
+
 - package: github.com/willf/bitset
   version: 988f4f24992fc745de53c42df0da6581e42a6686
+
 - package: google.golang.org/grpc
   version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+
 - package: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+
 - package: github.com/coreos/go-semver
   version: 568e959cd89871e61434c1143528d9162da89ef2
+
 - package: github.com/coreos/go-systemd
   version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
+
 - package: github.com/coreos/pkg
   version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+
 - package: github.com/gogo/protobuf
-  version: 909568be09de550ed094403c2bf8a261b5bb730a
+  version: 0.4
+
 - package: github.com/google/btree
   version: 925471ac9e2131377a91e1595defec898166fe49
+
 - package: github.com/jonboulle/clockwork
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+
 - package: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
+
 - package: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+
 - package: github.com/xiang90/probing
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
+
 - package: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
+
 - package: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb


### PR DESCRIPTION
- Pulled in latest m3x/m3cluster/m3metrics changes
- Ended up having to make changes to a few other packages e.g. protobuf, because of the version of etcd we're pinning was incompatible with the version of protobuf we were on. ref https://github.com/coreos/etcd/issues/7787 

Link line has changed a fair bit, probably want to test a deploy before landing this. 