### PR TITLE
Admin client API for writing forwarded metrics

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
@@ -638,14 +639,14 @@ func (agg *aggregator) updateShardsWithLock(
 
 func (agg *aggregator) checkMetricType(mu unaggregated.MetricUnion) error {
 	switch mu.Type {
-	case unaggregated.CounterType:
+	case metric.CounterType:
 		agg.metrics.counters.Inc(1)
 		return nil
-	case unaggregated.BatchTimerType:
+	case metric.TimerType:
 		agg.metrics.timerBatches.Inc(1)
 		agg.metrics.timers.Inc(int64(len(mu.BatchTimerVal)))
 		return nil
-	case unaggregated.GaugeType:
+	case metric.GaugeType:
 		agg.metrics.gauges.Inc(1)
 		return nil
 	default:

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	xtime "github.com/m3db/m3x/time"
@@ -56,12 +57,12 @@ const (
 
 var (
 	testValidMetric = unaggregated.MetricUnion{
-		Type:       unaggregated.CounterType,
+		Type:       metric.CounterType,
 		ID:         []byte("foo"),
 		CounterVal: 1234,
 	}
 	testInvalidMetric = unaggregated.MetricUnion{
-		Type: unaggregated.UnknownType,
+		Type: metric.UnknownType,
 		ID:   []byte("testInvalid"),
 	}
 	testStagedMetadatas = metadata.StagedMetadatas{

--- a/aggregator/capture/aggregator.go
+++ b/aggregator/capture/aggregator.go
@@ -26,6 +26,8 @@ import (
 
 	aggr "github.com/m3db/m3aggregator/aggregator"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
@@ -62,19 +64,19 @@ func (agg *aggregator) AddUntimed(
 	defer agg.Unlock()
 
 	switch mu.Type {
-	case unaggregated.CounterType:
+	case metric.CounterType:
 		cp := unaggregated.CounterWithMetadatas{
 			Counter:         mu.Counter(),
 			StagedMetadatas: sm,
 		}
 		agg.countersWithMetadatas = append(agg.countersWithMetadatas, cp)
-	case unaggregated.BatchTimerType:
+	case metric.TimerType:
 		btp := unaggregated.BatchTimerWithMetadatas{
 			BatchTimer:      mu.BatchTimer(),
 			StagedMetadatas: sm,
 		}
 		agg.batchTimersWithMetadatas = append(agg.batchTimersWithMetadatas, btp)
-	case unaggregated.GaugeType:
+	case metric.GaugeType:
 		gp := unaggregated.GaugeWithMetadatas{
 			Gauge:           mu.Gauge(),
 			StagedMetadatas: sm,
@@ -84,6 +86,14 @@ func (agg *aggregator) AddUntimed(
 		return fmt.Errorf("unrecognized metric type %v", mu.Type)
 	}
 	agg.numMetricsAdded++
+	return nil
+}
+
+// TODO(xichen): implement this.
+func (agg *aggregator) AddForwarded(
+	metric aggregated.Metric,
+	metadata metadata.ForwardMetadata,
+) error {
 	return nil
 }
 
@@ -118,13 +128,14 @@ func (agg *aggregator) Snapshot() SnapshotResult {
 
 func cloneMetric(m unaggregated.MetricUnion) unaggregated.MetricUnion {
 	mu := m
-	if !m.OwnsID {
-		clonedID := make(id.RawID, len(m.ID))
-		copy(clonedID, m.ID)
-		mu.ID = clonedID
-		mu.OwnsID = true
-	}
-	if m.Type == unaggregated.BatchTimerType {
+
+	// Clone metric ID.
+	clonedID := make(id.RawID, len(m.ID))
+	copy(clonedID, m.ID)
+	mu.ID = clonedID
+
+	// Clone time values.
+	if m.Type == metric.TimerType {
 		clonedTimerVal := make([]float64, len(m.BatchTimerVal))
 		copy(clonedTimerVal, m.BatchTimerVal)
 		mu.BatchTimerVal = clonedTimerVal

--- a/aggregator/capture/aggregator.go
+++ b/aggregator/capture/aggregator.go
@@ -21,6 +21,7 @@
 package capture
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -94,7 +95,7 @@ func (agg *aggregator) AddForwarded(
 	metric aggregated.Metric,
 	metadata metadata.ForwardMetadata,
 ) error {
-	return nil
+	return errors.New("not implemented")
 }
 
 func (agg *aggregator) Resign() error              { return nil }

--- a/aggregator/capture/aggregator_test.go
+++ b/aggregator/capture/aggregator_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 
@@ -33,22 +34,22 @@ import (
 
 var (
 	testCounter = unaggregated.MetricUnion{
-		Type:       unaggregated.CounterType,
+		Type:       metric.CounterType,
 		ID:         id.RawID("testCounter"),
 		CounterVal: 1234,
 	}
 	testBatchTimer = unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		ID:            id.RawID("testCounter"),
 		BatchTimerVal: []float64{1.0, 3.5, 2.2, 6.5, 4.8},
 	}
 	testGauge = unaggregated.MetricUnion{
-		Type:     unaggregated.GaugeType,
+		Type:     metric.GaugeType,
 		ID:       id.RawID("testCounter"),
 		GaugeVal: 123.456,
 	}
 	testInvalid = unaggregated.MetricUnion{
-		Type: unaggregated.UnknownType,
+		Type: metric.UnknownType,
 		ID:   id.RawID("invalid"),
 	}
 	testDefaultMetadatas = metadata.DefaultStagedMetadatas
@@ -65,21 +66,21 @@ func TestAggregator(t *testing.T) {
 	var expected SnapshotResult
 	for _, mu := range []unaggregated.MetricUnion{testCounter, testBatchTimer, testGauge} {
 		switch mu.Type {
-		case unaggregated.CounterType:
+		case metric.CounterType:
 			expected.CountersWithMetadatas = append(
 				expected.CountersWithMetadatas,
 				unaggregated.CounterWithMetadatas{
 					Counter:         mu.Counter(),
 					StagedMetadatas: metadatas,
 				})
-		case unaggregated.BatchTimerType:
+		case metric.TimerType:
 			expected.BatchTimersWithMetadatas = append(
 				expected.BatchTimersWithMetadatas,
 				unaggregated.BatchTimerWithMetadatas{
 					BatchTimer:      mu.BatchTimer(),
 					StagedMetadatas: metadatas,
 				})
-		case unaggregated.GaugeType:
+		case metric.GaugeType:
 			expected.GaugesWithMetadatas = append(
 				expected.GaugesWithMetadatas,
 				unaggregated.GaugeWithMetadatas{

--- a/aggregator/counter_elem.gen.go
+++ b/aggregator/counter_elem.gen.go
@@ -154,7 +154,7 @@ func (e *CounterElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion
 func (e *CounterElem) Consume(
 	earlierThanNanos int64,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) bool {
 	e.Lock()
 	if e.closed {
@@ -187,7 +187,7 @@ func (e *CounterElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardedFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -299,7 +299,7 @@ func (e *CounterElem) processValue(
 	timeNanos int64,
 	agg *lockedCounter,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
 		fullPrefix      = e.FullPrefix(e.opts)
@@ -341,7 +341,7 @@ func (e *CounterElem) processValue(
 				StoragePolicy: e.sp,
 				Pipeline:      e.parsedPipeline.Remainder,
 			}
-			flushForwardFn(fm, meta)
+			flushForwardedFn(fm, meta)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/elem_base.go
+++ b/aggregator/elem_base.go
@@ -75,7 +75,7 @@ type metricElem interface {
 	Consume(
 		earlierThanNanos int64,
 		flushLocalFn flushLocalMetricFn,
-		flushForwardFn flushForwardMetricFn,
+		flushForwardedFn flushForwardedMetricFn,
 	) bool
 
 	// MarkAsTombstoned marks an element as tombstoned, which means this element

--- a/aggregator/elem_base_test.go
+++ b/aggregator/elem_base_test.go
@@ -26,6 +26,7 @@ import (
 
 	raggregation "github.com/m3db/m3aggregator/aggregation"
 	maggregation "github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/op"
 	"github.com/m3db/m3metrics/op/applied"
@@ -123,11 +124,11 @@ func TestCounterElemBaseNewLockedAggregation(t *testing.T) {
 	la := e.NewLockedAggregation(nil, raggregation.Options{})
 	la.Lock()
 	la.Add(unaggregated.MetricUnion{
-		Type:       unaggregated.CounterType,
+		Type:       metric.CounterType,
 		CounterVal: 100,
 	})
 	la.Add(unaggregated.MetricUnion{
-		Type:       unaggregated.CounterType,
+		Type:       metric.CounterType,
 		CounterVal: 200,
 	})
 	res := la.ValueOf(maggregation.Sum)
@@ -175,11 +176,11 @@ func TestTimerElemBaseNewLockedAggregation(t *testing.T) {
 	la := e.NewLockedAggregation(NewOptions(), raggregation.Options{})
 	la.Lock()
 	la.Add(unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		BatchTimerVal: []float64{100.0, 200.0},
 	})
 	la.Add(unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		BatchTimerVal: []float64{300.0, 400.0, 500.0},
 	})
 	res := la.ValueOf(maggregation.Mean)
@@ -236,11 +237,11 @@ func TestGaugeElemBaseNewLockedAggregation(t *testing.T) {
 	la := e.NewLockedAggregation(nil, raggregation.Options{})
 	la.Lock()
 	la.Add(unaggregated.MetricUnion{
-		Type:     unaggregated.GaugeType,
+		Type:     metric.GaugeType,
 		GaugeVal: 100.0,
 	})
 	la.Add(unaggregated.MetricUnion{
-		Type:     unaggregated.GaugeType,
+		Type:     metric.GaugeType,
 		GaugeVal: 200.0,
 	})
 	res := la.ValueOf(maggregation.Last)

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/op"
@@ -230,7 +231,7 @@ func TestEntryBatchTimerRateLimiting(t *testing.T) {
 	defer ctrl.Finish()
 
 	bt := unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		ID:            testBatchTimerID,
 		BatchTimerVal: make([]float64, 1000),
 	}
@@ -308,7 +309,7 @@ func TestEntryAddBatchTimerWithPoolAlloc(t *testing.T) {
 	input := timerValPool.Get(10)
 	input = append(input, []float64{1.0, 3.5, 2.2, 6.5, 4.8}...)
 	bt := unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		ID:            testBatchTimerID,
 		BatchTimerVal: input,
 		TimerValPool:  timerValPool,
@@ -332,7 +333,7 @@ func TestEntryAddBatchTimerWithTimerBatchSizeLimit(t *testing.T) {
 		SetDefaultStoragePolicies(testDefaultStoragePolicies)
 
 	bt := unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		ID:            testBatchTimerID,
 		BatchTimerVal: []float64{1.0, 3.5, 2.2, 6.5, 4.8},
 	}
@@ -358,7 +359,7 @@ func TestEntryAddBatchTimerWithTimerBatchSizeLimitError(t *testing.T) {
 	e.closed = true
 
 	bt := unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		ID:            testBatchTimerID,
 		BatchTimerVal: []float64{1.0, 3.5, 2.2, 6.5, 4.8},
 	}
@@ -441,7 +442,6 @@ func TestEntryAddUntimedDefaultStagedMetadata(t *testing.T) {
 	var (
 		withPrepopulation       = true
 		prePopulateData         = testDefaultAggregationKeys
-		ownsID                  = false
 		inputMetadatas          = testDefaultStagedMetadatas
 		expectedShouldAdd       = true
 		expectedCutoverNanos    = int64(0)
@@ -465,7 +465,7 @@ func TestEntryAddUntimedDefaultStagedMetadata(t *testing.T) {
 	}
 
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -478,7 +478,6 @@ func TestEntryAddUntimedSameDefaultMetadata(t *testing.T) {
 	var (
 		withPrepopulation = true
 		prePopulateData   = testDefaultAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -520,7 +519,7 @@ func TestEntryAddUntimedSameDefaultMetadata(t *testing.T) {
 	}
 
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -533,7 +532,6 @@ func TestEntryAddUntimedSameCustomMetadata(t *testing.T) {
 	var (
 		withPrepopulation = true
 		prePopulateData   = testAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -575,7 +573,7 @@ func TestEntryAddUntimedSameCustomMetadata(t *testing.T) {
 	}
 
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -588,7 +586,6 @@ func TestEntryAddUntimedDifferentTombstone(t *testing.T) {
 	var (
 		withPrepopulation = true
 		prePopulateData   = testAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -630,7 +627,7 @@ func TestEntryAddUntimedDifferentTombstone(t *testing.T) {
 	}
 
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -643,7 +640,6 @@ func TestEntryAddUntimedDifferentCutoverSameMetadata(t *testing.T) {
 	var (
 		withPrepopulation = true
 		prePopulateData   = testAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -685,7 +681,7 @@ func TestEntryAddUntimedDifferentCutoverSameMetadata(t *testing.T) {
 	}
 
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -698,7 +694,6 @@ func TestEntryAddUntimedDifferentCutoverDifferentMetadata(t *testing.T) {
 	var (
 		withPrepopulation = true
 		prePopulateData   = testAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -749,7 +744,7 @@ func TestEntryAddUntimedDifferentCutoverDifferentMetadata(t *testing.T) {
 	}
 
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -762,7 +757,6 @@ func TestEntryAddUntimedWithPolicyUpdateIDNotOwnedCopyID(t *testing.T) {
 	var (
 		withPrepopulation = false
 		prePopulateData   = testAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -804,66 +798,7 @@ func TestEntryAddUntimedWithPolicyUpdateIDNotOwnedCopyID(t *testing.T) {
 		}
 	}
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
-		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
-		expectedCutoverNanos, expectedAggregationKeys,
-	)
-}
-
-func TestEntryAddUntimedWithPolicyUpdateIDOwnsID(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	var (
-		withPrepopulation = false
-		prePopulateData   = testAggregationKeys
-		ownsID            = true
-		nowNanos          = time.Now().UnixNano()
-		inputMetadatas    = metadata.StagedMetadatas{
-			metadata.StagedMetadata{
-				CutoverNanos: nowNanos - 1000,
-				Tombstoned:   false,
-				Metadata:     metadata.Metadata{Pipelines: testDefaultPipelines},
-			},
-			metadata.StagedMetadata{
-				CutoverNanos: nowNanos - 10,
-				Tombstoned:   false,
-				Metadata:     metadata.Metadata{Pipelines: testPipelines},
-			},
-			metadata.StagedMetadata{
-				CutoverNanos: nowNanos + 100,
-				Tombstoned:   false,
-				Metadata:     metadata.Metadata{Pipelines: testPipelines},
-			},
-		}
-		expectedShouldAdd       = true
-		expectedCutoverNanos    = nowNanos - 10
-		expectedAggregationKeys = testAggregationKeys
-		lists                   *metricLists
-	)
-
-	deletedStoragePolicies := make(map[policy.StoragePolicy]struct{})
-	deletedStoragePolicies[testAggregationKeys[1].storagePolicy] = struct{}{}
-	deletedStoragePolicies[testAggregationKeys[2].storagePolicy] = struct{}{}
-
-	preAddFn := func(e *Entry, now *time.Time) {
-		*now = time.Unix(0, nowNanos)
-		e.cutoverNanos = uninitializedCutoverNanos
-		lists = e.lists
-	}
-	postAddFn := func(t *testing.T) {
-		require.Equal(t, 3, len(lists.lists))
-		for _, key := range expectedAggregationKeys {
-			list, exists := lists.lists[key.storagePolicy.Resolution().Window]
-			require.True(t, exists)
-			require.Equal(t, 1, list.aggregations.Len())
-			for elem := list.aggregations.Front(); elem != nil; elem = elem.Next() {
-				checkElemTombstoned(t, elem.Value.(metricElem), nil)
-			}
-		}
-	}
-	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -876,7 +811,6 @@ func TestEntryAddUntimedDuplicateAggregationKeys(t *testing.T) {
 	var (
 		withPrepopulation = true
 		prePopulateData   = testAggregationKeys
-		ownsID            = false
 		nowNanos          = time.Now().UnixNano()
 		inputMetadatas    = metadata.StagedMetadatas{
 			metadata.StagedMetadata{
@@ -929,7 +863,7 @@ func TestEntryAddUntimedDuplicateAggregationKeys(t *testing.T) {
 		}
 	}
 	testEntryAddUntimed(
-		t, ctrl, withPrepopulation, prePopulateData, ownsID,
+		t, ctrl, withPrepopulation, prePopulateData,
 		preAddFn, inputMetadatas, postAddFn, expectedShouldAdd,
 		expectedCutoverNanos, expectedAggregationKeys,
 	)
@@ -1047,7 +981,7 @@ func TestEntryMaybeExpireWithExpiry(t *testing.T) {
 	defer ctrl.Finish()
 
 	e, _, now := testEntry(ctrl)
-	populateTestAggregations(t, e, testAggregationKeys, unaggregated.CounterType)
+	populateTestAggregations(t, e, testAggregationKeys, metric.CounterType)
 
 	var elems []*CounterElem
 	for _, agg := range e.aggregations {
@@ -1205,7 +1139,7 @@ func TestShouldUpdateMetadataWithLock(t *testing.T) {
 	for _, input := range inputs {
 		e, _, _ := testEntry(ctrl)
 		e.cutoverNanos = input.cutoverNanos
-		populateTestAggregations(t, e, input.aggregationKeys, unaggregated.CounterType)
+		populateTestAggregations(t, e, input.aggregationKeys, metric.CounterType)
 		e.Lock()
 		require.Equal(t, input.expected, e.shouldUpdateMetadatasWithLock(input.metadata))
 		e.Unlock()
@@ -1244,38 +1178,18 @@ func TestEntryStoragePolicies(t *testing.T) {
 	}
 }
 
-func TestEntryMaybeCopyIDWithLockOwnedID(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mu := unaggregated.MetricUnion{
-		ID:     []byte("foo"),
-		OwnsID: true,
-	}
-	e, _, _ := testEntry(ctrl)
-	id := e.maybeCopyIDWithLock(mu)
-	require.Equal(t, mu.ID, id)
-
-	// Verify the returned ID shares the same backing array as the original ID.
-	mu.ID[0] = 'b'
-	require.Equal(t, mu.ID, id)
-}
-
 func TestEntryMaybeCopyIDWithLockIDNotOwnedCloned(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mu := unaggregated.MetricUnion{
-		ID:     []byte("foo"),
-		OwnsID: false,
-	}
+	id := id.RawID("foo")
 	e, _, _ := testEntry(ctrl)
-	id := e.maybeCopyIDWithLock(mu)
-	require.Equal(t, mu.ID, id)
+	res := e.maybeCopyIDWithLock(id)
+	require.Equal(t, id, res)
 
 	// Verify the returned ID is a clone of the original ID.
-	mu.ID[0] = 'b'
-	require.NotEqual(t, mu.ID, id)
+	id[0] = 'b'
+	require.NotEqual(t, id, res)
 }
 
 func TestAggregationKeyEqual(t *testing.T) {
@@ -1510,7 +1424,7 @@ func populateTestAggregations(
 	t *testing.T,
 	e *Entry,
 	aggregationKeys []aggregationKey,
-	typ unaggregated.Type,
+	typ metric.Type,
 ) {
 	for _, aggKey := range aggregationKeys {
 		var (
@@ -1518,13 +1432,13 @@ func populateTestAggregations(
 			testID  id.RawID
 		)
 		switch typ {
-		case unaggregated.CounterType:
+		case metric.CounterType:
 			newElem = e.opts.CounterElemPool().Get()
 			testID = testCounterID
-		case unaggregated.BatchTimerType:
+		case metric.TimerType:
 			newElem = e.opts.TimerElemPool().Get()
 			testID = testBatchTimerID
-		case unaggregated.GaugeType:
+		case metric.GaugeType:
 			newElem = e.opts.GaugeElemPool().Get()
 			testID = testGaugeID
 		default:
@@ -1570,7 +1484,6 @@ func testEntryAddUntimed(
 	ctrl *gomock.Controller,
 	withPrePopulation bool,
 	prePopulateData []aggregationKey,
-	ownsID bool,
 	preAddFn testPreProcessFn,
 	inputMetadatas metadata.StagedMetadatas,
 	postAddFn testPostProcessFn,
@@ -1627,8 +1540,6 @@ func testEntryAddUntimed(
 	}
 
 	for _, input := range inputs {
-		input.mu.OwnsID = ownsID
-
 		e, _, now := testEntry(ctrl)
 		if withPrePopulation {
 			populateTestAggregations(t, e, prePopulateData, input.mu.Type)

--- a/aggregator/flush.go
+++ b/aggregator/flush.go
@@ -81,11 +81,11 @@ type flushLocalMetricFn func(
 	sp policy.StoragePolicy,
 )
 
-// A flushForwardMetricFn flushes an aggregated metric datapoint eligible for
+// A flushForwardedMetricFn flushes an aggregated metric datapoint eligible for
 // forwarding by either forwarding it (potentially to a different aggregation
 // server) or dropping it. Processing of the datapoint continues after it is
 // flushed as required by the pipeline.
-type flushForwardMetricFn func(
+type flushForwardedMetricFn func(
 	metric aggregated.Metric,
 	meta metadata.ForwardMetadata,
 )

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -154,7 +154,7 @@ func (e *GaugeElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 func (e *GaugeElem) Consume(
 	earlierThanNanos int64,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) bool {
 	e.Lock()
 	if e.closed {
@@ -187,7 +187,7 @@ func (e *GaugeElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardedFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -299,7 +299,7 @@ func (e *GaugeElem) processValue(
 	timeNanos int64,
 	agg *lockedGauge,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
 		fullPrefix      = e.FullPrefix(e.opts)
@@ -341,7 +341,7 @@ func (e *GaugeElem) processValue(
 				StoragePolicy: e.sp,
 				Pipeline:      e.parsedPipeline.Remainder,
 			}
-			flushForwardFn(fm, meta)
+			flushForwardedFn(fm, meta)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/generic_elem.go
+++ b/aggregator/generic_elem.go
@@ -196,7 +196,7 @@ func (e *GenericElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion
 func (e *GenericElem) Consume(
 	earlierThanNanos int64,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) bool {
 	e.Lock()
 	if e.closed {
@@ -229,7 +229,7 @@ func (e *GenericElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardedFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -341,7 +341,7 @@ func (e *GenericElem) processValue(
 	timeNanos int64,
 	agg lockedAggregation,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
 		fullPrefix      = e.FullPrefix(e.opts)
@@ -383,7 +383,7 @@ func (e *GenericElem) processValue(
 				StoragePolicy: e.sp,
 				Pipeline:      e.parsedPipeline.Remainder,
 			}
-			flushForwardFn(fm, meta)
+			flushForwardedFn(fm, meta)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -101,16 +101,16 @@ type metricList struct {
 	flushInterval time.Duration
 	flushMgr      FlushManager
 
-	closed                 bool
-	aggregations           *list.List
-	lastFlushedNanos       int64
-	toCollect              []*list.Element
-	flushBeforeFn          flushBeforeFn
-	consumeLocalMetricFn   flushLocalMetricFn
-	discardLocalMetricFn   flushLocalMetricFn
-	consumeForwardMetricFn flushForwardMetricFn
-	discardForwardMetricFn flushForwardMetricFn
-	metrics                metricListMetrics
+	closed                   bool
+	aggregations             *list.List
+	lastFlushedNanos         int64
+	toCollect                []*list.Element
+	flushBeforeFn            flushBeforeFn
+	consumeLocalMetricFn     flushLocalMetricFn
+	discardLocalMetricFn     flushLocalMetricFn
+	consumeForwardedMetricFn flushForwardedMetricFn
+	discardForwardedMetricFn flushForwardedMetricFn
+	metrics                  metricListMetrics
 }
 
 func newMetricList(shard uint32, resolution time.Duration, opts Options) (*metricList, error) {
@@ -148,8 +148,8 @@ func newMetricList(shard uint32, resolution time.Duration, opts Options) (*metri
 	l.flushBeforeFn = l.flushBefore
 	l.consumeLocalMetricFn = l.consumeLocalMetric
 	l.discardLocalMetricFn = l.discardLocalMetric
-	l.consumeForwardMetricFn = l.consumeForwardMetric
-	l.discardForwardMetricFn = l.discardForwardMetric
+	l.consumeForwardedMetricFn = l.consumeForwardedMetric
+	l.discardForwardedMetricFn = l.discardForwardedMetric
 	l.flushMgr.Register(l)
 
 	return l, nil
@@ -270,10 +270,10 @@ func (l *metricList) flushBefore(beforeNanos int64, flushType flushType) {
 	flushBeforeStart := l.nowFn()
 	l.toCollect = l.toCollect[:0]
 	flushLocalFn := l.consumeLocalMetricFn
-	flushForwardFn := l.consumeForwardMetricFn
+	flushForwardedFn := l.consumeForwardedMetricFn
 	if flushType == discardType {
 		flushLocalFn = l.discardLocalMetricFn
-		flushForwardFn = l.discardForwardMetricFn
+		flushForwardedFn = l.discardForwardedMetricFn
 	}
 
 	// Flush out aggregations, may need to do it in batches if the read lock
@@ -283,7 +283,7 @@ func (l *metricList) flushBefore(beforeNanos int64, flushType flushType) {
 		// If the element is eligible for collection after the values are
 		// processed, close it and reset the value to nil.
 		elem := e.Value.(metricElem)
-		if elem.Consume(alignedBeforeNanos, flushLocalFn, flushForwardFn) {
+		if elem.Consume(alignedBeforeNanos, flushLocalFn, flushForwardedFn) {
 			elem.Close()
 			e.Value = nil
 			l.toCollect = append(l.toCollect, e)
@@ -354,18 +354,18 @@ func (l *metricList) discardLocalMetric(
 	l.metrics.flushMetricDiscarded.Inc(1)
 }
 
-// consumeForwardMetric consumes a forward metric.
+// consumeForwardedMetric consumes a forward metric.
 // TODO(xichen): implement this.
-func (l *metricList) consumeForwardMetric(
+func (l *metricList) consumeForwardedMetric(
 	metric aggregated.Metric,
 	meta metadata.ForwardMetadata,
 ) {
 
 }
 
-// discardForwardMetric discards a forward metric.
+// discardForwardedMetric discards a forward metric.
 // TODO(xichen): implement this.
-func (l *metricList) discardForwardMetric(
+func (l *metricList) discardForwardedMetric(
 	metric aggregated.Metric,
 	meta metadata.ForwardMetadata,
 ) {

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -360,7 +360,7 @@ func (l *metricList) consumeForwardedMetric(
 	metric aggregated.Metric,
 	meta metadata.ForwardMetadata,
 ) {
-
+	panic("not implemented")
 }
 
 // discardForwardedMetric discards a forward metric.
@@ -369,7 +369,7 @@ func (l *metricList) discardForwardedMetric(
 	metric aggregated.Metric,
 	meta metadata.ForwardMetadata,
 ) {
-
+	panic("not implemented")
 }
 
 type newMetricListFn func(

--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3aggregator/rate"
 	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/close"
@@ -49,9 +50,18 @@ var (
 	errWriteNewMetricRateLimitExceeded = errors.New("write new metric rate limit is exceeded")
 )
 
+type metricCategory int
+
+const (
+	// nolint: megacheck
+	unknownMetricCategory metricCategory = iota
+	untimedMetric
+)
+
 type entryKey struct {
-	metricType unaggregated.Type
-	idHash     xid.Hash128
+	metricCategory metricCategory
+	metricType     metric.Type
+	idHash         xid.Hash128
 }
 
 type hashedEntry struct {
@@ -133,8 +143,9 @@ func (m *metricMap) AddUntimed(
 	metadatas metadata.StagedMetadatas,
 ) error {
 	key := entryKey{
-		metricType: metric.Type,
-		idHash:     xid.Murmur3Hash128(metric.ID),
+		metricCategory: untimedMetric,
+		metricType:     metric.Type,
+		idHash:         xid.Murmur3Hash128(metric.ID),
 	}
 	entry, err := m.findOrCreate(key)
 	if err != nil {

--- a/aggregator/map_test.go
+++ b/aggregator/map_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
@@ -83,8 +84,9 @@ func TestMetricMapAddUntimedNoRateLimit(t *testing.T) {
 
 	// Add a counter metric and assert there is one entry afterwards.
 	key := entryKey{
-		metricType: unaggregated.CounterType,
-		idHash:     xid.Murmur3Hash128(testCounterID),
+		metricCategory: untimedMetric,
+		metricType:     metric.CounterType,
+		idHash:         xid.Murmur3Hash128(testCounterID),
 	}
 	require.NoError(t, m.AddUntimed(testCounter, policies))
 	require.Equal(t, 1, len(m.entries))
@@ -111,11 +113,12 @@ func TestMetricMapAddUntimedNoRateLimit(t *testing.T) {
 	// Add a metric with different type and assert there are
 	// now two entries.
 	key2 := entryKey{
-		metricType: unaggregated.GaugeType,
-		idHash:     xid.Murmur3Hash128(testCounterID),
+		metricCategory: untimedMetric,
+		metricType:     metric.GaugeType,
+		idHash:         xid.Murmur3Hash128(testCounterID),
 	}
 	metricWithDifferentType := unaggregated.MetricUnion{
-		Type:     unaggregated.GaugeType,
+		Type:     metric.GaugeType,
 		ID:       testCounterID,
 		GaugeVal: 123.456,
 	}
@@ -134,7 +137,7 @@ func TestMetricMapAddUntimedNoRateLimit(t *testing.T) {
 
 	// Add a metric with a different id and assert there are now three entries.
 	metricWithDifferentID := unaggregated.MetricUnion{
-		Type:     unaggregated.GaugeType,
+		Type:     metric.GaugeType,
 		ID:       []byte("bar"),
 		GaugeVal: 123.456,
 	}
@@ -203,7 +206,7 @@ func TestMetricMapAddUntimedWithRateLimit(t *testing.T) {
 	endIdx := 100
 	for i := startIdx; i < endIdx; i++ {
 		metric := unaggregated.MetricUnion{
-			Type: unaggregated.CounterType,
+			Type: metric.CounterType,
 			ID:   id.RawID(fmt.Sprintf("testC%d", i)),
 		}
 		require.NoError(t, m.AddUntimed(metric, testDefaultStagedMetadatas))
@@ -218,7 +221,7 @@ func TestMetricMapAddUntimedWithRateLimit(t *testing.T) {
 	endIdx = startIdx + 1
 	for i := startIdx; i < endIdx; i++ {
 		metric := unaggregated.MetricUnion{
-			Type: unaggregated.CounterType,
+			Type: metric.CounterType,
 			ID:   id.RawID(fmt.Sprintf("testC%d", i)),
 		}
 		if i == startIdx {
@@ -240,7 +243,7 @@ func TestMetricMapAddUntimedWithRateLimit(t *testing.T) {
 	endIdx = startIdx + 100
 	for i := startIdx; i < endIdx; i++ {
 		metric := unaggregated.MetricUnion{
-			Type: unaggregated.CounterType,
+			Type: metric.CounterType,
 			ID:   id.RawID(fmt.Sprintf("testC%d", i)),
 		}
 		require.NoError(t, m.AddUntimed(metric, testDefaultStagedMetadatas))
@@ -248,7 +251,7 @@ func TestMetricMapAddUntimedWithRateLimit(t *testing.T) {
 
 	// Verify one more insert results in rate limit violation.
 	metric := unaggregated.MetricUnion{
-		Type: unaggregated.CounterType,
+		Type: metric.CounterType,
 		ID:   id.RawID(fmt.Sprintf("testC%d", endIdx)),
 	}
 	require.Equal(t, errWriteNewMetricRateLimitExceeded, m.AddUntimed(metric, testDefaultStagedMetadatas))
@@ -287,7 +290,7 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 	numEntries := 500
 	for i := 0; i < numEntries; i++ {
 		key := entryKey{
-			metricType: unaggregated.CounterType,
+			metricType: metric.CounterType,
 			idHash:     xid.Murmur3Hash128([]byte(fmt.Sprintf("%d", i))),
 		}
 		if i%2 == 0 {

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -154,7 +154,7 @@ func (e *TimerElem) AddMetric(timestamp time.Time, mu unaggregated.MetricUnion) 
 func (e *TimerElem) Consume(
 	earlierThanNanos int64,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) bool {
 	e.Lock()
 	if e.closed {
@@ -187,7 +187,7 @@ func (e *TimerElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		endAtNanos := e.toConsume[i].timeNanos + int64(e.sp.Resolution().Window)
-		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardFn)
+		e.processValue(endAtNanos, e.toConsume[i].aggregation, flushLocalFn, flushForwardedFn)
 		// Closes the aggregation object after it's processed.
 		e.toConsume[i].aggregation.Close()
 		e.toConsume[i].Reset()
@@ -299,7 +299,7 @@ func (e *TimerElem) processValue(
 	timeNanos int64,
 	agg *lockedTimer,
 	flushLocalFn flushLocalMetricFn,
-	flushForwardFn flushForwardMetricFn,
+	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
 		fullPrefix      = e.FullPrefix(e.opts)
@@ -341,7 +341,7 @@ func (e *TimerElem) processValue(
 				StoragePolicy: e.sp,
 				Pipeline:      e.parsedPipeline.Remainder,
 			}
-			flushForwardFn(fm, meta)
+			flushForwardedFn(fm, meta)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/client/payload.go
+++ b/client/payload.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/unaggregated"
+)
+
+type payloadType int
+
+const (
+	// nolint: megacheck
+	unknownPayloadType payloadType = iota
+	untimedType
+	forwardedType
+)
+
+type untimedPayload struct {
+	metric    unaggregated.MetricUnion
+	metadatas metadata.StagedMetadatas
+}
+
+type forwardedPayload struct {
+	metric   aggregated.Metric
+	metadata metadata.ForwardMetadata
+}
+
+type payloadUnion struct {
+	payloadType payloadType
+	untimed     untimedPayload
+	forwarded   forwardedPayload
+}

--- a/client/writer_mgr_mock.go
+++ b/client/writer_mgr_mock.go
@@ -25,8 +25,6 @@ package client
 
 import (
 	"github.com/m3db/m3cluster/placement"
-	"github.com/m3db/m3metrics/metadata"
-	"github.com/m3db/m3metrics/metric/unaggregated"
 
 	"github.com/golang/mock/gomock"
 )
@@ -72,14 +70,14 @@ func (_mr *_MockinstanceWriterManagerRecorder) RemoveInstances(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveInstances", arg0)
 }
 
-func (_m *MockinstanceWriterManager) WriteUntimed(instance placement.Instance, shardID uint32, metric unaggregated.MetricUnion, metadatas metadata.StagedMetadatas) error {
-	ret := _m.ctrl.Call(_m, "WriteUntimed", instance, shardID, metric, metadatas)
+func (_m *MockinstanceWriterManager) Write(instance placement.Instance, shardID uint32, payload payloadUnion) error {
+	ret := _m.ctrl.Call(_m, "Write", instance, shardID, payload)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockinstanceWriterManagerRecorder) WriteUntimed(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteUntimed", arg0, arg1, arg2, arg3)
+func (_mr *_MockinstanceWriterManagerRecorder) Write(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2)
 }
 
 func (_m *MockinstanceWriterManager) Flush() error {

--- a/client/writer_mock.go
+++ b/client/writer_mock.go
@@ -24,9 +24,6 @@
 package client
 
 import (
-	"github.com/m3db/m3metrics/metadata"
-	"github.com/m3db/m3metrics/metric/unaggregated"
-
 	"github.com/golang/mock/gomock"
 )
 
@@ -51,14 +48,14 @@ func (_m *MockinstanceWriter) EXPECT() *_MockinstanceWriterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockinstanceWriter) WriteUntimed(shard uint32, metric unaggregated.MetricUnion, metadatas metadata.StagedMetadatas) error {
-	ret := _m.ctrl.Call(_m, "WriteUntimed", shard, metric, metadatas)
+func (_m *MockinstanceWriter) Write(shard uint32, payload payloadUnion) error {
+	ret := _m.ctrl.Call(_m, "Write", shard, payload)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockinstanceWriterRecorder) WriteUntimed(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteUntimed", arg0, arg1, arg2)
+func (_mr *_MockinstanceWriterRecorder) Write(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1)
 }
 
 func (_m *MockinstanceWriter) Flush() error {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 55d4c0d6d11e11e508d5b1b55320bb821b9dc8546e63068a31fb72500455c515
-updated: 2018-04-22T10:33:44.472767-04:00
+hash: b936fe3adb737996cc6f20ec112ec6459294dfd31a9e247a80f43a6022a60d3a
+updated: 2018-05-01T11:37:37.861614-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -182,7 +182,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 814a1041da8ffcf885e6ce8fbbae2b1cf0b080fe
+  version: 6f5b192995f7a396a292d354cd172fc615e76a38
   subpackages:
   - aggregation
   - encoding

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b936fe3adb737996cc6f20ec112ec6459294dfd31a9e247a80f43a6022a60d3a
-updated: 2018-05-01T11:37:37.861614-04:00
+hash: 25e56025cc446e51f29eed01eb64e33452d202dfb12fe9851985d1cc4e094ab8
+updated: 2018-05-01T13:14:31.906581-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -182,7 +182,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 6f5b192995f7a396a292d354cd172fc615e76a38
+  version: e43eeadc9c3db2c2ecfc35b943545ee1452a6c4a
   subpackages:
   - aggregation
   - encoding

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: 6f5b192995f7a396a292d354cd172fc615e76a38
+  version: e43eeadc9c3db2c2ecfc35b943545ee1452a6c4a
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: 814a1041da8ffcf885e6ce8fbbae2b1cf0b080fe
+  version: 6f5b192995f7a396a292d354cd172fc615e76a38
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/integration/client.go
+++ b/integration/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3metrics/encoding/msgpack"
 	"github.com/m3db/m3metrics/encoding/protobuf"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 )
@@ -82,17 +83,17 @@ func (c *client) writeMetricWithPoliciesList(
 	sizeBefore := encoder.Buffer().Len()
 	var err error
 	switch mu.Type {
-	case unaggregated.CounterType:
+	case metric.CounterType:
 		err = c.msgpackEncoder.EncodeCounterWithPoliciesList(unaggregated.CounterWithPoliciesList{
 			Counter:      mu.Counter(),
 			PoliciesList: pl,
 		})
-	case unaggregated.BatchTimerType:
+	case metric.TimerType:
 		err = c.msgpackEncoder.EncodeBatchTimerWithPoliciesList(unaggregated.BatchTimerWithPoliciesList{
 			BatchTimer:   mu.BatchTimer(),
 			PoliciesList: pl,
 		})
-	case unaggregated.GaugeType:
+	case metric.GaugeType:
 		err = c.msgpackEncoder.EncodeGaugeWithPoliciesList(unaggregated.GaugeWithPoliciesList{
 			Gauge:        mu.Gauge(),
 			PoliciesList: pl,
@@ -131,21 +132,21 @@ func (c *client) writeMetricWithMetadatas(
 	sizeBefore := encoder.Len()
 	var err error
 	switch mu.Type {
-	case unaggregated.CounterType:
+	case metric.CounterType:
 		err = c.protobufEncoder.EncodeMessage(encoding.UnaggregatedMessageUnion{
 			Type: encoding.CounterWithMetadatasType,
 			CounterWithMetadatas: unaggregated.CounterWithMetadatas{
 				Counter:         mu.Counter(),
 				StagedMetadatas: sm,
 			}})
-	case unaggregated.BatchTimerType:
+	case metric.TimerType:
 		err = c.protobufEncoder.EncodeMessage(encoding.UnaggregatedMessageUnion{
 			Type: encoding.BatchTimerWithMetadatasType,
 			BatchTimerWithMetadatas: unaggregated.BatchTimerWithMetadatas{
 				BatchTimer:      mu.BatchTimer(),
 				StagedMetadatas: sm,
 			}})
-	case unaggregated.GaugeType:
+	case metric.GaugeType:
 		err = c.protobufEncoder.EncodeMessage(encoding.UnaggregatedMessageUnion{
 			Type: encoding.GaugeWithMetadatasType,
 			GaugeWithMetadatas: unaggregated.GaugeWithMetadatas{

--- a/integration/multi_client_one_type_test.go
+++ b/integration/multi_client_one_type_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3metrics/metric/unaggregated"
+	"github.com/m3db/m3metrics/metric"
 
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +86,7 @@ func testMultiClientOneType(t *testing.T, metadata metadataUnion) {
 	}
 
 	ids := generateTestIDs(idPrefix, numIDs)
-	typeFn := constantMetricTypeFnFactory(unaggregated.CounterType)
+	typeFn := constantMetricTypeFnFactory(metric.CounterType)
 	dataset := generateTestDataset(start, stop, interval, ids, typeFn)
 	for _, data := range dataset {
 		testSetup.setNowFn(data.timestamp)

--- a/integration/same_id_multi_type_test.go
+++ b/integration/same_id_multi_type_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3metrics/metric/unaggregated"
+	"github.com/m3db/m3metrics/metric"
 
 	"github.com/stretchr/testify/require"
 )
@@ -82,24 +82,24 @@ func testSameIDMultiType(t *testing.T, metadata metadataUnion) {
 	defer client.close()
 
 	ids := generateTestIDs(idPrefix, numIDs)
-	metricTypeFn := func(ts time.Time, idx int) unaggregated.Type {
+	metricTypeFn := func(ts time.Time, idx int) metric.Type {
 		if ts.Before(mid) {
 			switch idx % 3 {
 			case 0:
-				return unaggregated.CounterType
+				return metric.CounterType
 			case 1:
-				return unaggregated.BatchTimerType
+				return metric.TimerType
 			default:
-				return unaggregated.GaugeType
+				return metric.GaugeType
 			}
 		} else {
 			switch idx % 3 {
 			case 0:
-				return unaggregated.BatchTimerType
+				return metric.TimerType
 			case 1:
-				return unaggregated.GaugeType
+				return metric.GaugeType
 			default:
-				return unaggregated.CounterType
+				return metric.CounterType
 			}
 		}
 	}

--- a/server/rawtcp/server_test.go
+++ b/server/rawtcp/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3metrics/encoding/msgpack"
 	"github.com/m3db/m3metrics/encoding/protobuf"
 	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/retry"
@@ -50,17 +51,17 @@ const (
 var (
 	testNowNanos = time.Now().UnixNano()
 	testCounter  = unaggregated.MetricUnion{
-		Type:       unaggregated.CounterType,
+		Type:       metric.CounterType,
 		ID:         []byte("testCounter"),
 		CounterVal: 123,
 	}
 	testBatchTimer = unaggregated.MetricUnion{
-		Type:          unaggregated.BatchTimerType,
+		Type:          metric.TimerType,
 		ID:            []byte("testBatchTimer"),
 		BatchTimerVal: []float64{1.0, 2.0, 3.0},
 	}
 	testGauge = unaggregated.MetricUnion{
-		Type:     unaggregated.GaugeType,
+		Type:     metric.GaugeType,
 		ID:       []byte("testGauge"),
 		GaugeVal: 456.780,
 	}


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds the admin client interface as well as the API for writing forwarded metrics to destination aggregation servers.

There are other minor renaming changes due to consolidating metric types in `m3metrics` but most of them are immaterial.  