### PR TITLE
Aggregation elements flush or forward metrics based on pipeline metadata

### DIFF
--- a/aggregator/elem_base.go
+++ b/aggregator/elem_base.go
@@ -22,6 +22,8 @@ package aggregator
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	maggregation "github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
+	"github.com/m3db/m3metrics/op"
 	"github.com/m3db/m3metrics/op/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
@@ -37,19 +40,15 @@ import (
 const (
 	// Default number of aggregation buckets allocated initially.
 	defaultNumValues = 2
+
+	// Maximum transformation derivative order that is supported.
+	maxSupportedTransformationDerivativeOrer = 1
 )
 
 var (
-	errElemClosed = errors.New("element is closed")
-)
-
-type aggMetricFn func(
-	idPrefix []byte,
-	id id.RawID,
-	idSuffix []byte,
-	timeNanos int64,
-	value float64,
-	sp policy.StoragePolicy,
+	nan                           = math.NaN()
+	errElemClosed                 = errors.New("element is closed")
+	errNoRollupInNonEmptyPipeline = errors.New("no rollup operation in pipeline")
 )
 
 // metricElem is the common interface for metric elements.
@@ -63,16 +62,20 @@ type metricElem interface {
 		sp policy.StoragePolicy,
 		aggTypes maggregation.Types,
 		pipeline applied.Pipeline,
-	)
+	) error
 
 	// AddMetric adds a new metric value.
 	// TODO(xichen): a value union would suffice here.
 	AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error
 
-	// Consume processes values before a given time and discards
-	// them afterwards, returning whether the element can be collected
-	// after discarding the values.
-	Consume(earlierThanNanos int64, fn aggMetricFn) bool
+	// Consume consumes values before a given time and removes
+	// them from the element after they are consumed, returning whether
+	// the element can be collected after the consumption is completed.
+	Consume(
+		earlierThanNanos int64,
+		flushLocalFn flushLocalMetricFn,
+		flushForwardFn flushForwardMetricFn,
+	) bool
 
 	// MarkAsTombstoned marks an element as tombstoned, which means this element
 	// will be deleted once its aggregated values have been flushed.
