### PR TITLE
Distinguish tick metrics for standard metrics and forwarded metrics

### DIFF
--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -734,9 +734,13 @@ func TestMetricLists(t *testing.T) {
 
 	// Perform a tick.
 	tickRes := lists.Tick()
-	expectedRes := map[time.Duration]int{
-		time.Second:      0,
-		10 * time.Second: 0,
+	expectedRes := listsTickResult{
+		standard: map[time.Duration]int{
+			time.Second: 0,
+		},
+		forwarded: map[time.Duration]int{
+			10 * time.Second: 0,
+		},
 	}
 	require.Equal(t, expectedRes, tickRes)
 

--- a/aggregator/map_test.go
+++ b/aggregator/map_test.go
@@ -411,7 +411,7 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 	}
 
 	// Delete expired entries.
-	m.deleteExpired(opts.EntryCheckInterval())
+	m.tick(opts.EntryCheckInterval())
 
 	// Assert there should be only half of the entries left.
 	require.Equal(t, numEntries/2, len(m.entries))


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds the logic to distinguish tick metrics for standard metrics from those for forwarded metrics to make it more clear on aggregator dashboards.