### PR TITLE
Ingest untimed metrics with pipeline metadata

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -242,7 +242,7 @@ type aggregatorMetrics struct {
 }
 
 func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMetrics {
-	addMetricScope := scope.SubScope("addUntimed")
+	addUntimedScope := scope.SubScope("addUntimed")
 	placementScope := scope.SubScope("placement")
 	shardsScope := scope.SubScope("shards")
 	shardSetIDScope := scope.SubScope("shard-set-id")
@@ -252,7 +252,7 @@ func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMet
 		timers:       scope.Counter("timers"),
 		timerBatches: scope.Counter("timer-batches"),
 		gauges:       scope.Counter("gauges"),
-		addUntimed:   newAggregatorAddUntimedMetrics(addMetricScope, samplingRate),
+		addUntimed:   newAggregatorAddUntimedMetrics(addUntimedScope, samplingRate),
 		placement:    newAggregatorPlacementMetrics(placementScope),
 		shards:       newAggregatorShardsMetrics(shardsScope),
 		shardSetID:   newAggregatorShardSetIDMetrics(shardSetIDScope),

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -32,9 +32,10 @@ import (
 	"github.com/m3db/m3aggregator/sharding"
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 
@@ -46,8 +47,8 @@ type Aggregator interface {
 	// Open opens the aggregator.
 	Open() error
 
-	// AddMetricWithPoliciesList adds a metric with policies list for aggregation.
-	AddMetricWithPoliciesList(mu unaggregated.MetricUnion, pl policy.PoliciesList) error
+	// AddUntimed adds an untimed metric with staged metadatas.
+	AddUntimed(metric unaggregated.MetricUnion, metas metadata.StagedMetadatas) error
 
 	// Resign stops the aggregator from participating in leader election and resigns
 	// from ongoing campaign if any.
@@ -58,6 +59,12 @@ type Aggregator interface {
 
 	// Close closes the aggregator.
 	Close() error
+}
+
+// metricsAggregator contains private aggregator APIs.
+type metricsAggregator interface {
+	// addForwarded adds a forwarded metric with metadata.
+	addForwarded(metric aggregated.Metric, metadata metadata.ForwardMetadata) error
 }
 
 const (
@@ -72,7 +79,7 @@ var (
 	errShardNotOwned                 = errors.New("aggregator shard is not owned")
 )
 
-type aggregatorAddMetricMetrics struct {
+type aggregatorAddUntimedMetrics struct {
 	success                    tally.Counter
 	successLatency             tally.Timer
 	invalidMetricTypes         tally.Counter
@@ -83,11 +90,11 @@ type aggregatorAddMetricMetrics struct {
 	uncategorizedErrors        tally.Counter
 }
 
-func newAggregatorAddMetricMetrics(
+func newAggregatorAddUntimedMetrics(
 	scope tally.Scope,
 	samplingRate float64,
-) aggregatorAddMetricMetrics {
-	return aggregatorAddMetricMetrics{
+) aggregatorAddUntimedMetrics {
+	return aggregatorAddUntimedMetrics{
 		success:        scope.Counter("success"),
 		successLatency: instrument.MustCreateSampledTimer(scope.Timer("success-latency"), samplingRate),
 		invalidMetricTypes: scope.Tagged(map[string]string{
@@ -111,12 +118,12 @@ func newAggregatorAddMetricMetrics(
 	}
 }
 
-func (m *aggregatorAddMetricMetrics) ReportSuccess(d time.Duration) {
+func (m *aggregatorAddUntimedMetrics) ReportSuccess(d time.Duration) {
 	m.success.Inc(1)
 	m.successLatency.Record(d)
 }
 
-func (m *aggregatorAddMetricMetrics) ReportError(err error) {
+func (m *aggregatorAddUntimedMetrics) ReportError(err error) {
 	if err == nil {
 		return
 	}
@@ -223,19 +230,19 @@ func newAggregatorShardSetIDMetrics(scope tally.Scope) aggregatorShardSetIDMetri
 }
 
 type aggregatorMetrics struct {
-	counters                  tally.Counter
-	timers                    tally.Counter
-	timerBatches              tally.Counter
-	gauges                    tally.Counter
-	addMetricWithPoliciesList aggregatorAddMetricMetrics
-	placement                 aggregatorPlacementMetrics
-	shards                    aggregatorShardsMetrics
-	shardSetID                aggregatorShardSetIDMetrics
-	tick                      aggregatorTickMetrics
+	counters     tally.Counter
+	timers       tally.Counter
+	timerBatches tally.Counter
+	gauges       tally.Counter
+	addUntimed   aggregatorAddUntimedMetrics
+	placement    aggregatorPlacementMetrics
+	shards       aggregatorShardsMetrics
+	shardSetID   aggregatorShardSetIDMetrics
+	tick         aggregatorTickMetrics
 }
 
 func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMetrics {
-	addMetricScope := scope.SubScope("addMetricWithPoliciesList")
+	addMetricScope := scope.SubScope("addUntimed")
 	placementScope := scope.SubScope("placement")
 	shardsScope := scope.SubScope("shards")
 	shardSetIDScope := scope.SubScope("shard-set-id")
@@ -245,11 +252,11 @@ func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMet
 		timers:       scope.Counter("timers"),
 		timerBatches: scope.Counter("timer-batches"),
 		gauges:       scope.Counter("gauges"),
-		addMetricWithPoliciesList: newAggregatorAddMetricMetrics(addMetricScope, samplingRate),
-		placement:                 newAggregatorPlacementMetrics(placementScope),
-		shards:                    newAggregatorShardsMetrics(shardsScope),
-		shardSetID:                newAggregatorShardSetIDMetrics(shardSetIDScope),
-		tick:                      newAggregatorTickMetrics(tickScope),
+		addUntimed:   newAggregatorAddUntimedMetrics(addMetricScope, samplingRate),
+		placement:    newAggregatorPlacementMetrics(placementScope),
+		shards:       newAggregatorShardsMetrics(shardsScope),
+		shardSetID:   newAggregatorShardSetIDMetrics(shardSetIDScope),
+		tick:         newAggregatorTickMetrics(tickScope),
 	}
 }
 
@@ -355,25 +362,25 @@ func (agg *aggregator) Open() error {
 	return nil
 }
 
-func (agg *aggregator) AddMetricWithPoliciesList(
-	mu unaggregated.MetricUnion,
-	pl policy.PoliciesList,
+func (agg *aggregator) AddUntimed(
+	metric unaggregated.MetricUnion,
+	metadatas metadata.StagedMetadatas,
 ) error {
 	callStart := agg.nowFn()
-	if err := agg.checkMetricType(mu); err != nil {
-		agg.metrics.addMetricWithPoliciesList.ReportError(err)
+	if err := agg.checkMetricType(metric); err != nil {
+		agg.metrics.addUntimed.ReportError(err)
 		return err
 	}
-	shard, err := agg.shardFor(mu.ID)
+	shard, err := agg.shardFor(metric.ID)
 	if err != nil {
-		agg.metrics.addMetricWithPoliciesList.ReportError(err)
+		agg.metrics.addUntimed.ReportError(err)
 		return err
 	}
-	if err = shard.AddMetricWithPoliciesList(mu, pl); err != nil {
-		agg.metrics.addMetricWithPoliciesList.ReportError(err)
+	if err = shard.AddUntimed(metric, metadatas); err != nil {
+		agg.metrics.addUntimed.ReportError(err)
 		return err
 	}
-	agg.metrics.addMetricWithPoliciesList.ReportSuccess(agg.nowFn().Sub(callStart))
+	agg.metrics.addUntimed.ReportSuccess(agg.nowFn().Sub(callStart))
 	return nil
 }
 

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -63,8 +63,8 @@ type Aggregator interface {
 
 // metricsAggregator contains private aggregator APIs.
 type metricsAggregator interface {
-	// addForwarded adds a forwarded metric with metadata.
-	addForwarded(metric aggregated.Metric, metadata metadata.ForwardMetadata) error
+	// AddForwarded adds a forwarded metric with metadata.
+	AddForwarded(metric aggregated.Metric, metadata metadata.ForwardMetadata) error
 }
 
 const (

--- a/aggregator/elem.go
+++ b/aggregator/elem.go
@@ -29,6 +29,7 @@ import (
 	maggregation "github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
+	"github.com/m3db/m3metrics/op/applied"
 	"github.com/m3db/m3metrics/policy"
 )
 
@@ -61,7 +62,12 @@ type metricElem interface {
 	ID() id.RawID
 
 	// ResetSetData resets the element and sets data.
-	ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types)
+	ResetSetData(
+		id id.RawID,
+		sp policy.StoragePolicy,
+		aggTypes maggregation.Types,
+		pipeline applied.Pipeline,
+	)
 
 	// AddMetric adds a new metric value.
 	// TODO(xichen): a value union would suffice here.
@@ -145,7 +151,12 @@ func newElemBase(opts Options) elemBase {
 }
 
 // resetSetData resets the element base and sets data.
-func (e *elemBase) resetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types, useDefaultAggregation bool) {
+func (e *elemBase) resetSetData(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	useDefaultAggregation bool,
+) {
 	e.id = id
 	e.sp = sp
 	e.aggTypes = aggTypes
@@ -176,17 +187,30 @@ func (e *elemBase) MarkAsTombstoned() {
 }
 
 // NewCounterElem creates a new counter element.
-func NewCounterElem(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types, opts Options) *CounterElem {
+// TODO(xichen): handle pipeline properly here.
+func NewCounterElem(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+	opts Options,
+) *CounterElem {
 	e := &CounterElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedCounter, 0, defaultNumValues), // in most cases values will have two entries
 	}
-	e.ResetSetData(id, sp, aggTypes)
+	e.ResetSetData(id, sp, aggTypes, pipeline)
 	return e
 }
 
 // ResetSetData resets the counter element and sets data.
-func (e *CounterElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types) {
+// TODO(xichen): handle pipeline properly here.
+func (e *CounterElem) ResetSetData(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+) {
 	useDefaultAggregation := aggTypes.IsDefault()
 	if useDefaultAggregation {
 		aggTypes = e.aggTypesOpts.DefaultCounterAggregationTypes()
@@ -356,17 +380,30 @@ func (e *CounterElem) processValue(timeNanos int64, agg aggregation.Counter, fn 
 }
 
 // NewTimerElem creates a new timer element.
-func NewTimerElem(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types, opts Options) *TimerElem {
+// TODO(xichen): properly handle pipeline here.
+func NewTimerElem(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+	opts Options,
+) *TimerElem {
 	e := &TimerElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedTimer, 0, defaultNumValues), // in most cases values will have two entries
 	}
-	e.ResetSetData(id, sp, aggTypes)
+	e.ResetSetData(id, sp, aggTypes, pipeline)
 	return e
 }
 
 // ResetSetData resets the timer element and sets data.
-func (e *TimerElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types) {
+// TODO(xichen): handle pipeline properly here.
+func (e *TimerElem) ResetSetData(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+) {
 	useDefaultAggregation := aggTypes.IsDefault()
 	if useDefaultAggregation {
 		aggTypes = e.aggTypesOpts.DefaultTimerAggregationTypes()
@@ -555,17 +592,30 @@ func (e *TimerElem) processValue(timeNanos int64, agg aggregation.Timer, fn aggM
 }
 
 // NewGaugeElem creates a new gauge element.
-func NewGaugeElem(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types, opts Options) *GaugeElem {
+// TODO(xichen): properly handle pipeline here.
+func NewGaugeElem(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+	opts Options,
+) *GaugeElem {
 	e := &GaugeElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedGauge, 0, defaultNumValues), // in most cases values will have two entries
 	}
-	e.ResetSetData(id, sp, aggTypes)
+	e.ResetSetData(id, sp, aggTypes, pipeline)
 	return e
 }
 
 // ResetSetData resets the gauge element and sets data.
-func (e *GaugeElem) ResetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types) {
+// TODO(xichen): handle pipeline properly here.
+func (e *GaugeElem) ResetSetData(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+) {
 	useDefaultAggregation := aggTypes.IsDefault()
 	if useDefaultAggregation {
 		aggTypes = e.aggTypesOpts.DefaultGaugeAggregationTypes()

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -82,7 +82,7 @@ func newEntryMetrics(scope tally.Scope) entryMetrics {
 	}
 }
 
-// Entry keeps track of all aggregations of a metric alongside their aggregation
+// Entry keeps track of a metric's aggregations alongside the aggregation
 // metadatas including storage policies, aggregation types, and remaining pipeline
 // steps if any.
 type Entry struct {

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -28,60 +28,76 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/m3db/m3aggregator/bitset"
 	"github.com/m3db/m3aggregator/rate"
 	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/metadata"
 	metricid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
+	"github.com/m3db/m3metrics/op/applied"
 	"github.com/m3db/m3metrics/policy"
 	xerrors "github.com/m3db/m3x/errors"
 
 	"github.com/uber-go/tally"
 )
 
+const (
+	initialAggregationCapacity = 2
+)
+
 var (
-	errEmptyPoliciesList           = errors.New("empty policies list")
+	errEmptyMetadatas              = errors.New("empty metadata list")
+	errNoApplicableMetadata        = errors.New("no applicable metadata")
+	errNoPipelinesInMetadata       = errors.New("no pipelines in metadata")
 	errEntryClosed                 = errors.New("entry is closed")
 	errWriteValueRateLimitExceeded = errors.New("write value rate limit is exceeded")
 )
 
 type entryMetrics struct {
-	emptyPoliciesList      tally.Counter
-	valueRateLimitExceeded tally.Counter
-	droppedValues          tally.Counter
-	stalePolicy            tally.Counter
-	futurePolicy           tally.Counter
-	tombstonedPolicy       tally.Counter
-	policyUpdates          tally.Counter
+	emptyMetadatas          tally.Counter
+	noApplicableMetadata    tally.Counter
+	noPipelinesInMetadata   tally.Counter
+	emptyPipeline           tally.Counter
+	noAggregationInPipeline tally.Counter
+	valueRateLimitExceeded  tally.Counter
+	droppedValues           tally.Counter
+	staleMetadata           tally.Counter
+	tombstonedMetadata      tally.Counter
+	metadataUpdates         tally.Counter
 }
 
 func newEntryMetrics(scope tally.Scope) entryMetrics {
 	return entryMetrics{
-		emptyPoliciesList:      scope.Counter("empty-policies-list"),
-		valueRateLimitExceeded: scope.Counter("value-rate-limit-exceeded"),
-		droppedValues:          scope.Counter("dropped-values"),
-		stalePolicy:            scope.Counter("stale-policy"),
-		futurePolicy:           scope.Counter("future-policy"),
-		tombstonedPolicy:       scope.Counter("tombstoned-policy"),
-		policyUpdates:          scope.Counter("policy-updates"),
+		emptyMetadatas:          scope.Counter("empty-metadatas"),
+		noApplicableMetadata:    scope.Counter("no-applicable-metadata"),
+		noPipelinesInMetadata:   scope.Counter("no-pipelines-in-metadata"),
+		emptyPipeline:           scope.Counter("empty-pipeline"),
+		noAggregationInPipeline: scope.Counter("no-aggregation-in-pipeline"),
+		valueRateLimitExceeded:  scope.Counter("value-rate-limit-exceeded"),
+		droppedValues:           scope.Counter("dropped-values"),
+		staleMetadata:           scope.Counter("stale-metadata"),
+		tombstonedMetadata:      scope.Counter("tombstoned-metadata"),
+		metadataUpdates:         scope.Counter("metadata-updates"),
 	}
 }
 
-// Entry stores metadata about current policies and aggregations for a metric.
+// Entry keeps track of all aggregations of a metric alongside their aggregation
+// metadatas including storage policies, aggregation types, and remaining pipeline
+// steps if any.
 type Entry struct {
 	sync.RWMutex
 
-	closed                 bool
-	opts                   Options
-	rateLimiter            *rate.Limiter
-	hasDefaultPoliciesList bool
-	useDefaultPolicies     bool
-	cutoverNanos           int64
-	lists                  *metricLists
-	numWriters             int32
-	lastAccessNanos        int64
-	aggregations           map[policy.Policy]*list.Element
-	metrics                entryMetrics
+	closed              bool
+	opts                Options
+	rateLimiter         *rate.Limiter
+	hasDefaultMetadatas bool
+	cutoverNanos        int64
+	lists               *metricLists
+	numWriters          int32
+	lastAccessNanos     int64
+	aggregations        aggregationValues
+	metrics             entryMetrics
 	// The entry keeps a decompressor to reuse the bitset in it, so we can
 	// save some heap allocations.
 	decompressor aggregation.IDDecompressor
@@ -91,7 +107,7 @@ type Entry struct {
 func NewEntry(lists *metricLists, runtimeOpts runtime.Options, opts Options) *Entry {
 	scope := opts.InstrumentOptions().MetricsScope().SubScope("entry")
 	e := &Entry{
-		aggregations: make(map[policy.Policy]*list.Element),
+		aggregations: make(aggregationValues, 0, initialAggregationCapacity),
 		metrics:      newEntryMetrics(scope),
 		decompressor: aggregation.NewPooledIDDecompressor(opts.AggregationTypesOptions().TypesPool()),
 	}
@@ -113,8 +129,7 @@ func (e *Entry) ResetSetData(lists *metricLists, runtimeOpts runtime.Options, op
 	e.closed = false
 	e.opts = opts
 	e.resetRateLimiterWithLock(runtimeOpts)
-	e.hasDefaultPoliciesList = false
-	e.useDefaultPolicies = false
+	e.hasDefaultMetadatas = false
 	e.cutoverNanos = uninitializedCutoverNanos
 	e.lists = lists
 	e.numWriters = 0
@@ -133,19 +148,19 @@ func (e *Entry) SetRuntimeOptions(opts runtime.Options) {
 	e.Unlock()
 }
 
-// AddMetricWithPoliciesList adds a metric along with applicable policies list.
-func (e *Entry) AddMetricWithPoliciesList(
-	mu unaggregated.MetricUnion,
-	pl policy.PoliciesList,
+// AddUntimed adds an untimed metric along with its metadatas.
+func (e *Entry) AddUntimed(
+	metric unaggregated.MetricUnion,
+	metadatas metadata.StagedMetadatas,
 ) error {
-	switch mu.Type {
+	switch metric.Type {
 	case unaggregated.BatchTimerType:
 		var err error
-		if err = e.applyValueRateLimit(int64(len(mu.BatchTimerVal))); err == nil {
-			err = e.writeBatchTimerWithPoliciesList(mu, pl)
+		if err = e.applyValueRateLimit(int64(len(metric.BatchTimerVal))); err == nil {
+			err = e.writeBatchTimerWithMetadatas(metric, metadatas)
 		}
-		if mu.BatchTimerVal != nil && mu.TimerValPool != nil {
-			mu.TimerValPool.Put(mu.BatchTimerVal)
+		if metric.BatchTimerVal != nil && metric.TimerValPool != nil {
+			metric.TimerValPool.Put(metric.BatchTimerVal)
 		}
 		return err
 	default:
@@ -153,24 +168,24 @@ func (e *Entry) AddMetricWithPoliciesList(
 		if err := e.applyValueRateLimit(1); err != nil {
 			return err
 		}
-		return e.addMetricWithPoliciesList(mu, pl)
+		return e.addUntimed(metric, metadatas)
 	}
 }
 
-func (e *Entry) writeBatchTimerWithPoliciesList(
-	mu unaggregated.MetricUnion,
-	pl policy.PoliciesList,
+func (e *Entry) writeBatchTimerWithMetadatas(
+	metric unaggregated.MetricUnion,
+	metadatas metadata.StagedMetadatas,
 ) error {
 	// If there is no limit on the maximum batch size per write, write
 	// all timers at once.
 	maxTimerBatchSizePerWrite := e.opts.MaxTimerBatchSizePerWrite()
 	if maxTimerBatchSizePerWrite == 0 {
-		return e.addMetricWithPoliciesList(mu, pl)
+		return e.addUntimed(metric, metadatas)
 	}
 
 	// Otherwise, honor maximum timer batch size.
 	var (
-		timerValues    = mu.BatchTimerVal
+		timerValues    = metric.BatchTimerVal
 		numTimerValues = len(timerValues)
 		start, end     int
 	)
@@ -179,18 +194,18 @@ func (e *Entry) writeBatchTimerWithPoliciesList(
 		if end > numTimerValues {
 			end = numTimerValues
 		}
-		splitTimer := mu
+		splitTimer := metric
 		splitTimer.BatchTimerVal = timerValues[start:end]
-		if err := e.addMetricWithPoliciesList(splitTimer, pl); err != nil {
+		if err := e.addUntimed(splitTimer, metadatas); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (e *Entry) addMetricWithPoliciesList(
-	mu unaggregated.MetricUnion,
-	pl policy.PoliciesList,
+func (e *Entry) addUntimed(
+	metric unaggregated.MetricUnion,
+	metadatas metadata.StagedMetadatas,
 ) error {
 	timeLock := e.opts.TimeLock()
 	timeLock.RLock()
@@ -211,36 +226,44 @@ func (e *Entry) addMetricWithPoliciesList(
 		return errEntryClosed
 	}
 
-	// Fast exit path for the common case.
-	hasDefaultPoliciesList := pl.IsDefault()
-	if e.hasDefaultPoliciesList && hasDefaultPoliciesList {
-		err := e.addMetricWithLock(currTime, mu)
+	// Fast exit path for the common case where the metric has default metadatas for aggregation.
+	hasDefaultMetadatas := metadatas.IsDefault()
+	if e.hasDefaultMetadatas && hasDefaultMetadatas {
+		err := e.addMetricWithLock(currTime, metric)
 		e.RUnlock()
 		timeLock.RUnlock()
 		return err
 	}
 
-	sp, err := e.activeStagedPoliciesWithLock(pl, currTime)
+	sm, err := e.activeStagedMetadataWithLock(currTime, metadatas)
 	if err != nil {
 		e.RUnlock()
 		timeLock.RUnlock()
 		return err
 	}
 
-	// If the policy indicates the (rollup) metric has been tombstoned, the metric is
+	// If the metadata indicates the (rollup) metric has been tombstoned, the metric is
 	// not ingested for aggregation. However, we do not update the policies asssociated
 	// with this entry and mark it tombstoned because there may be a different raw metric
 	// generating this same (rollup) metric that is actively emitting, meaning this entry
 	// may still be very much alive.
-	if sp.Tombstoned {
+	if sm.Tombstoned {
 		e.RUnlock()
 		timeLock.RUnlock()
-		e.metrics.tombstonedPolicy.Inc(1)
+		e.metrics.tombstonedMetadata.Inc(1)
 		return nil
 	}
 
-	if !e.shouldUpdatePoliciesWithLock(currTime, sp) {
-		err := e.addMetricWithLock(currTime, mu)
+	// It is expected that there is at least one pipeline in the metadata.
+	if len(sm.Pipelines) == 0 {
+		e.RUnlock()
+		timeLock.RUnlock()
+		e.metrics.noPipelinesInMetadata.Inc(1)
+		return errNoPipelinesInMetadata
+	}
+
+	if !e.shouldUpdateMetadatasWithLock(currTime, sm) {
+		err = e.addMetricWithLock(currTime, metric)
 		e.RUnlock()
 		timeLock.RUnlock()
 		return err
@@ -254,8 +277,8 @@ func (e *Entry) addMetricWithPoliciesList(
 		return errEntryClosed
 	}
 
-	if e.shouldUpdatePoliciesWithLock(currTime, sp) {
-		if err := e.updatePoliciesWithLock(mu.Type, mu.ID, mu.OwnsID, hasDefaultPoliciesList, sp); err != nil {
+	if e.shouldUpdateMetadatasWithLock(currTime, sm) {
+		if err = e.updateMetadatasWithLock(metric, hasDefaultMetadatas, sm); err != nil {
 			// NB(xichen): if an error occurred during policy update, the policies
 			// will remain as they are, i.e., there are no half-updated policies.
 			e.Unlock()
@@ -264,7 +287,7 @@ func (e *Entry) addMetricWithPoliciesList(
 		}
 	}
 
-	err = e.addMetricWithLock(currTime, mu)
+	err = e.addMetricWithLock(currTime, metric)
 	e.Unlock()
 	timeLock.RUnlock()
 
@@ -296,10 +319,11 @@ func (e *Entry) TryExpire(now time.Time) bool {
 		return false
 	}
 	e.closed = true
-	for p, agg := range e.aggregations {
-		agg.Value.(metricElem).MarkAsTombstoned()
-		delete(e.aggregations, p)
+	for i := range e.aggregations {
+		e.aggregations[i].elem.Value.(metricElem).MarkAsTombstoned()
+		e.aggregations[i] = aggregationValue{}
 	}
+	e.aggregations = e.aggregations[:0]
 	e.lists = nil
 	pool := e.opts.EntryPool()
 	e.Unlock()
@@ -315,170 +339,179 @@ func (e *Entry) recordLastAccessed(currTime time.Time) {
 	atomic.StoreInt64(&e.lastAccessNanos, currTime.UnixNano())
 }
 
-// NB(xichen): we assume the policies are sorted by their cutover times
+// NB(xichen): we assume the metadatas are sorted by their cutover times
 // in ascending order.
-func (e *Entry) activeStagedPoliciesWithLock(
-	pl policy.PoliciesList,
+func (e *Entry) activeStagedMetadataWithLock(
 	t time.Time,
-) (policy.StagedPolicies, error) {
-	// If we have no policy to apply, simply bail.
-	if len(pl) == 0 {
-		e.metrics.emptyPoliciesList.Inc(1)
-		return policy.DefaultStagedPolicies, errEmptyPoliciesList
+	metadatas metadata.StagedMetadatas,
+) (metadata.StagedMetadata, error) {
+	// If we have no metadata to apply, simply bail.
+	if len(metadatas) == 0 {
+		e.metrics.emptyMetadatas.Inc(1)
+		return metadata.DefaultStagedMetadata, errEmptyMetadatas
 	}
 	timeNanos := t.UnixNano()
-	for idx := len(pl) - 1; idx >= 0; idx-- {
-		if pl[idx].CutoverNanos <= timeNanos {
-			return pl[idx], nil
+	for idx := len(metadatas) - 1; idx >= 0; idx-- {
+		if metadatas[idx].CutoverNanos <= timeNanos {
+			return metadatas[idx], nil
 		}
 	}
-	return pl[0], nil
+	e.metrics.noApplicableMetadata.Inc(1)
+	return metadata.DefaultStagedMetadata, errNoApplicableMetadata
 }
 
-func (e *Entry) shouldUpdatePoliciesWithLock(currTime time.Time, sp policy.StagedPolicies) bool {
-	if e.cutoverNanos == uninitializedCutoverNanos {
-		return true
-	}
-	// If this is a future policy, we don't update the existing policy
-	// and instead use the cached policy.
-	if currTime.UnixNano() < sp.CutoverNanos {
-		e.metrics.futurePolicy.Inc(1)
+// NB: The metadata passed in is guaranteed to have cut over based on the current time.
+func (e *Entry) shouldUpdateMetadatasWithLock(
+	currTime time.Time,
+	sm metadata.StagedMetadata,
+) bool {
+	// If this is a stale metadata, we don't update the existing metadata.
+	if e.cutoverNanos > sm.CutoverNanos {
+		e.metrics.staleMetadata.Inc(1)
 		return false
 	}
-	// If this is a stale policy, we don't update the existing policy
-	// and instead use the cached policy.
-	if sp.CutoverNanos < e.cutoverNanos {
-		e.metrics.stalePolicy.Inc(1)
-		return false
-	}
-	if e.cutoverNanos != sp.CutoverNanos {
-		return true
-	}
-	policies, useDefaultPolicies := sp.Policies()
-	if e.useDefaultPolicies && useDefaultPolicies {
-		return false
-	}
-	if useDefaultPolicies {
-		policies = e.opts.DefaultPolicies()
-	}
-	return e.hasPolicyChangesWithLock(policies)
-}
 
-func (e *Entry) hasPolicyChangesWithLock(newPolicies []policy.Policy) bool {
-	if len(e.aggregations) != len(newPolicies) {
+	// If this is a newer metadata, we always update.
+	if e.cutoverNanos < sm.CutoverNanos {
 		return true
 	}
-	for _, policy := range newPolicies {
-		if _, exists := e.aggregations[policy]; !exists {
-			return true
+
+	// Iterate over the list of pipelines and check whether we have metadata changes.
+	// NB: If the incoming metadata have the same set of aggregation keys as the cached
+	// set but also have duplicates, there is no need to update metadatas as long as
+	// the cached set has all aggregation keys in the incoming metadata and vice versa.
+	bs := bitset.New(uint(len(e.aggregations)))
+	for _, pipeline := range sm.Pipelines {
+		storagePolicies := e.storagePolicies(pipeline.StoragePolicies)
+		for _, storagePolicy := range storagePolicies {
+			key := aggregationKey{
+				aggregationID: pipeline.AggregationID,
+				storagePolicy: storagePolicy,
+				pipeline:      pipeline.Pipeline,
+			}
+			idx := e.aggregations.index(key)
+			if idx < 0 {
+				return true
+			}
+			bs.Set(uint(idx))
 		}
 	}
-	return false
+	return bs.All(uint(len(e.aggregations)))
 }
 
-func (e *Entry) updatePoliciesWithLock(
-	typ unaggregated.Type,
-	id metricid.RawID,
-	ownsID bool,
-	hasDefaultPoliciesList bool,
-	sp policy.StagedPolicies,
+func (e *Entry) storagePolicies(policies []policy.StoragePolicy) []policy.StoragePolicy {
+	if !policy.IsDefaultStoragePolicies(policies) {
+		return policies
+	}
+	return e.opts.DefaultStoragePolicies()
+}
+
+func (e *Entry) maybeCopyIDWithLock(metric unaggregated.MetricUnion) metricid.RawID {
+	// If we own the ID, there is no need to copy.
+	if metric.OwnsID {
+		return metric.ID
+	}
+
+	// If there are existing elements for this id, try reusing
+	// the id from the elements because those are owned by us.
+	if len(e.aggregations) > 0 {
+		for _, aggVal := range e.aggregations {
+			return aggVal.elem.Value.(metricElem).ID()
+		}
+	}
+
+	// Otherwise it is necessary to make a copy because it's not owned by us.
+	elemID := make(metricid.RawID, len(metric.ID))
+	copy(elemID, metric.ID)
+	return elemID
+}
+
+func (e *Entry) updateMetadatasWithLock(
+	metric unaggregated.MetricUnion,
+	hasDefaultMetadatas bool,
+	sm metadata.StagedMetadata,
 ) error {
-	policies, useDefaultPolicies := sp.Policies()
-	if useDefaultPolicies {
-		policies = e.opts.DefaultPolicies()
-	}
+	var (
+		elemID          = e.maybeCopyIDWithLock(metric)
+		newAggregations = make(aggregationValues, 0, initialAggregationCapacity)
+	)
 
-	// Fast path to exit in case the policies didn't change.
-	if !e.hasPolicyChangesWithLock(policies) {
-		e.hasDefaultPoliciesList = hasDefaultPoliciesList
-		e.useDefaultPolicies = useDefaultPolicies
-		e.cutoverNanos = sp.CutoverNanos
-		e.metrics.policyUpdates.Inc(1)
-		return nil
-	}
-
-	elemID := id
-	if !ownsID {
-		if len(e.aggregations) > 0 {
-			// If there are existing elements for this id, try reusing
-			// the id from the elements because those are owned by us.
-			for _, elem := range e.aggregations {
-				elemID = elem.Value.(metricElem).ID()
-				break
+	// Update the metadatas.
+	for _, pipeline := range sm.Pipelines {
+		storagePolicies := e.storagePolicies(pipeline.StoragePolicies)
+		for _, storagePolicy := range storagePolicies {
+			key := aggregationKey{
+				aggregationID: pipeline.AggregationID,
+				storagePolicy: storagePolicy,
+				pipeline:      pipeline.Pipeline,
 			}
-		} else {
-			// Otherwise this is a new id so it is necessary to make a
-			// copy because it's not owned by us.
-			elemID = make(metricid.RawID, len(id))
-			copy(elemID, id)
-		}
-	}
-
-	// We should update the policies first.
-	newAggregations := make(map[policy.Policy]*list.Element, len(policies))
-	for _, p := range policies {
-		if elem, exists := e.aggregations[p]; exists {
-			newAggregations[p] = elem
-		} else {
-			aggTypes, err := e.decompressor.Decompress(p.AggregationID)
-			if err != nil {
-				return err
+			// Remove duplicate aggregation pipelines.
+			if newAggregations.contains(key) {
+				continue
 			}
-
-			var newElem metricElem
-			switch typ {
-			case unaggregated.CounterType:
-				if !aggTypes.IsValidForCounter() {
-					return fmt.Errorf("invalid aggregation types %s for Counter", aggTypes.String())
+			if idx := e.aggregations.index(key); idx >= 0 {
+				newAggregations = append(newAggregations, e.aggregations[idx])
+			} else {
+				aggTypes, err := e.decompressor.Decompress(key.aggregationID)
+				if err != nil {
+					return err
 				}
-				newElem = e.opts.CounterElemPool().Get()
-			case unaggregated.BatchTimerType:
-				if !aggTypes.IsValidForTimer() {
-					return fmt.Errorf("invalid aggregation types %s for Timer", aggTypes.String())
+				var newElem metricElem
+				switch metric.Type {
+				case unaggregated.CounterType:
+					if !aggTypes.IsValidForCounter() {
+						return fmt.Errorf("invalid aggregation types %s for Counter", aggTypes.String())
+					}
+					newElem = e.opts.CounterElemPool().Get()
+				case unaggregated.BatchTimerType:
+					if !aggTypes.IsValidForTimer() {
+						return fmt.Errorf("invalid aggregation types %s for Timer", aggTypes.String())
+					}
+					newElem = e.opts.TimerElemPool().Get()
+				case unaggregated.GaugeType:
+					if !aggTypes.IsValidForGauge() {
+						return fmt.Errorf("invalid aggregation types %s for Gauge", aggTypes.String())
+					}
+					newElem = e.opts.GaugeElemPool().Get()
+				default:
+					return errInvalidMetricType
 				}
-				newElem = e.opts.TimerElemPool().Get()
-			case unaggregated.GaugeType:
-				if !aggTypes.IsValidForGauge() {
-					return fmt.Errorf("invalid aggregation types %s for Gauge", aggTypes.String())
+				// NB: The pipeline may not be owned by us and as such we need to make a copy here.
+				key.pipeline = key.pipeline.Clone()
+				newElem.ResetSetData(elemID, storagePolicy, aggTypes, key.pipeline)
+				list, err := e.lists.FindOrCreate(storagePolicy.Resolution().Window)
+				if err != nil {
+					return err
 				}
-				newElem = e.opts.GaugeElemPool().Get()
-			default:
-				return errInvalidMetricType
+				newListElem, err := list.PushBack(newElem)
+				if err != nil {
+					return err
+				}
+				newAggregations = append(newAggregations, aggregationValue{key: key, elem: newListElem})
 			}
-			newElem.ResetSetData(elemID, p.StoragePolicy, aggTypes)
-			list, err := e.lists.FindOrCreate(p.Resolution().Window)
-			if err != nil {
-				return err
-			}
-			newListElem, err := list.PushBack(newElem)
-			if err != nil {
-				return err
-			}
-			newAggregations[p] = newListElem
 		}
 	}
 
 	// Mark the outdated elements as tombstoned.
-	for policy, elem := range e.aggregations {
-		if _, exists := newAggregations[policy]; !exists {
-			elem.Value.(metricElem).MarkAsTombstoned()
+	for _, val := range e.aggregations {
+		if !newAggregations.contains(val.key) {
+			val.elem.Value.(metricElem).MarkAsTombstoned()
 		}
 	}
 
 	// Replace the existing aggregations with new aggregations.
 	e.aggregations = newAggregations
-	e.hasDefaultPoliciesList = hasDefaultPoliciesList
-	e.useDefaultPolicies = useDefaultPolicies
-	e.cutoverNanos = sp.CutoverNanos
-	e.metrics.policyUpdates.Inc(1)
+	e.hasDefaultMetadatas = hasDefaultMetadatas
+	e.cutoverNanos = sm.CutoverNanos
+	e.metrics.metadataUpdates.Inc(1)
 
 	return nil
 }
 
 func (e *Entry) addMetricWithLock(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	multiErr := xerrors.NewMultiError()
-	for _, elem := range e.aggregations {
-		if err := elem.Value.(metricElem).AddMetric(timestamp, mu); err != nil {
+	for _, val := range e.aggregations {
+		if err := val.elem.Value.(metricElem).AddMetric(timestamp, mu); err != nil {
 			multiErr = multiErr.Add(err)
 		}
 	}
@@ -518,4 +551,38 @@ func (e *Entry) applyValueRateLimit(numValues int64) error {
 	e.metrics.valueRateLimitExceeded.Inc(1)
 	e.metrics.droppedValues.Inc(numValues)
 	return errWriteValueRateLimitExceeded
+}
+
+type aggregationKey struct {
+	aggregationID aggregation.ID
+	storagePolicy policy.StoragePolicy
+	pipeline      applied.Pipeline
+}
+
+func (k aggregationKey) Equal(other aggregationKey) bool {
+	return k.aggregationID == other.aggregationID &&
+		k.storagePolicy == other.storagePolicy &&
+		k.pipeline.Equal(other.pipeline)
+}
+
+type aggregationValue struct {
+	key  aggregationKey
+	elem *list.Element
+}
+
+// TODO(xichen): benchmark the performance of using a single slice
+// versus a map with a partial key versus a map with a hash of full key.
+type aggregationValues []aggregationValue
+
+func (vals aggregationValues) index(k aggregationKey) int {
+	for i, val := range vals {
+		if val.key.Equal(k) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (vals aggregationValues) contains(k aggregationKey) bool {
+	return vals.index(k) != -1
 }

--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/m3db/m3aggregator/rate"
 	"github.com/m3db/m3aggregator/runtime"
+	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/close"
 	xid "github.com/m3db/m3x/ident"
@@ -128,19 +128,19 @@ func newMetricMap(shard uint32, opts Options) *metricMap {
 	return m
 }
 
-func (m *metricMap) AddMetricWithPoliciesList(
-	mu unaggregated.MetricUnion,
-	pl policy.PoliciesList,
+func (m *metricMap) AddUntimed(
+	metric unaggregated.MetricUnion,
+	metadatas metadata.StagedMetadatas,
 ) error {
-	entryKey := entryKey{
-		metricType: mu.Type,
-		idHash:     xid.Murmur3Hash128(mu.ID),
+	key := entryKey{
+		metricType: metric.Type,
+		idHash:     xid.Murmur3Hash128(metric.ID),
 	}
-	entry, err := m.findOrCreate(entryKey)
+	entry, err := m.findOrCreate(key)
 	if err != nil {
 		return err
 	}
-	err = entry.AddMetricWithPoliciesList(mu, pl)
+	err = entry.AddUntimed(metric, metadatas)
 	entry.DecWriter()
 	return err
 }

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3aggregator/sharding"
 	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/op/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
@@ -48,9 +49,9 @@ var (
 	defaultEntryCheckBatchPercent    = 0.01
 	defaultMaxTimerBatchSizePerWrite = 0
 	defaultResignTimeout             = 5 * time.Minute
-	defaultDefaultPolicies           = []policy.Policy{
-		policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*24*time.Hour), aggregation.DefaultID),
-		policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 40*24*time.Hour), aggregation.DefaultID),
+	defaultDefaultStoragePolicies    = []policy.StoragePolicy{
+		policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*24*time.Hour),
+		policy.NewStoragePolicy(time.Minute, xtime.Minute, 40*24*time.Hour),
 	}
 
 	// By default writes are buffered for 10 minutes before traffic is cut over to a shard
@@ -205,11 +206,11 @@ type Options interface {
 	// MaxTimerBatchSizePerWrite returns the maximum timer batch size for each batched write.
 	MaxTimerBatchSizePerWrite() int
 
-	// SetDefaultPolicies sets the default policies.
-	SetDefaultPolicies(value []policy.Policy) Options
+	// SetDefaultStoragePolicies sets the default policies.
+	SetDefaultStoragePolicies(value []policy.StoragePolicy) Options
 
-	// DefaultPolicies returns the default policies.
-	DefaultPolicies() []policy.Policy
+	// DefaultStoragePolicies returns the default storage policies.
+	DefaultStoragePolicies() []policy.StoragePolicy
 
 	// SetResignTimeout sets the resign timeout.
 	SetResignTimeout(value time.Duration) Options
@@ -276,7 +277,7 @@ type options struct {
 	entryCheckInterval               time.Duration
 	entryCheckBatchPercent           float64
 	maxTimerBatchSizePerWrite        int
-	defaultPolicies                  []policy.Policy
+	defaultStoragePolicies           []policy.StoragePolicy
 	flushTimesManager                FlushTimesManager
 	electionManager                  ElectionManager
 	resignTimeout                    time.Duration
@@ -313,7 +314,7 @@ func NewOptions() Options {
 		entryCheckInterval:               defaultEntryCheckInterval,
 		entryCheckBatchPercent:           defaultEntryCheckBatchPercent,
 		maxTimerBatchSizePerWrite:        defaultMaxTimerBatchSizePerWrite,
-		defaultPolicies:                  defaultDefaultPolicies,
+		defaultStoragePolicies:           defaultDefaultStoragePolicies,
 		resignTimeout:                    defaultResignTimeout,
 	}
 
@@ -560,14 +561,14 @@ func (o *options) MaxTimerBatchSizePerWrite() int {
 	return o.maxTimerBatchSizePerWrite
 }
 
-func (o *options) SetDefaultPolicies(value []policy.Policy) Options {
+func (o *options) SetDefaultStoragePolicies(value []policy.StoragePolicy) Options {
 	opts := *o
-	opts.defaultPolicies = value
+	opts.defaultStoragePolicies = value
 	return &opts
 }
 
-func (o *options) DefaultPolicies() []policy.Policy {
-	return o.defaultPolicies
+func (o *options) DefaultStoragePolicies() []policy.StoragePolicy {
+	return o.defaultStoragePolicies
 }
 
 func (o *options) SetResignTimeout(value time.Duration) Options {
@@ -645,17 +646,17 @@ func (o *options) initPools() {
 
 	o.counterElemPool = NewCounterElemPool(nil)
 	o.counterElemPool.Init(func() *CounterElem {
-		return NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, o)
+		return NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
 	})
 
 	o.timerElemPool = NewTimerElemPool(nil)
 	o.timerElemPool.Init(func() *TimerElem {
-		return NewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, o)
+		return NewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
 	})
 
 	o.gaugeElemPool = NewGaugeElemPool(nil)
 	o.gaugeElemPool.Init(func() *GaugeElem {
-		return NewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, o)
+		return NewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
 	})
 }
 

--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bitset
+
+import (
+	"github.com/willf/bitset"
+)
+
+// BitSet is a specialized bitset that does not perform heap allocations if the
+// range of values in the bitset is small (e.g., [0, 64)). It falls back to
+// github.com/willf/bitset for large value ranges.
+type BitSet struct {
+	smallRange bool
+	val        uint64
+	bs         *bitset.BitSet
+}
+
+// New can be used to keep track of values between [0, maxExclusive).
+// Calling APIs with values outside that range may lead to incorrect results.
+func New(maxExclusive uint) BitSet {
+	if maxExclusive <= 64 {
+		return BitSet{smallRange: true}
+	}
+	return BitSet{bs: bitset.New(maxExclusive)}
+}
+
+// Set sets the bit associated with the given value.
+func (bs *BitSet) Set(i uint) {
+	if bs.smallRange {
+		bs.val = bs.val | (1 << i)
+		return
+	}
+	bs.bs.Set(i)
+}
+
+// All returns true if all the bits for values between [0, maxExclusive)
+// are set.
+func (bs *BitSet) All(maxExclusive uint) bool {
+	if bs.smallRange {
+		mask := uint64((1 << maxExclusive) - 1)
+		return (bs.val & mask) == mask
+	}
+	for i := uint(0); i < maxExclusive; i++ {
+		if !bs.bs.Test(i) {
+			return false
+		}
+	}
+	return true
+}

--- a/bitset/bitset_benchmark_test.go
+++ b/bitset/bitset_benchmark_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bitset
+
+import "testing"
+
+func BenchmarkBitSetSmallRange(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for j := 0; j <= 64; j++ {
+			bs := New(uint(j))
+			for k := 0; k < j; k++ {
+				bs.Set(uint(k))
+			}
+			bs.All(uint(j))
+		}
+	}
+}
+
+func BenchmarkBitSetLargeRange(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for j := 65; j <= 256; j++ {
+			bs := New(uint(j))
+			for k := 0; k < j; k++ {
+				bs.Set(uint(k))
+			}
+			bs.All(uint(j))
+		}
+	}
+}

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bitset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitSetSmallRangeSetAll(t *testing.T) {
+	for i := 0; i <= 64; i++ {
+		bs := New(uint(i))
+		for j := 0; j < i; j++ {
+			bs.Set(uint(j))
+		}
+		require.True(t, bs.All(uint(i)))
+	}
+}
+
+func TestBitSetSmallRangeSetPartial(t *testing.T) {
+	for i := 1; i <= 64; i++ {
+		for skip := 0; skip < i; skip++ {
+			bs := New(uint(i))
+			for j := 0; j < i; j++ {
+				if j == skip {
+					continue
+				}
+				bs.Set(uint(j))
+			}
+			require.False(t, bs.All(uint(i)))
+		}
+	}
+}
+
+func TestBitSetLargeRangeSetAll(t *testing.T) {
+	for i := 65; i <= 256; i++ {
+		bs := New(uint(i))
+		for j := 0; j < i; j++ {
+			bs.Set(uint(j))
+		}
+		require.True(t, bs.All(uint(i)))
+	}
+}
+
+func TestBitSetLargeRangeSetPartial(t *testing.T) {
+	for i := 65; i <= 256; i++ {
+		for skip := 0; skip < i; skip++ {
+			bs := New(uint(i))
+			for j := 0; j < i; j++ {
+				if j == skip {
+					continue
+				}
+				bs.Set(uint(j))
+			}
+			require.False(t, bs.All(uint(i)))
+		}
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 352c7ed1ef25c834843f1da320e45bad85ea5d7f39055e184ea4ab954a9704c2
-updated: 2018-03-23T13:58:52.613263231-04:00
+hash: ac4a763f43c3946849c3b9d4f72034d23e5051f2465f2a9e3cc94e82208888ae
+updated: 2018-03-23T15:34:28.974946815-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -180,7 +180,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: d3e872082b214a8ab743d4639c860ee39d7ebb8a
+  version: 8aa2467fbe78ba38fd03fa7ca03c32997393327d
   subpackages:
   - aggregation
   - generated/proto/schema

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bfa53c86eb804751ca738c8375f2ca6f67d5289cf28ec507ff0c29b9119c6e5f
-updated: 2018-03-19T10:24:42.109433159-04:00
+hash: 352c7ed1ef25c834843f1da320e45bad85ea5d7f39055e184ea4ab954a9704c2
+updated: 2018-03-23T13:58:52.613263231-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -180,16 +180,20 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: d4a5c022c5f0c23489c58ef2ce360d12713f799b
+  version: d3e872082b214a8ab743d4639c860ee39d7ebb8a
   subpackages:
   - aggregation
   - generated/proto/schema
+  - metadata
   - metric
   - metric/aggregated
   - metric/id
   - metric/unaggregated
+  - op
+  - op/applied
   - policy
   - protocol/msgpack
+  - transformation
 - name: github.com/m3db/m3x
   version: a3695ff2d9696fcd9fffca878b9b544e68c4b1ef
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: d4a5c022c5f0c23489c58ef2ce360d12713f799b
+  version: d3e872082b214a8ab743d4639c860ee39d7ebb8a
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: d3e872082b214a8ab743d4639c860ee39d7ebb8a
+  version: 8aa2467fbe78ba38fd03fa7ca03c32997393327d
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/op/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
@@ -274,7 +275,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	counterElemPool := aggregator.NewCounterElemPool(counterElemPoolOpts)
 	opts = opts.SetCounterElemPool(counterElemPool)
 	counterElemPool.Init(func() *aggregator.CounterElem {
-		return aggregator.NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, opts)
+		return aggregator.NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
 	})
 
 	// Set timer elem pool.
@@ -283,7 +284,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	timerElemPool := aggregator.NewTimerElemPool(timerElemPoolOpts)
 	opts = opts.SetTimerElemPool(timerElemPool)
 	timerElemPool.Init(func() *aggregator.TimerElem {
-		return aggregator.NewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, opts)
+		return aggregator.NewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
 	})
 
 	// Set gauge elem pool.
@@ -292,7 +293,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
 	opts = opts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem {
-		return aggregator.NewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, opts)
+		return aggregator.NewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
 	})
 
 	// Set entry pool.


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds logic to ingest untimed metrics with pipeline metadata at the aggregation tier.