@@ -85,15 +88,19 @@ type metricElem interface {
 type elemBase struct {
 	sync.RWMutex
 
+	// Immutable states.
 	opts                  Options
 	aggTypesOpts          maggregation.TypesOptions
 	id                    id.RawID
 	sp                    policy.StoragePolicy
+	useDefaultAggregation bool
 	aggTypes              maggregation.Types
 	aggOpts               raggregation.Options
-	useDefaultAggregation bool
-	tombstoned            bool
-	closed                bool
+	parsedPipeline        parsedPipeline
+
+	// Mutable states.
+	tombstoned bool
+	closed     bool
 }
 
 func newElemBase(opts Options) elemBase {
@@ -105,14 +112,26 @@ func newElemBase(opts Options) elemBase {
 }
 
 // resetSetData resets the element base and sets data.
-func (e *elemBase) resetSetData(id id.RawID, sp policy.StoragePolicy, aggTypes maggregation.Types, useDefaultAggregation bool) {
+func (e *elemBase) resetSetData(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	useDefaultAggregation bool,
+	pipeline applied.Pipeline,
+) error {
+	parsed, err := newParsedPipeline(pipeline)
+	if err != nil {
+		return err
+	}
 	e.id = id
 	e.sp = sp
 	e.aggTypes = aggTypes
 	e.useDefaultAggregation = useDefaultAggregation
 	e.aggOpts.ResetSetData(aggTypes)
+	e.parsedPipeline = parsed
 	e.tombstoned = false
 	e.closed = false
+	return nil
 }
 
 // ID returns the metric id.
@@ -139,10 +158,6 @@ type counterElemBase struct{}
 
 func (e counterElemBase) FullPrefix(opts Options) []byte { return opts.FullCounterPrefix() }
 
-func (e counterElemBase) DefaultAggregationTypeStrings(aggTypesOpts maggregation.TypesOptions) [][]byte {
-	return aggTypesOpts.DefaultCounterAggregationTypeStrings()
-}
-
 func (e counterElemBase) DefaultAggregationTypes(aggTypesOpts maggregation.TypesOptions) maggregation.Types {
 	return aggTypesOpts.DefaultCounterAggregationTypes()
 }
@@ -157,8 +172,18 @@ func (e counterElemBase) NewLockedAggregation(_ Options, aggOpts raggregation.Op
 	return newLockedCounter(raggregation.NewCounter(aggOpts))
 }
 
-func (e *counterElemBase) ResetSetData(maggregation.TypesOptions, maggregation.Types, bool) {}
-func (e *counterElemBase) Close()                                                           {}
+func (e *counterElemBase) ResetSetData(
+	_ maggregation.TypesOptions,
+	aggTypes maggregation.Types,
+	_ bool,
+) error {
+	if !aggTypes.IsValidForCounter() {
+		return fmt.Errorf("invalid aggregation types %s for counter", aggTypes.String())
+	}
+	return nil
+}
+
+func (e *counterElemBase) Close() {}
 
 type timerElemBase struct {
 	quantiles     []float64
@@ -166,10 +191,6 @@ type timerElemBase struct {
 }
 
 func (e timerElemBase) FullPrefix(opts Options) []byte { return opts.FullTimerPrefix() }
-
-func (e timerElemBase) DefaultAggregationTypeStrings(aggTypesOpts maggregation.TypesOptions) [][]byte {
-	return aggTypesOpts.DefaultTimerAggregationTypeStrings()
-}
 
 func (e timerElemBase) DefaultAggregationTypes(aggTypesOpts maggregation.TypesOptions) maggregation.Types {
 	return aggTypesOpts.DefaultTimerAggregationTypes()
@@ -190,11 +211,14 @@ func (e *timerElemBase) ResetSetData(
 	aggTypesOpts maggregation.TypesOptions,
 	aggTypes maggregation.Types,
 	useDefaultAggregation bool,
-) {
+) error {
+	if !aggTypes.IsValidForTimer() {
+		return fmt.Errorf("invalid aggregation types %s for timer", aggTypes.String())
+	}
 	if useDefaultAggregation {
 		e.quantiles = aggTypesOpts.TimerQuantiles()
 		e.quantilesPool = nil
-		return
+		return nil
 	}
 
 	var (
@@ -207,6 +231,7 @@ func (e *timerElemBase) ResetSetData(
 	} else {
 		e.quantilesPool = nil
 	}
+	return nil
 }
 
 func (e *timerElemBase) Close() {
@@ -220,10 +245,6 @@ func (e *timerElemBase) Close() {
 type gaugeElemBase struct{}
 
 func (e gaugeElemBase) FullPrefix(opts Options) []byte { return opts.FullGaugePrefix() }
-
-func (e gaugeElemBase) DefaultAggregationTypeStrings(aggTypesOpts maggregation.TypesOptions) [][]byte {
-	return aggTypesOpts.DefaultGaugeAggregationTypeStrings()
-}
 
 func (e gaugeElemBase) DefaultAggregationTypes(aggTypesOpts maggregation.TypesOptions) maggregation.Types {
 	return aggTypesOpts.DefaultGaugeAggregationTypes()
@@ -239,5 +260,89 @@ func (e gaugeElemBase) NewLockedAggregation(_ Options, aggOpts raggregation.Opti
 	return newLockedGauge(raggregation.NewGauge(aggOpts))
 }
 
-func (e *gaugeElemBase) ResetSetData(maggregation.TypesOptions, maggregation.Types, bool) {}
-func (e *gaugeElemBase) Close()                                                           {}
+func (e *gaugeElemBase) ResetSetData(
+	_ maggregation.TypesOptions,
+	aggTypes maggregation.Types,
+	_ bool,
+) error {
+	if !aggTypes.IsValidForGauge() {
+		return fmt.Errorf("invalid aggregation types %s for Gauge", aggTypes.String())
+	}
+	return nil
+}
+
+func (e *gaugeElemBase) Close() {}
+
+type parsedPipeline struct {
+	// Whether the source pipeline contains derivative transformations at its head.
+	HasDerivativeTransform bool
+
+	// Sub-pipline containing only transformation operations from the head
+	// of the source pipeline this parsed pipeline was derived from.
+	Transformations applied.Pipeline
+
+	// Whether the source pipeline contains a rollup operation that is either at the
+	// head of the source pipeline or immediately following the transformation operations
+	// at the head of the source pipeline if any.
+	HasRollup bool
+
+	// Rollup operation that is either at the head of the source pipeline or
+	// immediately following the transformation operations at the head of the
+	// source pipeline if applicable.
+	Rollup applied.Rollup
+
+	// The remainder of the source pipeline after stripping the transformation
+	// and rollup operations from the head of the source pipeline.
+	Remainder applied.Pipeline
+}
+
+// parsePipeline parses the given pipeline and returns an error if the pipeline is invalid.
+// A valid pipeline should take the form of one of the following:
+// * Empty pipeline with no operations.
+// * Pipeline that starts with a rollup operation.
+// * Pipeline that starts with a transformation operation and contains at least one
+//   rollup operation. Additionally, the transformation derivative order computed from
+//   the list of transformations must be no more than the maximum transformation derivative
+//   order that is supported.
+func newParsedPipeline(pipeline applied.Pipeline) (parsedPipeline, error) {
+	if pipeline.IsEmpty() {
+		return parsedPipeline{}, nil
+	}
+	var (
+		firstRollupOpIdx              = -1
+		transformationDerivativeOrder int
+		numSteps                      = pipeline.NumSteps()
+	)
+	for i := 0; i < numSteps; i++ {
+		pipelineOp := pipeline.At(i)
+		if pipelineOp.Type != op.TransformationType && pipelineOp.Type != op.RollupType {
+			return parsedPipeline{}, fmt.Errorf("pipeline %v step %d has invalid operation type %v", pipeline, i, pipelineOp.Type)
+		}
+		if pipelineOp.Type == op.RollupType {
+			if firstRollupOpIdx == -1 {
+				firstRollupOpIdx = i
+			}
+		} else if firstRollupOpIdx == -1 {
+			// We only care about the transformation operations at the head of the pipeline
+			// before the first rollup operation since those are going to be processed locally.
+			transformOp := pipelineOp.Transformation
+			// A binary transformation is a transformation that computes first-order derivatives.
+			if transformOp.Type.IsBinaryTransform() {
+				transformationDerivativeOrder++
+			}
+		}
+	}
+	if firstRollupOpIdx == -1 {
+		return parsedPipeline{}, fmt.Errorf("pipeline %v has no rollup operations", pipeline)
+	}
+	if transformationDerivativeOrder > maxSupportedTransformationDerivativeOrer {
+		return parsedPipeline{}, fmt.Errorf("pipeline %v transformation derivative order is %d higher than supported %d", pipeline, transformationDerivativeOrder, maxSupportedTransformationDerivativeOrer)
+	}
+	return parsedPipeline{
+		HasDerivativeTransform: transformationDerivativeOrder > 0,
+		Transformations:        pipeline.SubPipeline(0, firstRollupOpIdx),
+		HasRollup:              true,
+		Rollup:                 pipeline.At(firstRollupOpIdx).Rollup,
+		Remainder:              pipeline.SubPipeline(firstRollupOpIdx+1, numSteps),
+	}, nil
+}

--- a/aggregator/flush.go
+++ b/aggregator/flush.go
@@ -20,7 +20,13 @@
 
 package aggregator
 
-import "time"
+import (
+	"time"
+
+	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3metrics/policy"
+)
 
 // FlushRequest is a request to flush data.
 type FlushRequest struct {
@@ -60,4 +66,27 @@ type flushType int
 const (
 	consumeType flushType = iota
 	discardType
+)
+
+// A flushLocalMetricFn flushes an aggregated metric datapoint locally by either
+// consuming or discarding it. Processing of the datapoint is completed once it is
+// flushed.
+type flushLocalMetricFn func(
+	idPrefix []byte,
+	id id.RawID,
+	idSuffix []byte,
+	timeNanos int64,
+	value float64,
+	sp policy.StoragePolicy,
+)
+
+// A flushForwardMetricFn flushes an aggregated metric datapoint eligible for
+// forwarding by either forwarding it (potentially to a different aggregation
+// server) or dropping it. Processing of the datapoint continues after it is
+// flushed as required by the pipeline.
+type flushForwardMetricFn func(
+	id id.RawID,
+	timeNanos int64,
+	value float64,
+	meta metadata.ForwardMetadata,
 )

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -25,9 +25,13 @@
 package aggregator
 
 import (
+	"fmt"
+
 	"time"
 
 	maggregation "github.com/m3db/m3metrics/aggregation"
+
+	"github.com/m3db/m3metrics/metadata"
 
 	"github.com/m3db/m3metrics/metric/id"
 
@@ -36,6 +40,8 @@ import (
 	"github.com/m3db/m3metrics/op/applied"
 
 	"github.com/m3db/m3metrics/policy"
+
+	"github.com/m3db/m3metrics/transformation"
 )
 
 type timedGauge struct {
@@ -53,8 +59,10 @@ type GaugeElem struct {
 	elemBase
 	gaugeElemBase
 
-	values    []timedGauge // metric aggregations sorted by time in ascending order
-	toConsume []timedGauge
+	values              []timedGauge // metric aggregations sorted by time in ascending order
+	toConsume           []timedGauge // small buffer to avoid memory allocations during consumption
+	lastConsumedAtNanos int64        // last consumed at in Unix nanoseconds
+	lastConsumedValues  []float64    // last consumed values
 }
 
 // NewGaugeElem creates a new element for the given metric type.
@@ -64,33 +72,66 @@ func NewGaugeElem(
 	aggTypes maggregation.Types,
 	pipeline applied.Pipeline,
 	opts Options,
-) *GaugeElem {
+) (*GaugeElem, error) {
 	e := &GaugeElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedGauge, 0, defaultNumValues), // in most cases values will have two entries
 	}
-	e.ResetSetData(id, sp, aggTypes, pipeline)
-	return e
+	if err := e.ResetSetData(id, sp, aggTypes, pipeline); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// MustNewGaugeElem creates a new element, or panics if the input is invalid.
+func MustNewGaugeElem(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+	opts Options,
+) *GaugeElem {
+	elem, err := NewGaugeElem(id, sp, aggTypes, pipeline, opts)
+	if err != nil {
+		panic(fmt.Errorf("unable to create element: %v", err))
+	}
+	return elem
 }
 
 // ResetSetData resets the element and sets data.
-// TODO(xichen): handle pipelines properly.
 func (e *GaugeElem) ResetSetData(
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
 	pipeline applied.Pipeline,
-) {
+) error {
 	useDefaultAggregation := aggTypes.IsDefault()
 	if useDefaultAggregation {
 		aggTypes = e.DefaultAggregationTypes(e.aggTypesOpts)
 	}
-
-	e.gaugeElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation)
-	e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation)
+	if err := e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation, pipeline); err != nil {
+		return err
+	}
+	if err := e.gaugeElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation); err != nil {
+		return err
+	}
+	// If the pipeline contains derivative transformations, we need to store past
+	// values in order to compute the derivatives.
+	if !e.parsedPipeline.HasDerivativeTransform {
+		return nil
+	}
+	numAggTypes := len(e.aggTypes)
+	if cap(e.lastConsumedValues) < numAggTypes {
+		e.lastConsumedValues = make([]float64, numAggTypes)
+	}
+	e.lastConsumedValues = e.lastConsumedValues[:numAggTypes]
+	for i := 0; i < len(e.lastConsumedValues); i++ {
+		e.lastConsumedValues[i] = nan
+	}
+	return nil
 }
 
-// AddMetric adds a new value.
+// AddMetric adds a new metric value.
 func (e *GaugeElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	agg, err := e.findOrCreate(alignedStart)
@@ -103,10 +144,16 @@ func (e *GaugeElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 	return nil
 }
 
-// Consume processes values before a given time and discards
-// them afterwards, returning whether the element can be collected
-// after consuming the values.
-func (e *GaugeElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
+// Consume consumes values before a given time and removes them from the element
+// after they are consumed, returning whether the element can be collected after
+// the consumption is completed.
+// NB: Consume is not thread-safe and must be called within a single goroutine
+// to avoid race conditions.
+func (e *GaugeElem) Consume(
+	earlierThanNanos int64,
+	flushLocalFn flushLocalMetricFn,
+	flushForwardFn flushForwardMetricFn,
+) bool {
 	e.Lock()
 	if e.closed {
 		e.Unlock()
@@ -138,7 +185,7 @@ func (e *GaugeElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, fn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -156,6 +203,7 @@ func (e *GaugeElem) Close() {
 	}
 	e.closed = true
 	e.id = nil
+	e.parsedPipeline = parsedPipeline{}
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
 		e.values[idx].aggregation.Close()
@@ -163,6 +211,7 @@ func (e *GaugeElem) Close() {
 	}
 	e.values = e.values[:0]
 	e.toConsume = e.toConsume[:0]
+	e.lastConsumedValues = e.lastConsumedValues[:0]
 	e.gaugeElemBase.Close()
 	aggTypesPool := e.aggTypesOpts.TypesPool()
 	pool := e.ElemPool(e.opts)
@@ -244,23 +293,50 @@ func (e *GaugeElem) indexOfWithLock(alignedStart int64) (int, bool) {
 	return left, false
 }
 
-func (e *GaugeElem) processValue(timeNanos int64, agg *lockedGauge, fn aggMetricFn) {
-	var fullPrefix = e.FullPrefix(e.opts)
-	if e.useDefaultAggregation {
-		// NB(cw) Use default suffix slice for faster look up.
-		suffixes := e.DefaultAggregationTypeStrings(e.aggTypesOpts)
-		aggTypes := e.DefaultAggregationTypes(e.aggTypesOpts)
-		agg.Lock()
-		for i, aggType := range aggTypes {
-			fn(fullPrefix, e.id, suffixes[i], timeNanos, agg.ValueOf(aggType), e.sp)
-		}
-		agg.Unlock()
-		return
-	}
-
+func (e *GaugeElem) processValue(
+	timeNanos int64,
+	agg *lockedGauge,
+	flushLocalFn flushLocalMetricFn,
+	flushForwardFn flushForwardMetricFn,
+) {
+	var (
+		fullPrefix      = e.FullPrefix(e.opts)
+		transformations = e.parsedPipeline.Transformations
+	)
 	agg.Lock()
-	for _, aggType := range e.aggTypes {
-		fn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+	for aggTypeIdx, aggType := range e.aggTypes {
+		value := agg.ValueOf(aggType)
+		for i := 0; i < transformations.NumSteps(); i++ {
+			transformType := transformations.At(i).Transformation.Type
+			if transformType.IsUnaryTransform() {
+				fn := transformType.MustUnaryTransform()
+				res := fn(transformation.Datapoint{TimeNanos: timeNanos, Value: value})
+				value = res.Value
+			} else {
+				fn := transformType.MustBinaryTransform()
+				prev := transformation.Datapoint{TimeNanos: e.lastConsumedAtNanos, Value: e.lastConsumedValues[aggTypeIdx]}
+				curr := transformation.Datapoint{TimeNanos: timeNanos, Value: value}
+				res := fn(prev, curr)
+				value = res.Value
+				// NB: we only need to record the value needed for derivative transformations.
+				// We currently only support first-order derivative transformations so we only
+				// need to keep one value. In the future if we need to support higher-order
+				// derivative transformations, we need to store an array of values here.
+				e.lastConsumedValues[aggTypeIdx] = value
+			}
+		}
+		// Do we need to flush or forward NaNs?
+		if !e.parsedPipeline.HasRollup {
+			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
+		} else {
+			fm := metadata.ForwardMetadata{
+				AggregationID: e.parsedPipeline.Rollup.AggregationID,
+				StoragePolicy: e.sp,
+				Pipeline:      e.parsedPipeline.Remainder,
+			}
+			flushForwardFn(e.parsedPipeline.Rollup.ID, timeNanos, value, fm)
+		}
 	}
+	e.lastConsumedAtNanos = timeNanos
 	agg.Unlock()
 }

--- a/aggregator/generic_elem.go
+++ b/aggregator/generic_elem.go
@@ -21,15 +21,18 @@
 package aggregator
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	raggregation "github.com/m3db/m3aggregator/aggregation"
 	maggregation "github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/op/applied"
 	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3metrics/transformation"
 
 	"github.com/mauricelam/genny/generic"
 )
@@ -61,9 +64,6 @@ type typeSpecificElemBase interface {
 	// FullPrefix returns the full prefix for the given metric type.
 	FullPrefix(opts Options) []byte
 
-	// DefaultAggregationTypeStrings returns the default aggregation type strings.
-	DefaultAggregationTypeStrings(aggTypesOpts maggregation.TypesOptions) [][]byte
-
 	// DefaultAggregationTypes returns the default aggregation types.
 	DefaultAggregationTypes(aggTypesOpts maggregation.TypesOptions) maggregation.Types
 
@@ -81,7 +81,7 @@ type typeSpecificElemBase interface {
 		aggTypesOpts maggregation.TypesOptions,
 		aggTypes maggregation.Types,
 		useDefaultAggregation bool,
-	)
+	) error
 
 	// Close closes the element.
 	Close()
@@ -102,8 +102,10 @@ type GenericElem struct {
 	elemBase
 	typeSpecificElemBase
 
-	values    []timedAggregation // metric aggregations sorted by time in ascending order
-	toConsume []timedAggregation
+	values              []timedAggregation // metric aggregations sorted by time in ascending order
+	toConsume           []timedAggregation // small buffer to avoid memory allocations during consumption
+	lastConsumedAtNanos int64              // last consumed at in Unix nanoseconds
+	lastConsumedValues  []float64          // last consumed values
 }
 
 // NewGenericElem creates a new element for the given metric type.
@@ -113,33 +115,66 @@ func NewGenericElem(
 	aggTypes maggregation.Types,
 	pipeline applied.Pipeline,
 	opts Options,
-) *GenericElem {
+) (*GenericElem, error) {
 	e := &GenericElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedAggregation, 0, defaultNumValues), // in most cases values will have two entries
 	}
-	e.ResetSetData(id, sp, aggTypes, pipeline)
-	return e
+	if err := e.ResetSetData(id, sp, aggTypes, pipeline); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// MustNewGenericElem creates a new element, or panics if the input is invalid.
+func MustNewGenericElem(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+	opts Options,
+) *GenericElem {
+	elem, err := NewGenericElem(id, sp, aggTypes, pipeline, opts)
+	if err != nil {
+		panic(fmt.Errorf("unable to create element: %v", err))
+	}
+	return elem
 }
 
 // ResetSetData resets the element and sets data.
-// TODO(xichen): handle pipelines properly.
 func (e *GenericElem) ResetSetData(
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
 	pipeline applied.Pipeline,
-) {
+) error {
 	useDefaultAggregation := aggTypes.IsDefault()
 	if useDefaultAggregation {
 		aggTypes = e.DefaultAggregationTypes(e.aggTypesOpts)
 	}
-
-	e.typeSpecificElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation)
-	e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation)
+	if err := e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation, pipeline); err != nil {
+		return err
+	}
+	if err := e.typeSpecificElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation); err != nil {
+		return err
+	}
+	// If the pipeline contains derivative transformations, we need to store past
+	// values in order to compute the derivatives.
+	if !e.parsedPipeline.HasDerivativeTransform {
+		return nil
+	}
+	numAggTypes := len(e.aggTypes)
+	if cap(e.lastConsumedValues) < numAggTypes {
+		e.lastConsumedValues = make([]float64, numAggTypes)
+	}
+	e.lastConsumedValues = e.lastConsumedValues[:numAggTypes]
+	for i := 0; i < len(e.lastConsumedValues); i++ {
+		e.lastConsumedValues[i] = nan
+	}
+	return nil
 }
 
-// AddMetric adds a new value.
+// AddMetric adds a new metric value.
 func (e *GenericElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	agg, err := e.findOrCreate(alignedStart)
@@ -152,10 +187,16 @@ func (e *GenericElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion
 	return nil
 }
 
-// Consume processes values before a given time and discards
-// them afterwards, returning whether the element can be collected
-// after consuming the values.
-func (e *GenericElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
+// Consume consumes values before a given time and removes them from the element
+// after they are consumed, returning whether the element can be collected after
+// the consumption is completed.
+// NB: Consume is not thread-safe and must be called within a single goroutine
+// to avoid race conditions.
+func (e *GenericElem) Consume(
+	earlierThanNanos int64,
+	flushLocalFn flushLocalMetricFn,
+	flushForwardFn flushForwardMetricFn,
+) bool {
 	e.Lock()
 	if e.closed {
 		e.Unlock()
@@ -187,7 +228,7 @@ func (e *GenericElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, fn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -205,6 +246,7 @@ func (e *GenericElem) Close() {
 	}
 	e.closed = true
 	e.id = nil
+	e.parsedPipeline = parsedPipeline{}
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
 		e.values[idx].aggregation.Close()
@@ -212,6 +254,7 @@ func (e *GenericElem) Close() {
 	}
 	e.values = e.values[:0]
 	e.toConsume = e.toConsume[:0]
+	e.lastConsumedValues = e.lastConsumedValues[:0]
 	e.typeSpecificElemBase.Close()
 	aggTypesPool := e.aggTypesOpts.TypesPool()
 	pool := e.ElemPool(e.opts)
@@ -293,23 +336,50 @@ func (e *GenericElem) indexOfWithLock(alignedStart int64) (int, bool) {
 	return left, false
 }
 
-func (e *GenericElem) processValue(timeNanos int64, agg lockedAggregation, fn aggMetricFn) {
-	var fullPrefix = e.FullPrefix(e.opts)
-	if e.useDefaultAggregation {
-		// NB(cw) Use default suffix slice for faster look up.
-		suffixes := e.DefaultAggregationTypeStrings(e.aggTypesOpts)
-		aggTypes := e.DefaultAggregationTypes(e.aggTypesOpts)
-		agg.Lock()
-		for i, aggType := range aggTypes {
-			fn(fullPrefix, e.id, suffixes[i], timeNanos, agg.ValueOf(aggType), e.sp)
-		}
-		agg.Unlock()
-		return
-	}
-
+func (e *GenericElem) processValue(
+	timeNanos int64,
+	agg lockedAggregation,
+	flushLocalFn flushLocalMetricFn,
+	flushForwardFn flushForwardMetricFn,
+) {
+	var (
+		fullPrefix      = e.FullPrefix(e.opts)
+		transformations = e.parsedPipeline.Transformations
+	)
 	agg.Lock()
-	for _, aggType := range e.aggTypes {
-		fn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+	for aggTypeIdx, aggType := range e.aggTypes {
+		value := agg.ValueOf(aggType)
+		for i := 0; i < transformations.NumSteps(); i++ {
+			transformType := transformations.At(i).Transformation.Type
+			if transformType.IsUnaryTransform() {
+				fn := transformType.MustUnaryTransform()
+				res := fn(transformation.Datapoint{TimeNanos: timeNanos, Value: value})
+				value = res.Value
+			} else {
+				fn := transformType.MustBinaryTransform()
+				prev := transformation.Datapoint{TimeNanos: e.lastConsumedAtNanos, Value: e.lastConsumedValues[aggTypeIdx]}
+				curr := transformation.Datapoint{TimeNanos: timeNanos, Value: value}
+				res := fn(prev, curr)
+				value = res.Value
+				// NB: we only need to record the value needed for derivative transformations.
+				// We currently only support first-order derivative transformations so we only
+				// need to keep one value. In the future if we need to support higher-order
+				// derivative transformations, we need to store an array of values here.
+				e.lastConsumedValues[aggTypeIdx] = value
+			}
+		}
+		// Do we need to flush or forward NaNs?
+		if !e.parsedPipeline.HasRollup {
+			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
+		} else {
+			fm := metadata.ForwardMetadata{
+				AggregationID: e.parsedPipeline.Rollup.AggregationID,
+				StoragePolicy: e.sp,
+				Pipeline:      e.parsedPipeline.Remainder,
+			}
+			flushForwardFn(e.parsedPipeline.Rollup.ID, timeNanos, value, fm)
+		}
 	}
+	e.lastConsumedAtNanos = timeNanos
 	agg.Unlock()
 }

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/m3db/m3aggregator/aggregator/handler"
 	"github.com/m3db/m3aggregator/aggregator/handler/writer"
+	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	metricid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
@@ -100,14 +101,16 @@ type metricList struct {
 	flushInterval time.Duration
 	flushMgr      FlushManager
 
-	closed             bool
-	aggregations       *list.List
-	lastFlushedNanos   int64
-	toCollect          []*list.Element
-	flushBeforeFn      flushBeforeFn
-	consumeAggMetricFn aggMetricFn
-	discardAggMetricFn aggMetricFn
-	metrics            metricListMetrics
+	closed                 bool
+	aggregations           *list.List
+	lastFlushedNanos       int64
+	toCollect              []*list.Element
+	flushBeforeFn          flushBeforeFn
+	consumeLocalMetricFn   flushLocalMetricFn
+	discardLocalMetricFn   flushLocalMetricFn
+	consumeForwardMetricFn flushForwardMetricFn
+	discardForwardMetricFn flushForwardMetricFn
+	metrics                metricListMetrics
 }
 
 func newMetricList(shard uint32, resolution time.Duration, opts Options) (*metricList, error) {
@@ -143,8 +146,10 @@ func newMetricList(shard uint32, resolution time.Duration, opts Options) (*metri
 		metrics:       newMetricListMetrics(scope),
 	}
 	l.flushBeforeFn = l.flushBefore
-	l.consumeAggMetricFn = l.consumeAggregatedMetric
-	l.discardAggMetricFn = l.discardAggregatedMetric
+	l.consumeLocalMetricFn = l.consumeLocalMetric
+	l.discardLocalMetricFn = l.discardLocalMetric
+	l.consumeForwardMetricFn = l.consumeForwardMetric
+	l.discardForwardMetricFn = l.discardForwardMetric
 	l.flushMgr.Register(l)
 
 	return l, nil
@@ -264,9 +269,11 @@ func (l *metricList) flushBefore(beforeNanos int64, flushType flushType) {
 
 	flushBeforeStart := l.nowFn()
 	l.toCollect = l.toCollect[:0]
-	flushFn := l.consumeAggMetricFn
+	flushLocalFn := l.consumeLocalMetricFn
+	flushForwardFn := l.consumeForwardMetricFn
 	if flushType == discardType {
-		flushFn = l.discardAggMetricFn
+		flushLocalFn = l.discardLocalMetricFn
+		flushForwardFn = l.discardForwardMetricFn
 	}
 
 	// Flush out aggregations, may need to do it in batches if the read lock
@@ -276,7 +283,7 @@ func (l *metricList) flushBefore(beforeNanos int64, flushType flushType) {
 		// If the element is eligible for collection after the values are
 		// processed, close it and reset the value to nil.
 		elem := e.Value.(metricElem)
-		if elem.Consume(alignedBeforeNanos, flushFn) {
+		if elem.Consume(alignedBeforeNanos, flushLocalFn, flushForwardFn) {
 			elem.Close()
 			e.Value = nil
 			l.toCollect = append(l.toCollect, e)
@@ -307,7 +314,7 @@ func (l *metricList) flushBefore(beforeNanos int64, flushType flushType) {
 	l.metrics.flushBeforeDuration.Record(flushBeforeDuration)
 }
 
-func (l *metricList) consumeAggregatedMetric(
+func (l *metricList) consumeLocalMetric(
 	idPrefix []byte,
 	id metricid.RawID,
 	idSuffix []byte,
@@ -335,9 +342,8 @@ func (l *metricList) consumeAggregatedMetric(
 	}
 }
 
-// discardAggregatedMetric discards aggregated metrics.
 // nolint: unparam
-func (l *metricList) discardAggregatedMetric(
+func (l *metricList) discardLocalMetric(
 	idPrefix []byte,
 	id metricid.RawID,
 	idSuffix []byte,
@@ -346,6 +352,28 @@ func (l *metricList) discardAggregatedMetric(
 	sp policy.StoragePolicy,
 ) {
 	l.metrics.flushMetricDiscarded.Inc(1)
+}
+
+// consumeForwardMetric consumes a forward metric.
+// TODO(xichen): implement this.
+func (l *metricList) consumeForwardMetric(
+	id metricid.RawID,
+	timeNanos int64,
+	value float64,
+	meta metadata.ForwardMetadata,
+) {
+
+}
+
+// discardForwardMetric discards a forward metric.
+// TODO(xichen): implement this.
+func (l *metricList) discardForwardMetric(
+	id metricid.RawID,
+	timeNanos int64,
+	value float64,
+	meta metadata.ForwardMetadata,
+) {
+
 }
 
 type newMetricListFn func(

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -646,17 +646,17 @@ func (o *options) initPools() {
 
 	o.counterElemPool = NewCounterElemPool(nil)
 	o.counterElemPool.Init(func() *CounterElem {
-		return NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
+		return MustNewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
 	})
 
 	o.timerElemPool = NewTimerElemPool(nil)
 	o.timerElemPool.Init(func() *TimerElem {
-		return NewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
+		return MustNewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
 	})
 
 	o.gaugeElemPool = NewGaugeElemPool(nil)
 	o.gaugeElemPool.Init(func() *GaugeElem {
-		return NewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
+		return MustNewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, o)
 	})
 }
 

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -25,9 +25,13 @@
 package aggregator
 
 import (
+	"fmt"
+
 	"time"
 
 	maggregation "github.com/m3db/m3metrics/aggregation"
+
+	"github.com/m3db/m3metrics/metadata"
 
 	"github.com/m3db/m3metrics/metric/id"
 
@@ -36,6 +40,8 @@ import (
 	"github.com/m3db/m3metrics/op/applied"
 
 	"github.com/m3db/m3metrics/policy"
+
+	"github.com/m3db/m3metrics/transformation"
 )
 
 type timedTimer struct {
@@ -53,8 +59,10 @@ type TimerElem struct {
 	elemBase
 	timerElemBase
 
-	values    []timedTimer // metric aggregations sorted by time in ascending order
-	toConsume []timedTimer
+	values              []timedTimer // metric aggregations sorted by time in ascending order
+	toConsume           []timedTimer // small buffer to avoid memory allocations during consumption
+	lastConsumedAtNanos int64        // last consumed at in Unix nanoseconds
+	lastConsumedValues  []float64    // last consumed values
 }
 
 // NewTimerElem creates a new element for the given metric type.
@@ -64,33 +72,66 @@ func NewTimerElem(
 	aggTypes maggregation.Types,
 	pipeline applied.Pipeline,
 	opts Options,
-) *TimerElem {
+) (*TimerElem, error) {
 	e := &TimerElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedTimer, 0, defaultNumValues), // in most cases values will have two entries
 	}
-	e.ResetSetData(id, sp, aggTypes, pipeline)
-	return e
+	if err := e.ResetSetData(id, sp, aggTypes, pipeline); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// MustNewTimerElem creates a new element, or panics if the input is invalid.
+func MustNewTimerElem(
+	id id.RawID,
+	sp policy.StoragePolicy,
+	aggTypes maggregation.Types,
+	pipeline applied.Pipeline,
+	opts Options,
+) *TimerElem {
+	elem, err := NewTimerElem(id, sp, aggTypes, pipeline, opts)
+	if err != nil {
+		panic(fmt.Errorf("unable to create element: %v", err))
+	}
+	return elem
 }
 
 // ResetSetData resets the element and sets data.
-// TODO(xichen): handle pipelines properly.
 func (e *TimerElem) ResetSetData(
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
 	pipeline applied.Pipeline,
-) {
+) error {
 	useDefaultAggregation := aggTypes.IsDefault()
 	if useDefaultAggregation {
 		aggTypes = e.DefaultAggregationTypes(e.aggTypesOpts)
 	}
-
-	e.timerElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation)
-	e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation)
+	if err := e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation, pipeline); err != nil {
+		return err
+	}
+	if err := e.timerElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation); err != nil {
+		return err
+	}
+	// If the pipeline contains derivative transformations, we need to store past
+	// values in order to compute the derivatives.
+	if !e.parsedPipeline.HasDerivativeTransform {
+		return nil
+	}
+	numAggTypes := len(e.aggTypes)
+	if cap(e.lastConsumedValues) < numAggTypes {
+		e.lastConsumedValues = make([]float64, numAggTypes)
+	}
+	e.lastConsumedValues = e.lastConsumedValues[:numAggTypes]
+	for i := 0; i < len(e.lastConsumedValues); i++ {
+		e.lastConsumedValues[i] = nan
+	}
+	return nil
 }
 
-// AddMetric adds a new value.
+// AddMetric adds a new metric value.
 func (e *TimerElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	agg, err := e.findOrCreate(alignedStart)
@@ -103,10 +144,16 @@ func (e *TimerElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 	return nil
 }
 
-// Consume processes values before a given time and discards
-// them afterwards, returning whether the element can be collected
-// after consuming the values.
-func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
+// Consume consumes values before a given time and removes them from the element
+// after they are consumed, returning whether the element can be collected after
+// the consumption is completed.
+// NB: Consume is not thread-safe and must be called within a single goroutine
+// to avoid race conditions.
+func (e *TimerElem) Consume(
+	earlierThanNanos int64,
+	flushLocalFn flushLocalMetricFn,
+	flushForwardFn flushForwardMetricFn,
+) bool {
 	e.Lock()
 	if e.closed {
 		e.Unlock()
@@ -138,7 +185,7 @@ func (e *TimerElem) Consume(earlierThanNanos int64, fn aggMetricFn) bool {
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, fn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -156,6 +203,7 @@ func (e *TimerElem) Close() {
 	}
 	e.closed = true
 	e.id = nil
+	e.parsedPipeline = parsedPipeline{}
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
 		e.values[idx].aggregation.Close()
@@ -163,6 +211,7 @@ func (e *TimerElem) Close() {
 	}
 	e.values = e.values[:0]
 	e.toConsume = e.toConsume[:0]
+	e.lastConsumedValues = e.lastConsumedValues[:0]
 	e.timerElemBase.Close()
 	aggTypesPool := e.aggTypesOpts.TypesPool()
 	pool := e.ElemPool(e.opts)
@@ -244,23 +293,50 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 	return left, false
 }
 
-func (e *TimerElem) processValue(timeNanos int64, agg *lockedTimer, fn aggMetricFn) {
-	var fullPrefix = e.FullPrefix(e.opts)
-	if e.useDefaultAggregation {
-		// NB(cw) Use default suffix slice for faster look up.
-		suffixes := e.DefaultAggregationTypeStrings(e.aggTypesOpts)
-		aggTypes := e.DefaultAggregationTypes(e.aggTypesOpts)
-		agg.Lock()
-		for i, aggType := range aggTypes {
-			fn(fullPrefix, e.id, suffixes[i], timeNanos, agg.ValueOf(aggType), e.sp)
-		}
-		agg.Unlock()
-		return
-	}
-
+func (e *TimerElem) processValue(
+	timeNanos int64,
+	agg *lockedTimer,
+	flushLocalFn flushLocalMetricFn,
+	flushForwardFn flushForwardMetricFn,
+) {
+	var (
+		fullPrefix      = e.FullPrefix(e.opts)
+		transformations = e.parsedPipeline.Transformations
+	)
 	agg.Lock()
-	for _, aggType := range e.aggTypes {
-		fn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, agg.ValueOf(aggType), e.sp)
+	for aggTypeIdx, aggType := range e.aggTypes {
+		value := agg.ValueOf(aggType)
+		for i := 0; i < transformations.NumSteps(); i++ {
+			transformType := transformations.At(i).Transformation.Type
+			if transformType.IsUnaryTransform() {
+				fn := transformType.MustUnaryTransform()
+				res := fn(transformation.Datapoint{TimeNanos: timeNanos, Value: value})
+				value = res.Value
+			} else {
+				fn := transformType.MustBinaryTransform()
+				prev := transformation.Datapoint{TimeNanos: e.lastConsumedAtNanos, Value: e.lastConsumedValues[aggTypeIdx]}
+				curr := transformation.Datapoint{TimeNanos: timeNanos, Value: value}
+				res := fn(prev, curr)
+				value = res.Value
+				// NB: we only need to record the value needed for derivative transformations.
+				// We currently only support first-order derivative transformations so we only
+				// need to keep one value. In the future if we need to support higher-order
+				// derivative transformations, we need to store an array of values here.
+				e.lastConsumedValues[aggTypeIdx] = value
+			}
+		}
+		// Do we need to flush or forward NaNs?
+		if !e.parsedPipeline.HasRollup {
+			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
+		} else {
+			fm := metadata.ForwardMetadata{
+				AggregationID: e.parsedPipeline.Rollup.AggregationID,
+				StoragePolicy: e.sp,
+				Pipeline:      e.parsedPipeline.Remainder,
+			}
+			flushForwardFn(e.parsedPipeline.Rollup.ID, timeNanos, value, fm)
+		}
 	}
+	e.lastConsumedAtNanos = timeNanos
 	agg.Unlock()
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ac4a763f43c3946849c3b9d4f72034d23e5051f2465f2a9e3cc94e82208888ae
-updated: 2018-03-23T15:34:28.974946815-04:00
+hash: 081c1d5f2832a840dbd1bde50e635413915de199bdb3e2f70fcc776e82d143ac
+updated: 2018-03-29T14:20:11.637314385-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -180,7 +180,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 8aa2467fbe78ba38fd03fa7ca03c32997393327d
+  version: b6bc1e8a8effb065626150ec63f70095219e7243
   subpackages:
   - aggregation
   - generated/proto/schema

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 081c1d5f2832a840dbd1bde50e635413915de199bdb3e2f70fcc776e82d143ac
-updated: 2018-03-29T14:20:11.637314385-04:00
+hash: df095b440006914f1a3f73e9541218ffa870903c23f96c2f9cafadd3645a4bc7
+updated: 2018-03-30T10:51:04.91189502-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -180,7 +180,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: b6bc1e8a8effb065626150ec63f70095219e7243
+  version: ff080bbc8162792b4844b4017dc55b6fc3662e92
   subpackages:
   - aggregation
   - generated/proto/schema

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: b6bc1e8a8effb065626150ec63f70095219e7243
+  version: ff080bbc8162792b4844b4017dc55b6fc3662e92
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: 8aa2467fbe78ba38fd03fa7ca03c32997393327d
+  version: b6bc1e8a8effb065626150ec63f70095219e7243
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -115,7 +115,7 @@ type AggregatorConfiguration struct {
 	MaxTimerBatchSizePerWrite int `yaml:"maxTimerBatchSizePerWrite" validate:"min=0"`
 
 	// Default policies.
-	DefaultPolicies []policy.Policy `yaml:"defaultPolicies" validate:"nonzero"`
+	DefaultPolicies []policy.StoragePolicy `yaml:"defaultPolicies" validate:"nonzero"`
 
 	// Pool of counter elements.
 	CounterElemPool pool.ObjectPoolConfiguration `yaml:"counterElemPool"`
@@ -263,11 +263,12 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		opts = opts.SetMaxTimerBatchSizePerWrite(c.MaxTimerBatchSizePerWrite)
 	}
 
-	// Set default policies.
-	policies := make([]policy.Policy, len(c.DefaultPolicies))
+	// Set default storage policies.
+	// TODO(xichen): sort the storage policies.
+	policies := make([]policy.StoragePolicy, len(c.DefaultPolicies))
 	copy(policies, c.DefaultPolicies)
-	sort.Sort(policy.ByResolutionAscRetentionDesc(policies))
-	opts = opts.SetDefaultPolicies(policies)
+	// sort.Sort(policy.ByResolutionAscRetentionDesc(policies))
+	opts = opts.SetDefaultStoragePolicies(policies)
 
 	// Set counter elem pool.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("counter-elem-pool"))
@@ -275,7 +276,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	counterElemPool := aggregator.NewCounterElemPool(counterElemPoolOpts)
 	opts = opts.SetCounterElemPool(counterElemPool)
 	counterElemPool.Init(func() *aggregator.CounterElem {
-		return aggregator.NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
+		return aggregator.MustNewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
 	})
 
 	// Set timer elem pool.
@@ -284,7 +285,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	timerElemPool := aggregator.NewTimerElemPool(timerElemPoolOpts)
 	opts = opts.SetTimerElemPool(timerElemPool)
 	timerElemPool.Init(func() *aggregator.TimerElem {
-		return aggregator.NewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
+		return aggregator.MustNewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
 	})
 
 	// Set gauge elem pool.
@@ -293,7 +294,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
 	opts = opts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem {
-		return aggregator.NewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
+		return aggregator.MustNewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, opts)
 	})
 
 	// Set entry pool.


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds logic to the aggregation elements to process aggregated metrics by flushing or forwarding them based on pipeline metadata.

NB: the changes in `*.gen.go` are auto-generated from `generic_elem.go`. 