### PR TITLE
Allow passing in clock options when creating agg tier client

### DIFF
--- a/client/config_test.go
+++ b/client/config_test.go
@@ -28,6 +28,7 @@ import (
 	m3clusterclient "github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
 
@@ -122,8 +123,9 @@ func TestNewClientOptions(t *testing.T) {
 	store := mem.NewStore()
 	kvClient := m3clusterclient.NewMockClient(ctrl)
 	kvClient.EXPECT().Store(expectedKvOpts).Return(store, nil)
+	clockOpts := clock.NewOptions()
 	instrumentOpts := instrument.NewOptions()
-	opts, err := cfg.newClientOptions(kvClient, instrumentOpts)
+	opts, err := cfg.newClientOptions(kvClient, clockOpts, instrumentOpts)
 	require.NoError(t, err)
 
 	// Verify the constructed options match expectations.

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -42,6 +42,7 @@ import (
 	"github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/retry"
@@ -176,7 +177,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	// Set administrative client.
 	// TODO(xichen): client retry threshold likely needs to be low for faster retries.
 	iOpts = instrumentOpts.SetMetricsScope(scope.SubScope("client"))
-	adminClient, err := c.Client.NewAdminClient(client, iOpts)
+	adminClient, err := c.Client.NewAdminClient(client, clock.NewOptions(), iOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR allows passing in clock options externally when creating agg tier client so the clock skews can be configured as needed.