### PR TITLE
Remove lint from build target

### DIFF
--- a/.metalinter.json
+++ b/.metalinter.json
@@ -1,20 +1,32 @@
 {
   "Linters": {
-    "badtime":   {"Command": "badtime", "Pattern": "PATH:LINE:COL:MESSAGE"},
-    "deadcode":  { "Command": "deadcode  -tags integration" },
-    "varcheck":  { "Command": "varcheck  -tags integration" },
-    "megacheck": { "Command": "megacheck -tags integration" } },
-  "Enable":
-    [ "deadcode"
-    , "varcheck"
-    , "structcheck"
-    , "goconst"
-    , "ineffassign"
-    , "unconvert"
-    , "misspell"
-    , "unparam"
-    , "badtime"
-    , "megacheck" ],
+    "badtime": {
+      "Command": "badtime",
+      "Pattern": "PATH:LINE:COL:MESSAGE"
+    },
+    "deadcode": {
+      "Command": "deadcode  -tags integration"
+    },
+    "varcheck": {
+      "Command": "varcheck  -tags integration"
+    },
+    "megacheck": {
+      "Command": "megacheck -tags integration"
+    }
+  },
+  "Enable": [
+    "golint",
+    "deadcode",
+    "varcheck",
+    "structcheck",
+    "goconst",
+    "ineffassign",
+    "unconvert",
+    "misspell",
+    "unparam",
+    "badtime",
+    "megacheck"
+  ],
   "Deadline": "3m",
   "EnableGC": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ env:
   matrix:
     - MAKE_TARGET="test-ci-unit"
     - MAKE_TARGET="test-ci-integration"
-    - MAKE_TARGET="lint metalint"
+    - MAKE_TARGET="metalint"
 script: "make $MAKE_TARGET"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ coverage_xml          := coverage.xml
 junit_xml             := junit.xml
 coverage_exclude      := .excludecoverage
 test_log              := test.log
-lint_check            := .ci/lint.sh
 metalint_check        := .ci/metalint.sh
 metalint_config       := .metalinter.json
 metalint_exclude      := .excludemetalint

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,6 @@ services-linux-amd64:
 
 $(foreach SERVICE,$(SERVICES),$(eval $(SERVICE_RULES)))
 
-.PHONY: lint
-lint:
-	@which golint > /dev/null || go get -u github.com/golang/lint/golint
-	$(lint_check)
-
 .PHONY: metalint
 metalint: install-metalinter install-linter-badtime
 	@($(metalint_check) $(metalint_config) $(metalint_exclude) && echo "metalinted successfully!") || (echo "metalinter failed" && exit 1)
@@ -147,7 +142,7 @@ clean:
 	@rm -f *.html *.xml *.out *.test
 
 .PHONY: all
-all: lint metalint test-ci-unit test-ci-integration m3aggregator
+all: metalint test-ci-unit test-ci-integration m3aggregator
 	@echo Made all successfully
 
 .DEFAULT_GOAL := all


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR removes `lint` from the build targets since we seem to be getting the error below when installing golint. As such we remove `lint` and rely on `metalint` for linting. 
```
package golang.org/x/lint: unrecognized import path "golang.org/x/lint" (parse https://golang.org/x/lint?go-get=1: no go-import meta tags ())
```
