### PR TITLE
Add logic to take into account forwarded metrics during leadership election

### DIFF
--- a/aggregator/election_mgr.go
+++ b/aggregator/election_mgr.go
@@ -588,7 +588,6 @@ func (mgr *electionManager) processCampaignStateChange(newState campaignState) {
 	}
 }
 
-// TODO(xichen): rework logic to take forwared metrics into account.
 func (mgr *electionManager) campaignIsEnabled() (bool, error) {
 	// If the current instance is not found in the placement, campaigning is disabled.
 	shards, err := mgr.placementManager.Shards()

--- a/aggregator/flush_times_mgr_test.go
+++ b/aggregator/flush_times_mgr_test.go
@@ -45,10 +45,25 @@ var (
 				StandardByResolution: map[int64]int64{
 					int64(time.Second): 1000,
 				},
+				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
+					1000000000: &schema.ForwardedFlushTimesForResolution{
+						ByNumForwardedTimes: map[int32]int64{
+							1: 700,
+						},
+					},
+				},
 			},
 			1: &schema.ShardFlushTimes{
 				StandardByResolution: map[int64]int64{
 					int64(time.Minute): 2000,
+				},
+				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
+					1000000000: &schema.ForwardedFlushTimesForResolution{
+						ByNumForwardedTimes: map[int32]int64{
+							1: 2500,
+							3: 3500,
+						},
+					},
 				},
 			},
 		},
@@ -178,10 +193,12 @@ func TestFlushTimesCheckerHasFlushed(t *testing.T) {
 		flushTimes  *schema.ShardSetFlushTimes
 		expected    bool
 	}{
+		{shardID: 0, targetNanos: 700, flushTimes: testFlushTimesProto, expected: true},
+		{shardID: 1, targetNanos: 2000, flushTimes: testFlushTimesProto, expected: true},
 		{shardID: 0, targetNanos: 0, flushTimes: nil, expected: false},
+		{shardID: 0, targetNanos: 1000, flushTimes: testFlushTimesProto, expected: false},
+		{shardID: 1, targetNanos: 3000, flushTimes: testFlushTimesProto, expected: false},
 		{shardID: 2, targetNanos: 0, flushTimes: testFlushTimesProto, expected: false},
-		{shardID: 0, targetNanos: 1500, flushTimes: testFlushTimesProto, expected: false},
-		{shardID: 0, targetNanos: 1000, flushTimes: testFlushTimesProto, expected: true},
 	}
 
 	for _, input := range inputs {

--- a/aggregator/follower_flush_mgr_test.go
+++ b/aggregator/follower_flush_mgr_test.go
@@ -85,7 +85,7 @@ func TestFollowerFlushManagerCanNotLeadProtoNotUpdated(t *testing.T) {
 	require.False(t, mgr.CanLead())
 }
 
-func TestFollowerFlushManagerCanNotLeadFlushWindowsNotEnded(t *testing.T) {
+func TestFollowerFlushManagerCanNotLeadStandardFlushWindowsNotEnded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -96,6 +96,20 @@ func TestFollowerFlushManagerCanNotLeadFlushWindowsNotEnded(t *testing.T) {
 	mgr := newFollowerFlushManager(doneCh, opts).(*followerFlushManager)
 	mgr.processed = testFlushTimes
 	mgr.openedAt = time.Unix(3624, 0)
+	require.False(t, mgr.CanLead())
+}
+
+func TestFollowerFlushManagerCanNotLeadForwardedFlushWindowsNotEnded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	doneCh := make(chan struct{})
+	electionManager := NewMockElectionManager(ctrl)
+	electionManager.EXPECT().IsCampaigning().Return(true)
+	opts := NewFlushManagerOptions().SetElectionManager(electionManager)
+	mgr := newFollowerFlushManager(doneCh, opts).(*followerFlushManager)
+	mgr.processed = testFlushTimes
+	mgr.openedAt = time.Unix(3640, 0)
 	require.False(t, mgr.CanLead())
 }
 
@@ -125,7 +139,7 @@ func TestFollowerFlushManagerCanLeadWithTombstonedShards(t *testing.T) {
 	mgr := newFollowerFlushManager(doneCh, opts).(*followerFlushManager)
 	mgr.flushTimesState = flushTimesProcessed
 	mgr.processed = testFlushTimes2
-	mgr.openedAt = time.Unix(3660, 0)
+	mgr.openedAt = time.Unix(3600, 0)
 	require.True(t, mgr.CanLead())
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -472,12 +472,14 @@ func TestClientWriteForwardedMetricSuccess(t *testing.T) {
 		testPlacementInstances[0],
 		testPlacementInstances[2],
 	}
-	err := c.WriteForwarded(testForwarded, testForwardMetadata)
+	testMetric := testForwarded
+	testMetric.TimeNanos = testNowNanos
+	err := c.WriteForwarded(testMetric, testForwardMetadata)
 	require.NoError(t, err)
 	require.Equal(t, expectedInstances, instancesRes)
 	require.Equal(t, uint32(1), shardRes)
 	require.Equal(t, forwardedType, payloadRes.payloadType)
-	require.Equal(t, testForwarded, payloadRes.forwarded.metric)
+	require.Equal(t, testMetric, payloadRes.forwarded.metric)
 	require.Equal(t, testForwardMetadata, payloadRes.forwarded.metadata)
 }
 
@@ -521,13 +523,15 @@ func TestClientWriteForwardedMetricPartialError(t *testing.T) {
 	expectedInstances := []placement.Instance{
 		testPlacementInstances[2],
 	}
-	err := c.WriteForwarded(testForwarded, testForwardMetadata)
+	testMetric := testForwarded
+	testMetric.TimeNanos = testNowNanos
+	err := c.WriteForwarded(testMetric, testForwardMetadata)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), errInstanceWrite.Error()))
 	require.Equal(t, expectedInstances, instancesRes)
 	require.Equal(t, uint32(1), shardRes)
 	require.Equal(t, forwardedType, payloadRes.payloadType)
-	require.Equal(t, testForwarded, payloadRes.forwarded.metric)
+	require.Equal(t, testMetric, payloadRes.forwarded.metric)
 	require.Equal(t, testForwardMetadata, payloadRes.forwarded.metadata)
 }
 


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds logic to take into account forwarded metrics during deployment and leadership election.