### PR TITLE
Pull in latest m3metrics dev

### DIFF
--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -41,8 +41,8 @@ import (
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	xtime "github.com/m3db/m3x/time"
 
@@ -104,10 +104,10 @@ var (
 	testForwardMetadata = metadata.ForwardMetadata{
 		AggregationID: aggregation.DefaultID,
 		StoragePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour),
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo"),
 					AggregationID: aggregation.MustCompressTypes(aggregation.Count),
 				},

--- a/aggregator/capture/aggregator_test.go
+++ b/aggregator/capture/aggregator_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	xtime "github.com/m3db/m3x/time"
 
@@ -69,10 +69,10 @@ var (
 	testForwardMetadata  = metadata.ForwardMetadata{
 		AggregationID: aggregation.DefaultID,
 		StoragePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour),
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo"),
 					AggregationID: aggregation.MustCompressTypes(aggregation.Count),
 				},

--- a/aggregator/counter_elem.gen.go
+++ b/aggregator/counter_elem.gen.go
@@ -41,7 +41,7 @@ import (
 
 	"github.com/m3db/m3metrics/metric/unaggregated"
 
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 
 	"github.com/m3db/m3metrics/policy"
 
@@ -394,7 +394,7 @@ func (e *CounterElem) processValueWithAggregationLock(
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
 		value := lockedAgg.aggregation.ValueOf(aggType)
-		for i := 0; i < transformations.NumSteps(); i++ {
+		for i := 0; i < transformations.Len(); i++ {
 			transformType := transformations.At(i).Transformation.Type
 			if transformType.IsUnaryTransform() {
 				fn := transformType.MustUnaryTransform()

--- a/aggregator/elem_pool_test.go
+++ b/aggregator/elem_pool_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3metrics/aggregation"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
 

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/transformation"
 	xid "github.com/m3db/m3x/ident"
@@ -67,25 +67,25 @@ var (
 		ID:       testGaugeID,
 		GaugeVal: 123.456,
 	}
-	testPipeline = applied.NewPipeline([]applied.Union{
+	testPipeline = applied.NewPipeline([]applied.OpUnion{
 		{
-			Type:           op.TransformationType,
-			Transformation: op.Transformation{Type: transformation.Absolute},
+			Type:           pipeline.TransformationOpType,
+			Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 		},
 		{
-			Type:           op.TransformationType,
-			Transformation: op.Transformation{Type: transformation.PerSecond},
+			Type:           pipeline.TransformationOpType,
+			Transformation: pipeline.TransformationOp{Type: transformation.PerSecond},
 		},
 		{
-			Type: op.RollupType,
-			Rollup: applied.Rollup{
+			Type: pipeline.RollupOpType,
+			Rollup: applied.RollupOp{
 				ID:            []byte("foo.bar"),
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 			},
 		},
 		{
-			Type: op.RollupType,
-			Rollup: applied.Rollup{
+			Type: pipeline.RollupOpType,
+			Rollup: applied.RollupOp{
 				ID:            []byte("foo.baz"),
 				AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 			},
@@ -130,25 +130,25 @@ func TestCounterResetSetData(t *testing.T) {
 	// Reset element with a pipeline containing a derivative transformation.
 	expectedParsedPipeline := parsedPipeline{
 		HasDerivativeTransform: true,
-		Transformations: applied.NewPipeline([]applied.Union{
+		Transformations: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.Absolute},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 			},
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.PerSecond},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.PerSecond},
 			},
 		}),
 		HasRollup: true,
-		Rollup: applied.Rollup{
+		Rollup: applied.RollupOp{
 			ID:            []byte("foo.bar"),
 			AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 		},
-		Remainder: applied.NewPipeline([]applied.Union{
+		Remainder: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo.baz"),
 					AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 				},
@@ -175,10 +175,10 @@ func TestCounterResetSetDataInvalidPipeline(t *testing.T) {
 	opts := NewOptions()
 	ce := MustNewCounterElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, opts)
 
-	invalidPipeline := applied.NewPipeline([]applied.Union{
+	invalidPipeline := applied.NewPipeline([]applied.OpUnion{
 		{
-			Type:           op.TransformationType,
-			Transformation: op.Transformation{Type: transformation.Absolute},
+			Type:           pipeline.TransformationOpType,
+			Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 		},
 	})
 	err := ce.ResetSetData(testCounterID, testStoragePolicy, maggregation.DefaultTypes, invalidPipeline, 0)
@@ -495,10 +495,10 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -529,10 +529,10 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -551,10 +551,10 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -689,25 +689,25 @@ func TestTimerResetSetData(t *testing.T) {
 	// Reset element with a pipeline containing a derivative transformation.
 	expectedParsedPipeline := parsedPipeline{
 		HasDerivativeTransform: true,
-		Transformations: applied.NewPipeline([]applied.Union{
+		Transformations: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.Absolute},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 			},
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.PerSecond},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.PerSecond},
 			},
 		}),
 		HasRollup: true,
-		Rollup: applied.Rollup{
+		Rollup: applied.RollupOp{
 			ID:            []byte("foo.bar"),
 			AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 		},
-		Remainder: applied.NewPipeline([]applied.Union{
+		Remainder: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo.baz"),
 					AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 				},
@@ -734,10 +734,10 @@ func TestTimerResetSetDataInvalidPipeline(t *testing.T) {
 	opts := NewOptions()
 	te := MustNewTimerElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, opts)
 
-	invalidPipeline := applied.NewPipeline([]applied.Union{
+	invalidPipeline := applied.NewPipeline([]applied.OpUnion{
 		{
-			Type:           op.TransformationType,
-			Transformation: op.Transformation{Type: transformation.Absolute},
+			Type:           pipeline.TransformationOpType,
+			Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 		},
 	})
 	err := te.ResetSetData(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes, invalidPipeline, 0)
@@ -992,10 +992,10 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -1026,10 +1026,10 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -1048,10 +1048,10 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -1191,25 +1191,25 @@ func TestGaugeResetSetData(t *testing.T) {
 	// Reset element with a pipeline containing a derivative transformation.
 	expectedParsedPipeline := parsedPipeline{
 		HasDerivativeTransform: true,
-		Transformations: applied.NewPipeline([]applied.Union{
+		Transformations: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.Absolute},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 			},
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.PerSecond},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.PerSecond},
 			},
 		}),
 		HasRollup: true,
-		Rollup: applied.Rollup{
+		Rollup: applied.RollupOp{
 			ID:            []byte("foo.bar"),
 			AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 		},
-		Remainder: applied.NewPipeline([]applied.Union{
+		Remainder: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo.baz"),
 					AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 				},
@@ -1541,10 +1541,10 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -1575,10 +1575,10 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},
@@ -1597,10 +1597,10 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 			ForwardMetadata: metadata.ForwardMetadata{
 				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
 				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.Union{
+				Pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
 						},

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -36,7 +36,7 @@ import (
 	"github.com/m3db/m3metrics/metric/aggregated"
 	metricid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	xerrors "github.com/m3db/m3x/errors"
 

--- a/aggregator/entry_test.go
+++ b/aggregator/entry_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/transformation"
 	"github.com/m3db/m3x/clock"
@@ -86,14 +86,14 @@ var (
 		{
 			AggregationID:   aggregation.DefaultID,
 			StoragePolicies: testDefaultStoragePolicies,
-			Pipeline: applied.NewPipeline([]applied.Union{
+			Pipeline: applied.NewPipeline([]applied.OpUnion{
 				{
-					Type:           op.TransformationType,
-					Transformation: op.Transformation{Type: transformation.Absolute},
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 				},
 				{
-					Type: op.RollupType,
-					Rollup: applied.Rollup{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
 						ID:            []byte("foo.bar"),
 						AggregationID: aggregation.DefaultID,
 					},
@@ -105,14 +105,14 @@ var (
 		{
 			AggregationID:   aggregation.DefaultID,
 			StoragePolicies: testDefaultStoragePolicies,
-			Pipeline: applied.NewPipeline([]applied.Union{
+			Pipeline: applied.NewPipeline([]applied.OpUnion{
 				{
-					Type:           op.TransformationType,
-					Transformation: op.Transformation{Type: transformation.Absolute},
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 				},
 				{
-					Type: op.RollupType,
-					Rollup: applied.Rollup{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
 						ID:            []byte("foo.baz"),
 						AggregationID: aggregation.DefaultID,
 					},
@@ -134,14 +134,14 @@ var (
 		{
 			AggregationID:   aggregation.DefaultID,
 			StoragePolicies: testDefaultStoragePolicies,
-			Pipeline: applied.NewPipeline([]applied.Union{
+			Pipeline: applied.NewPipeline([]applied.OpUnion{
 				{
-					Type:           op.TransformationType,
-					Transformation: op.Transformation{Type: transformation.Absolute},
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 				},
 				{
-					Type: op.RollupType,
-					Rollup: applied.Rollup{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
 						ID:            []byte("foo.baz"),
 						AggregationID: aggregation.DefaultID,
 					},
@@ -155,14 +155,14 @@ var (
 		{
 			AggregationID:   aggregation.DefaultID,
 			StoragePolicies: testDefaultStoragePolicies,
-			Pipeline: applied.NewPipeline([]applied.Union{
+			Pipeline: applied.NewPipeline([]applied.OpUnion{
 				{
-					Type:           op.TransformationType,
-					Transformation: op.Transformation{Type: transformation.Absolute},
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 				},
 				{
-					Type: op.RollupType,
-					Rollup: applied.Rollup{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
 						ID:            []byte("foo.baz"),
 						AggregationID: aggregation.DefaultID,
 					},
@@ -173,10 +173,10 @@ var (
 	testForwardMetadata1 = metadata.ForwardMetadata{
 		AggregationID: aggregation.DefaultID,
 		StoragePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour),
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo"),
 					AggregationID: aggregation.MustCompressTypes(aggregation.Count),
 				},
@@ -188,10 +188,10 @@ var (
 	testForwardMetadata2 = metadata.ForwardMetadata{
 		AggregationID: aggregation.DefaultID,
 		StoragePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("bar"),
 					AggregationID: aggregation.DefaultID,
 				},
@@ -1003,10 +1003,10 @@ func TestEntryAddUntimedWithInvalidPipeline(t *testing.T) {
 	defer ctrl.Finish()
 
 	invalidPipeline := metadata.PipelineMetadata{
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type:           op.TransformationType,
-				Transformation: op.Transformation{Type: transformation.Absolute},
+				Type:           pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 			},
 		}),
 	}
@@ -1491,14 +1491,14 @@ func TestAggregationKeyEqual(t *testing.T) {
 			a: aggregationKey{
 				aggregationID: aggregation.DefaultID,
 				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
-				pipeline: applied.NewPipeline([]applied.Union{
+				pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type:           op.TransformationType,
-						Transformation: op.Transformation{Type: transformation.Absolute},
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 					},
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: aggregation.DefaultID,
 						},
@@ -1508,14 +1508,14 @@ func TestAggregationKeyEqual(t *testing.T) {
 			b: aggregationKey{
 				aggregationID: aggregation.DefaultID,
 				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
-				pipeline: applied.NewPipeline([]applied.Union{
+				pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type:           op.TransformationType,
-						Transformation: op.Transformation{Type: transformation.Absolute},
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 					},
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: aggregation.DefaultID,
 						},
@@ -1550,14 +1550,14 @@ func TestAggregationKeyEqual(t *testing.T) {
 			a: aggregationKey{
 				aggregationID: aggregation.DefaultID,
 				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
-				pipeline: applied.NewPipeline([]applied.Union{
+				pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type:           op.TransformationType,
-						Transformation: op.Transformation{Type: transformation.Absolute},
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 					},
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.baz"),
 							AggregationID: aggregation.DefaultID,
 						},
@@ -1567,14 +1567,14 @@ func TestAggregationKeyEqual(t *testing.T) {
 			b: aggregationKey{
 				aggregationID: aggregation.DefaultID,
 				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
-				pipeline: applied.NewPipeline([]applied.Union{
+				pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type:           op.TransformationType,
-						Transformation: op.Transformation{Type: transformation.Absolute},
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 					},
 					{
-						Type: op.RollupType,
-						Rollup: applied.Rollup{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
 							ID:            []byte("foo.bar"),
 							AggregationID: aggregation.DefaultID,
 						},
@@ -1601,14 +1601,14 @@ func TestAggregationValues(t *testing.T) {
 		{
 			aggregationID: aggregation.DefaultID,
 			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
-			pipeline: applied.NewPipeline([]applied.Union{
+			pipeline: applied.NewPipeline([]applied.OpUnion{
 				{
-					Type:           op.TransformationType,
-					Transformation: op.Transformation{Type: transformation.Absolute},
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 				},
 				{
-					Type: op.RollupType,
-					Rollup: applied.Rollup{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
 						ID:            []byte("foo.baz"),
 						AggregationID: aggregation.DefaultID,
 					},
@@ -1653,10 +1653,10 @@ func TestAggregationValues(t *testing.T) {
 			key: aggregationKey{
 				aggregationID: aggregation.DefaultID,
 				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
-				pipeline: applied.NewPipeline([]applied.Union{
+				pipeline: applied.NewPipeline([]applied.OpUnion{
 					{
-						Type:           op.TransformationType,
-						Transformation: op.Transformation{Type: transformation.Absolute},
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
 					},
 				}),
 			},

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -41,7 +41,7 @@ import (
 
 	"github.com/m3db/m3metrics/metric/unaggregated"
 
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 
 	"github.com/m3db/m3metrics/policy"
 
@@ -394,7 +394,7 @@ func (e *GaugeElem) processValueWithAggregationLock(
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
 		value := lockedAgg.aggregation.ValueOf(aggType)
-		for i := 0; i < transformations.NumSteps(); i++ {
+		for i := 0; i < transformations.Len(); i++ {
 			transformType := transformations.At(i).Transformation.Type
 			if transformType.IsUnaryTransform() {
 				fn := transformType.MustUnaryTransform()

--- a/aggregator/generic_elem.go
+++ b/aggregator/generic_elem.go
@@ -32,7 +32,7 @@ import (
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/transformation"
 	xid "github.com/m3db/m3x/ident"
@@ -439,7 +439,7 @@ func (e *GenericElem) processValueWithAggregationLock(
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
 		value := lockedAgg.aggregation.ValueOf(aggType)
-		for i := 0; i < transformations.NumSteps(); i++ {
+		for i := 0; i < transformations.Len(); i++ {
 			transformType := transformations.At(i).Transformation.Type
 			if transformType.IsUnaryTransform() {
 				fn := transformType.MustUnaryTransform()

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
 
@@ -520,10 +520,10 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 	l, err := newForwardedMetricList(testShard, listID, opts)
 	require.NoError(t, err)
 
-	pipeline := applied.NewPipeline([]applied.Union{
+	pipeline := applied.NewPipeline([]applied.OpUnion{
 		{
-			Type: op.RollupType,
-			Rollup: applied.Rollup{
+			Type: pipeline.RollupOpType,
+			Rollup: applied.RollupOp{
 				ID:            []byte("foo.bar"),
 				AggregationID: aggregation.MustCompressTypes(aggregation.Max),
 			},
@@ -594,7 +594,7 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 			metadata := metadata.ForwardMetadata{
 				AggregationID:     aggregation.MustCompressTypes(aggregation.Max),
 				StoragePolicy:     testStoragePolicy,
-				Pipeline:          applied.NewPipeline([]applied.Union{}),
+				Pipeline:          applied.NewPipeline([]applied.OpUnion{}),
 				SourceID:          ep.elem.ID(),
 				NumForwardedTimes: testNumForwardedTimes + 1,
 			}

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -30,7 +30,7 @@ import (
 	"github.com/m3db/m3aggregator/runtime"
 	"github.com/m3db/m3aggregator/sharding"
 	"github.com/m3db/m3metrics/aggregation"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -41,7 +41,7 @@ import (
 
 	"github.com/m3db/m3metrics/metric/unaggregated"
 
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 
 	"github.com/m3db/m3metrics/policy"
 
@@ -394,7 +394,7 @@ func (e *TimerElem) processValueWithAggregationLock(
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
 		value := lockedAgg.aggregation.ValueOf(aggType)
-		for i := 0; i < transformations.NumSteps(); i++ {
+		for i := 0; i < transformations.Len(); i++ {
 			transformType := transformations.At(i).Transformation.Type
 			if transformType.IsUnaryTransform() {
 				fn := transformType.MustUnaryTransform()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
@@ -105,10 +105,10 @@ var (
 	testForwardMetadata = metadata.ForwardMetadata{
 		AggregationID: aggregation.DefaultID,
 		StoragePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour),
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo"),
 					AggregationID: aggregation.MustCompressTypes(aggregation.Count),
 				},

--- a/client/config.go
+++ b/client/config.go
@@ -190,8 +190,9 @@ func (c *EncoderConfiguration) NewEncoderOptions(
 	if c.BytesPool != nil {
 		sizeBuckets := c.BytesPool.NewBuckets()
 		objectPoolOpts := c.BytesPool.NewObjectPoolOptions(instrumentOpts)
-		bytesPoolOpts := pool.NewBytesPool(sizeBuckets, objectPoolOpts)
-		opts = opts.SetBytesPool(bytesPoolOpts)
+		bytesPool := pool.NewBytesPool(sizeBuckets, objectPoolOpts)
+		opts = opts.SetBytesPool(bytesPool)
+		bytesPool.Init()
 	}
 	return opts
 }

--- a/client/conn.go
+++ b/client/conn.go
@@ -97,6 +97,7 @@ func newConnection(addr string, opts ConnectionOptions) *connection {
 
 // Write sends data onto the connection, and attempts to re-establish
 // connection if the connection is down.
+// TODO(xichen): emit a metric when the write fails.
 func (c *connection) Write(data []byte) error {
 	c.Lock()
 	if c.conn == nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: de19cab356594d9e269e6fdce2c0b4ddb8d7334ae82c1eead6c3c6db32065cba
-updated: 2018-05-21T20:05:41.552156-07:00
+hash: d484a0943b921e21ce73c1ce42df0b8a94dfc9f771384eddd22ce3ac759a840b
+updated: 2018-06-06T16:00:30.810122-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -188,7 +188,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 8237e5d15386000b69bbdf7d5555b74d8c4bb212
+  version: b06fca5c5965e2a5e105a822ba3da1470107624c
   subpackages:
   - aggregation
   - encoding
@@ -205,10 +205,11 @@ imports:
   - metric/aggregated
   - metric/id
   - metric/unaggregated
-  - op
-  - op/applied
+  - pipeline
+  - pipeline/applied
   - policy
   - transformation
+  - x/bytes
 - name: github.com/m3db/m3x
   version: a3695ff2d9696fcd9fffca878b9b544e68c4b1ef
   subpackages:
@@ -303,7 +304,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 2dc8d10634f473f4dc678e48391a9dc8cf6ae6f9
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
 
 - package: github.com/m3db/m3metrics
-  version: 8237e5d15386000b69bbdf7d5555b74d8c4bb212
+  version: b06fca5c5965e2a5e105a822ba3da1470107624c
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/integration/data.go
+++ b/integration/data.go
@@ -36,7 +36,7 @@ import (
 	"github.com/m3db/m3metrics/metric/id"
 	metricid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	xtime "github.com/m3db/m3x/time"
 

--- a/integration/multi_server_forwarding_pipeline_test.go
+++ b/integration/multi_server_forwarding_pipeline_test.go
@@ -36,8 +36,8 @@ import (
 	maggregation "github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/transformation"
 	"github.com/m3db/m3x/clock"
@@ -234,14 +234,14 @@ func TestMultiServerForwardingPipeline(t *testing.T) {
 					{
 						AggregationID:   maggregation.DefaultID,
 						StoragePolicies: []policy.StoragePolicy{storagePolicy},
-						Pipeline: applied.NewPipeline([]applied.Union{
+						Pipeline: applied.NewPipeline([]applied.OpUnion{
 							{
-								Type:           op.TransformationType,
-								Transformation: op.Transformation{Type: transformation.PerSecond},
+								Type:           pipeline.TransformationOpType,
+								Transformation: pipeline.TransformationOp{Type: transformation.PerSecond},
 							},
 							{
-								Type: op.RollupType,
-								Rollup: applied.Rollup{
+								Type: pipeline.RollupOpType,
+								Rollup: applied.RollupOp{
 									ID:            []byte(pipelineRollupID),
 									AggregationID: maggregation.MustCompressTypes(maggregation.Sum),
 								},

--- a/server/rawtcp/server_test.go
+++ b/server/rawtcp/server_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/unaggregated"
-	"github.com/m3db/m3metrics/op"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/retry"
 	xserver "github.com/m3db/m3x/server"
@@ -113,10 +113,10 @@ var (
 	testForwardMetadata = metadata.ForwardMetadata{
 		AggregationID: aggregation.DefaultID,
 		StoragePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour),
-		Pipeline: applied.NewPipeline([]applied.Union{
+		Pipeline: applied.NewPipeline([]applied.OpUnion{
 			{
-				Type: op.RollupType,
-				Rollup: applied.Rollup{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
 					ID:            []byte("foo"),
 					AggregationID: aggregation.MustCompressTypes(aggregation.Count),
 				},

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -40,7 +40,7 @@ import (
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3metrics/aggregation"
-	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"

--- a/services/m3aggregator/config/server.go
+++ b/services/m3aggregator/config/server.go
@@ -167,6 +167,7 @@ func (c *protobufUnaggregatedIteratorConfiguration) NewOptions(
 	buckets := c.BytesPool.NewBuckets()
 	bytesPool := pool.NewBytesPool(buckets, objectPoolOpts)
 	opts = opts.SetBytesPool(bytesPool)
+	bytesPool.Init()
 
 	return opts
 }


### PR DESCRIPTION
cc @cw9 

This PR pulls in the latest m3metrics on tip of dev. It also initializes two bytes pool that weren't properly initialized previously.