### PR TITLE
Update m3metrics to pick up latest type options API changes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 341d40171dc7b6a96efe405b08bb2932c41d3826e612714d11af60db79fe9421
-updated: 2018-06-14T15:30:54.082945-04:00
+hash: fc6a95648dddbdd5c3fc25b6053d9b261d6a875de4ac2f4b0a57529ccfd91784
+updated: 2018-06-16T17:54:18.202452-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -186,7 +186,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: d84343677f64db35894920212a20475a4143c588
+  version: a1db73306c24b358a17b0ee9c93565796001a797
   subpackages:
   - aggregation
   - encoding
@@ -293,7 +293,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 88c71ae3d702167d7f8be42c0e0b68bfa4d1707e
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: cb17a54d6902c03790286942bafa04a188d4eeb8
 
 - package: github.com/m3db/m3metrics
-  version: d84343677f64db35894920212a20475a4143c588
+  version: a1db73306c24b358a17b0ee9c93565796001a797
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR updates m3metrics to pick up latest type options API changes.