### PR TITLE
Batch writing forwarded metric values for better scalability

### DIFF
--- a/aggregator/aggregation_key.go
+++ b/aggregator/aggregation_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,18 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-syntax = "proto3";
+package aggregator
 
-message ShardSetFlushTimes {
-  map<uint32, ShardFlushTimes> by_shard = 1;
+import (
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/pipeline/applied"
+	"github.com/m3db/m3metrics/policy"
+)
+
+type aggregationKey struct {
+	aggregationID     aggregation.ID
+	storagePolicy     policy.StoragePolicy
+	pipeline          applied.Pipeline
+	numForwardedTimes int
 }
 
-message ShardFlushTimes {
-  map<int64, int64> standard_by_resolution = 1;
-  bool tombstoned = 2;
-  map<int64, ForwardedFlushTimesForResolution> forwarded_by_resolution = 3;
-}
-
-message ForwardedFlushTimesForResolution {
-  map<int32, int64> by_num_forwarded_times = 1;
+func (k aggregationKey) Equal(other aggregationKey) bool {
+	return k.aggregationID == other.aggregationID &&
+		k.storagePolicy == other.storagePolicy &&
+		k.pipeline.Equal(other.pipeline) &&
+		k.numForwardedTimes == other.numForwardedTimes
 }

--- a/aggregator/aggregation_key_test.go
+++ b/aggregator/aggregation_key_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/pipeline"
+	"github.com/m3db/m3metrics/pipeline/applied"
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3metrics/transformation"
+	xtime "github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregationKeyEqual(t *testing.T) {
+	inputs := []struct {
+		a        aggregationKey
+		b        aggregationKey
+		expected bool
+	}{
+		{
+			a:        aggregationKey{},
+			b:        aggregationKey{},
+			expected: true,
+		},
+		{
+			a: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			},
+			b: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			},
+			expected: true,
+		},
+		{
+			a: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+				pipeline: applied.NewPipeline([]applied.OpUnion{
+					{
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+					},
+					{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
+							ID:            []byte("foo.baz"),
+							AggregationID: aggregation.DefaultID,
+						},
+					},
+				}),
+			},
+			b: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+				pipeline: applied.NewPipeline([]applied.OpUnion{
+					{
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+					},
+					{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
+							ID:            []byte("foo.baz"),
+							AggregationID: aggregation.DefaultID,
+						},
+					},
+				}),
+			},
+			expected: true,
+		},
+		{
+			a: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			},
+			b: aggregationKey{
+				aggregationID: aggregation.MustCompressTypes(aggregation.Count),
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			},
+			expected: false,
+		},
+		{
+			a: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			},
+			b: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 48*time.Hour),
+			},
+			expected: false,
+		},
+		{
+			a: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+				pipeline: applied.NewPipeline([]applied.OpUnion{
+					{
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+					},
+					{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
+							ID:            []byte("foo.baz"),
+							AggregationID: aggregation.DefaultID,
+						},
+					},
+				}),
+			},
+			b: aggregationKey{
+				aggregationID: aggregation.DefaultID,
+				storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+				pipeline: applied.NewPipeline([]applied.OpUnion{
+					{
+						Type:           pipeline.TransformationOpType,
+						Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+					},
+					{
+						Type: pipeline.RollupOpType,
+						Rollup: applied.RollupOp{
+							ID:            []byte("foo.bar"),
+							AggregationID: aggregation.DefaultID,
+						},
+					},
+				}),
+			},
+			expected: false,
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.a.Equal(input.b))
+		require.Equal(t, input.expected, input.b.Equal(input.a))
+	}
+}

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -67,7 +67,7 @@ type Aggregator interface {
 	AddUntimed(metric unaggregated.MetricUnion, metas metadata.StagedMetadatas) error
 
 	// AddForwarded adds a forwarded metric with metadata.
-	AddForwarded(metric aggregated.Metric, metadata metadata.ForwardMetadata) error
+	AddForwarded(metric aggregated.ForwardedMetric, metadata metadata.ForwardMetadata) error
 
 	// Resign stops the aggregator from participating in leader election and resigns
 	// from ongoing campaign if any.
@@ -184,7 +184,7 @@ func (agg *aggregator) AddUntimed(
 }
 
 func (agg *aggregator) AddForwarded(
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error {
 	callStart := agg.nowFn()

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -116,7 +116,7 @@ type aggregator struct {
 func NewAggregator(opts Options) Aggregator {
 	iOpts := opts.InstrumentOptions()
 	scope := iOpts.MetricsScope()
-	metrics := newAggregatorMetrics(scope, iOpts.MetricsSamplingRate())
+	samplingRate := iOpts.MetricsSamplingRate()
 	return &aggregator{
 		opts:              opts,
 		nowFn:             opts.ClockOptions().NowFn(),
@@ -130,7 +130,7 @@ func NewAggregator(opts Options) Aggregator {
 		flushHandler:      opts.FlushHandler(),
 		adminClient:       opts.AdminClient(),
 		resignTimeout:     opts.ResignTimeout(),
-		metrics:           metrics,
+		metrics:           newAggregatorMetrics(scope, samplingRate, opts.MaxAllowedForwardingDelayFn()),
 		doneCh:            make(chan struct{}),
 		sleepFn:           time.Sleep,
 	}
@@ -201,7 +201,11 @@ func (agg *aggregator) AddForwarded(
 	callEnd := agg.nowFn()
 	agg.metrics.addForwarded.ReportSuccess(callEnd.Sub(callStart))
 	forwardingDelay := time.Duration(callEnd.UnixNano() - metric.TimeNanos)
-	agg.metrics.addForwarded.ReportForwardingLatency(metadata.NumForwardedTimes, forwardingDelay)
+	agg.metrics.addForwarded.ReportForwardingLatency(
+		metadata.StoragePolicy.Resolution().Window,
+		metadata.NumForwardedTimes,
+		forwardingDelay,
+	)
 	return nil
 }
 
@@ -658,49 +662,66 @@ func (m *aggregatorAddUntimedMetrics) ReportError(err error) {
 	m.aggregatorAddMetricMetrics.ReportError(err)
 }
 
+type latencyBucketKey struct {
+	resolution        time.Duration
+	numForwardedTimes int
+}
+
 type aggregatorAddForwardedMetrics struct {
 	sync.RWMutex
 	aggregatorAddMetricMetrics
 
-	scope             tally.Scope
-	latencyBuckets    tally.DurationBuckets
-	forwardingLatency map[int]tally.Histogram
+	scope                       tally.Scope
+	maxAllowedForwardingDelayFn MaxAllowedForwardingDelayFn
+	forwardingLatency           map[latencyBucketKey]tally.Histogram
 }
 
 func newAggregatorAddForwardedMetrics(
 	scope tally.Scope,
 	samplingRate float64,
+	maxAllowedForwardingDelayFn MaxAllowedForwardingDelayFn,
 ) aggregatorAddForwardedMetrics {
-	numLatencyBuckets := int(maxLatencyBucketLimit / latencyBucketSize)
-	latencyBuckets := tally.MustMakeLinearDurationBuckets(0, latencyBucketSize, numLatencyBuckets)
 	return aggregatorAddForwardedMetrics{
 		aggregatorAddMetricMetrics: newAggregatorAddMetricMetrics(scope, samplingRate),
-		scope:             scope,
-		latencyBuckets:    latencyBuckets,
-		forwardingLatency: make(map[int]tally.Histogram),
+		scope: scope,
+		maxAllowedForwardingDelayFn: maxAllowedForwardingDelayFn,
+		forwardingLatency:           make(map[latencyBucketKey]tally.Histogram),
 	}
 }
 
 func (m *aggregatorAddForwardedMetrics) ReportForwardingLatency(
+	resolution time.Duration,
 	numForwardedTimes int,
 	duration time.Duration,
 ) {
+	key := latencyBucketKey{
+		resolution:        resolution,
+		numForwardedTimes: numForwardedTimes,
+	}
 	m.RLock()
-	histogram, exists := m.forwardingLatency[numForwardedTimes]
+	histogram, exists := m.forwardingLatency[key]
 	m.RUnlock()
 	if exists {
 		histogram.RecordDuration(duration)
 		return
 	}
 	m.Lock()
-	histogram, exists = m.forwardingLatency[numForwardedTimes]
-	if !exists {
-		histogram = m.scope.Tagged(map[string]string{
-			"bucket-version":      strconv.Itoa(latencyBucketVersion),
-			"num-forwarded-times": strconv.Itoa(numForwardedTimes),
-		}).Histogram("forwarding-latency", m.latencyBuckets)
-		m.forwardingLatency[numForwardedTimes] = histogram
+	histogram, exists = m.forwardingLatency[key]
+	if exists {
+		m.Unlock()
+		histogram.RecordDuration(duration)
+		return
 	}
+	maxForwardingDelayAllowed := m.maxAllowedForwardingDelayFn(resolution, numForwardedTimes)
+	maxLatencyBucketLimit := maxForwardingDelayAllowed * maxLatencyBucketLimitScaleFactor
+	latencyBucketSize := maxLatencyBucketLimit / time.Duration(numLatencyBuckets)
+	latencyBuckets := tally.MustMakeLinearDurationBuckets(0, latencyBucketSize, numLatencyBuckets)
+	histogram = m.scope.Tagged(map[string]string{
+		"bucket-version":      strconv.Itoa(latencyBucketVersion),
+		"resolution":          resolution.String(),
+		"num-forwarded-times": strconv.Itoa(numForwardedTimes),
+	}).Histogram("forwarding-latency", latencyBuckets)
+	m.forwardingLatency[key] = histogram
 	m.Unlock()
 	histogram.RecordDuration(duration)
 }
@@ -824,7 +845,11 @@ type aggregatorMetrics struct {
 	tick         aggregatorTickMetrics
 }
 
-func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMetrics {
+func newAggregatorMetrics(
+	scope tally.Scope,
+	samplingRate float64,
+	maxAllowedForwardingDelayFn MaxAllowedForwardingDelayFn,
+) aggregatorMetrics {
 	addUntimedScope := scope.SubScope("addUntimed")
 	addForwardedScope := scope.SubScope("addForwarded")
 	placementScope := scope.SubScope("placement")
@@ -838,7 +863,7 @@ func newAggregatorMetrics(scope tally.Scope, samplingRate float64) aggregatorMet
 		gauges:       scope.Counter("gauges"),
 		forwarded:    scope.Counter("forwarded"),
 		addUntimed:   newAggregatorAddUntimedMetrics(addUntimedScope, samplingRate),
-		addForwarded: newAggregatorAddForwardedMetrics(addForwardedScope, samplingRate),
+		addForwarded: newAggregatorAddForwardedMetrics(addForwardedScope, samplingRate, maxAllowedForwardingDelayFn),
 		placement:    newAggregatorPlacementMetrics(placementScope),
 		shards:       newAggregatorShardsMetrics(shardsScope),
 		shardSetID:   newAggregatorShardSetIDMetrics(shardSetIDScope),
@@ -869,7 +894,7 @@ const (
 type sleepFn func(d time.Duration)
 
 const (
-	latencyBucketVersion  = 1
-	latencyBucketSize     = 500 * time.Millisecond
-	maxLatencyBucketLimit = 20 * time.Second
+	latencyBucketVersion             = 2
+	numLatencyBuckets                = 40
+	maxLatencyBucketLimitScaleFactor = 2
 )

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -65,11 +65,11 @@ var (
 		ID:         []byte("foo"),
 		CounterVal: 1234,
 	}
-	testForwardedMetric = aggregated.Metric{
+	testForwardedMetric = aggregated.ForwardedMetric{
 		Type:      metric.CounterType,
 		ID:        []byte("testForwarded"),
 		TimeNanos: 12345,
-		Value:     76109,
+		Values:    []float64{76109, 23891},
 	}
 	testInvalidMetric = unaggregated.MetricUnion{
 		Type: metric.UnknownType,
@@ -113,7 +113,7 @@ var (
 				},
 			},
 		}),
-		SourceID:          []byte("testForwardSource"),
+		SourceID:          1234,
 		NumForwardedTimes: 3,
 	}
 )

--- a/aggregator/capture/aggregator_test.go
+++ b/aggregator/capture/aggregator_test.go
@@ -55,11 +55,11 @@ var (
 		ID:       id.RawID("testCounter"),
 		GaugeVal: 123.456,
 	}
-	testForwarded = aggregated.Metric{
+	testForwarded = aggregated.ForwardedMetric{
 		Type:      metric.CounterType,
 		ID:        []byte("testForwarded"),
 		TimeNanos: 12345,
-		Value:     908,
+		Values:    []float64{908, -13.5},
 	}
 	testInvalid = unaggregated.MetricUnion{
 		Type: metric.UnknownType,
@@ -78,7 +78,7 @@ var (
 				},
 			},
 		}),
-		SourceID:          []byte("testForwardSource"),
+		SourceID:          1234,
 		NumForwardedTimes: 3,
 	}
 )
@@ -122,10 +122,10 @@ func TestAggregator(t *testing.T) {
 	}
 
 	// Add valid forwarded metrics with metadata.
-	expected.MetricsWithForwardMetadata = append(
-		expected.MetricsWithForwardMetadata,
-		aggregated.MetricWithForwardMetadata{
-			Metric:          testForwarded,
+	expected.ForwardedMetricsWithMetadata = append(
+		expected.ForwardedMetricsWithMetadata,
+		aggregated.ForwardedMetricWithMetadata{
+			ForwardedMetric: testForwarded,
 			ForwardMetadata: testForwardMetadata,
 		},
 	)

--- a/aggregator/capture/types.go
+++ b/aggregator/capture/types.go
@@ -40,8 +40,8 @@ type Aggregator interface {
 
 // SnapshotResult is the snapshot result.
 type SnapshotResult struct {
-	CountersWithMetadatas      []unaggregated.CounterWithMetadatas
-	BatchTimersWithMetadatas   []unaggregated.BatchTimerWithMetadatas
-	GaugesWithMetadatas        []unaggregated.GaugeWithMetadatas
-	MetricsWithForwardMetadata []aggregated.MetricWithForwardMetadata
+	CountersWithMetadatas        []unaggregated.CounterWithMetadatas
+	BatchTimersWithMetadatas     []unaggregated.BatchTimerWithMetadatas
+	GaugesWithMetadatas          []unaggregated.GaugeWithMetadatas
+	ForwardedMetricsWithMetadata []aggregated.ForwardedMetricWithMetadata
 }

--- a/aggregator/counter_elem.gen.go
+++ b/aggregator/counter_elem.gen.go
@@ -254,7 +254,7 @@ func (e *CounterElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -270,8 +270,8 @@ func (e *CounterElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
-	e.writeForwardedFn = nil
-	e.onForwardedWrittenFn = nil
+	e.writeForwardedMetricFn = nil
+	e.onForwardedAggregationWrittenFn = nil
 	for idx := range e.cachedSourceSets {
 		e.cachedSourceSets[idx] = nil
 	}
@@ -422,7 +422,7 @@ func (e *CounterElem) processValueWithAggregationLock(
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
+			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/counter_elem.gen.go
+++ b/aggregator/counter_elem.gen.go
@@ -31,13 +31,7 @@ import (
 
 	"time"
 
-	"github.com/m3db/m3aggregator/hash"
-
 	maggregation "github.com/m3db/m3metrics/aggregation"
-
-	"github.com/m3db/m3metrics/metadata"
-
-	"github.com/m3db/m3metrics/metric/aggregated"
 
 	"github.com/m3db/m3metrics/metric/id"
 
@@ -48,13 +42,15 @@ import (
 	"github.com/m3db/m3metrics/policy"
 
 	"github.com/m3db/m3metrics/transformation"
+
+	"github.com/willf/bitset"
 )
 
 type lockedCounterAggregation struct {
 	sync.Mutex
 
 	closed      bool
-	sourcesSeen sourceSet
+	sourcesSeen *bitset.BitSet
 	aggregation counterAggregation
 }
 
@@ -168,7 +164,7 @@ func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion)
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
-func (e *CounterElem) AddUnique(timestamp time.Time, value float64, sourceID []byte) error {
+func (e *CounterElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
 	if err != nil {
@@ -179,13 +175,15 @@ func (e *CounterElem) AddUnique(timestamp time.Time, value float64, sourceID []b
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	sourceHash := hash.Murmur3Hash128(sourceID)
-	if v, exists := lockedAgg.sourcesSeen[sourceHash]; exists && v == alignedStart {
+	source := uint(sourceID)
+	if lockedAgg.sourcesSeen.Test(source) {
 		lockedAgg.Unlock()
 		return errDuplicateForwardingSource
 	}
-	lockedAgg.sourcesSeen[sourceHash] = alignedStart
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.sourcesSeen.Set(source)
+	for _, v := range values {
+		lockedAgg.aggregation.Add(v)
+	}
 	lockedAgg.Unlock()
 	return nil
 }
@@ -201,6 +199,7 @@ func (e *CounterElem) Consume(
 	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
+	onForwardedFlushedFn onForwardingElemFlushedFn,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	e.Lock()
@@ -240,25 +239,22 @@ func (e *CounterElem) Consume(
 		e.toConsume[i].lockedAgg.closed = true
 		e.toConsume[i].lockedAgg.aggregation.Close()
 		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			sourceSetSize := len(e.toConsume[i].lockedAgg.sourcesSeen)
-			// If the source set we are about to cache is too big (i.e., bigger than the
-			// configured max size), we do not want to retain it and instead simply discard it.
-			// This is useful if say over the course of a month the metric IDs producing
-			// the forward metric ID have changed significantly so there are a lot of stale
-			// IDs in the map so we regenerate the map once in a while to refresh the map.
-			if sourceSetSize <= e.opts.MaxCachedSourceSetSize() {
-				e.cachedSourceSetsLock.Lock()
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-				}
-				e.cachedSourceSetsLock.Unlock()
+			e.cachedSourceSetsLock.Lock()
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
 			}
+			e.cachedSourceSetsLock.Unlock()
 			e.toConsume[i].lockedAgg.sourcesSeen = nil
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
+	}
+
+	if e.parsedPipeline.HasRollup {
+		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -274,8 +270,15 @@ func (e *CounterElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
+	e.writeForwardedFn = nil
+	e.onForwardedWrittenFn = nil
+	for idx := range e.cachedSourceSets {
+		e.cachedSourceSets[idx] = nil
+	}
+	e.cachedSourceSets = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
+		e.values[idx].lockedAgg.sourcesSeen = nil
 		e.values[idx].lockedAgg.aggregation.Close()
 		e.values[idx].Reset()
 	}
@@ -329,15 +332,16 @@ func (e *CounterElem) findOrCreate(
 	e.values = append(e.values, timedCounter{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen sourceSet
+	var sourcesSeen *bitset.BitSet
 	if createOpts.initSourceSet {
 		e.cachedSourceSetsLock.Lock()
 		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
 			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
 			e.cachedSourceSets[numCachedSourceSets-1] = nil
 			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
+			sourcesSeen.ClearAll()
 		} else {
-			sourcesSeen = make(sourceSet, defaultNumSources)
+			sourcesSeen = bitset.New(defaultNumSources)
 		}
 		e.cachedSourceSetsLock.Unlock()
 	}
@@ -417,20 +421,8 @@ func (e *CounterElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
-			fm := aggregated.Metric{
-				Type:      e.Type(),
-				ID:        e.parsedPipeline.Rollup.ID,
-				TimeNanos: timeNanos,
-				Value:     value,
-			}
-			meta := metadata.ForwardMetadata{
-				AggregationID:     e.parsedPipeline.Rollup.AggregationID,
-				StoragePolicy:     e.sp,
-				Pipeline:          e.parsedPipeline.Remainder,
-				SourceID:          []byte(e.id),
-				NumForwardedTimes: e.numForwardedTimes + 1,
-			}
-			flushForwardedFn(fm, meta)
+			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/elem_base.go
+++ b/aggregator/elem_base.go
@@ -101,8 +101,7 @@ type metricElem interface {
 	// metrics for elements producing such forwarded metrics.
 	SetForwardedCallbacks(
 		writeFn writeForwardedMetricFn,
-		onDoneFn onAggregationKeyDoneFn,
-	)
+		onDoneFn onForwardedAggregationDoneFn)
 
 	// AddUnion adds a metric value union at a given timestamp.
 	AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) error
@@ -136,17 +135,17 @@ type elemBase struct {
 	sync.RWMutex
 
 	// Immutable states.
-	opts                  Options
-	aggTypesOpts          maggregation.TypesOptions
-	id                    id.RawID
-	sp                    policy.StoragePolicy
-	useDefaultAggregation bool
-	aggTypes              maggregation.Types
-	aggOpts               raggregation.Options
-	parsedPipeline        parsedPipeline
-	numForwardedTimes     int
-	writeForwardedFn      writeForwardedMetricFn
-	onForwardedWrittenFn  onAggregationKeyDoneFn
+	opts                            Options
+	aggTypesOpts                    maggregation.TypesOptions
+	id                              id.RawID
+	sp                              policy.StoragePolicy
+	useDefaultAggregation           bool
+	aggTypes                        maggregation.Types
+	aggOpts                         raggregation.Options
+	parsedPipeline                  parsedPipeline
+	numForwardedTimes               int
+	writeForwardedMetricFn          writeForwardedMetricFn
+	onForwardedAggregationWrittenFn onForwardedAggregationDoneFn
 
 	// Mutable states.
 	tombstoned           bool
@@ -190,10 +189,10 @@ func (e *elemBase) resetSetData(
 
 func (e *elemBase) SetForwardedCallbacks(
 	writeFn writeForwardedMetricFn,
-	onDoneFn onAggregationKeyDoneFn,
+	onDoneFn onForwardedAggregationDoneFn,
 ) {
-	e.writeForwardedFn = writeFn
-	e.onForwardedWrittenFn = onDoneFn
+	e.writeForwardedMetricFn = writeFn
+	e.onForwardedAggregationWrittenFn = onDoneFn
 }
 
 func (e *elemBase) ID() id.RawID { return e.id }

--- a/aggregator/elem_base.go
+++ b/aggregator/elem_base.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	raggregation "github.com/m3db/m3aggregator/aggregation"
-	"github.com/m3db/m3aggregator/hash"
 	maggregation "github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/id"
@@ -37,6 +36,8 @@ import (
 	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
+
+	"github.com/willf/bitset"
 )
 
 const (
@@ -68,9 +69,6 @@ type isEarlierThanFn func(windowStartNanos int64, resolution time.Duration, targ
 // window with a given resolution.
 type timestampNanosFn func(windowStartNanos int64, resolution time.Duration) int64
 
-// sourceSet is a set of sources.
-type sourceSet map[hash.Hash128]int64
-
 type createAggregationOptions struct {
 	// initSourceSet determines whether to initialize the source set.
 	initSourceSet bool
@@ -78,8 +76,17 @@ type createAggregationOptions struct {
 
 // metricElem is the common interface for metric elements.
 type metricElem interface {
+	// Type returns the metric type.
+	Type() metric.Type
+
 	// ID returns the metric id.
 	ID() id.RawID
+
+	// ForwardedID returns the id of the forwarded metric if applicable.
+	ForwardedID() (id.RawID, bool)
+
+	// ForwardedAggregationKey returns the forwarded aggregation key if applicable.
+	ForwardedAggregationKey() (aggregationKey, bool)
 
 	// ResetSetData resets the element and sets data.
 	ResetSetData(
@@ -90,13 +97,20 @@ type metricElem interface {
 		numForwardedTimes int,
 	) error
 
+	// SetForwardedCallbacks sets the callback functions to write forwarded
+	// metrics for elements producing such forwarded metrics.
+	SetForwardedCallbacks(
+		writeFn writeForwardedMetricFn,
+		onDoneFn onAggregationKeyDoneFn,
+	)
+
 	// AddUnion adds a metric value union at a given timestamp.
 	AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) error
 
 	// AddUnique adds a metric value from a given source at a given timestamp.
 	// If previous values from the same source have already been added to the
 	// same aggregation, the incoming value is discarded.
-	AddUnique(timestamp time.Time, value float64, sourceID []byte) error
+	AddUnique(timestamp time.Time, values []float64, sourceID uint32) error
 
 	// Consume consumes values before a given time and removes
 	// them from the element after they are consumed, returning whether
@@ -107,6 +121,7 @@ type metricElem interface {
 		timestampNanosFn timestampNanosFn,
 		flushLocalFn flushLocalMetricFn,
 		flushForwardedFn flushForwardedMetricFn,
+		onForwardedFlushedFn onForwardingElemFlushedFn,
 	) bool
 
 	// MarkAsTombstoned marks an element as tombstoned, which means this element
@@ -130,12 +145,14 @@ type elemBase struct {
 	aggOpts               raggregation.Options
 	parsedPipeline        parsedPipeline
 	numForwardedTimes     int
+	writeForwardedFn      writeForwardedMetricFn
+	onForwardedWrittenFn  onAggregationKeyDoneFn
 
 	// Mutable states.
 	tombstoned           bool
 	closed               bool
-	cachedSourceSetsLock sync.Mutex  // nolint: structcheck
-	cachedSourceSets     []sourceSet // nolint: structcheck
+	cachedSourceSetsLock sync.Mutex       // nolint: structcheck
+	cachedSourceSets     []*bitset.BitSet // nolint: structcheck
 }
 
 func newElemBase(opts Options) elemBase {
@@ -171,12 +188,33 @@ func (e *elemBase) resetSetData(
 	return nil
 }
 
-// ID returns the metric id.
-func (e *elemBase) ID() id.RawID {
-	e.RLock()
-	id := e.id
-	e.RUnlock()
-	return id
+func (e *elemBase) SetForwardedCallbacks(
+	writeFn writeForwardedMetricFn,
+	onDoneFn onAggregationKeyDoneFn,
+) {
+	e.writeForwardedFn = writeFn
+	e.onForwardedWrittenFn = onDoneFn
+}
+
+func (e *elemBase) ID() id.RawID { return e.id }
+
+func (e *elemBase) ForwardedID() (id.RawID, bool) {
+	if !e.parsedPipeline.HasRollup {
+		return nil, false
+	}
+	return e.parsedPipeline.Rollup.ID, true
+}
+
+func (e *elemBase) ForwardedAggregationKey() (aggregationKey, bool) {
+	if !e.parsedPipeline.HasRollup {
+		return aggregationKey{}, false
+	}
+	return aggregationKey{
+		aggregationID:     e.parsedPipeline.Rollup.AggregationID,
+		storagePolicy:     e.sp,
+		pipeline:          e.parsedPipeline.Remainder,
+		numForwardedTimes: e.numForwardedTimes + 1,
+	}, true
 }
 
 // MarkAsTombstoned marks an element as tombstoned, which means this element

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -597,8 +597,8 @@ func TestCounterElemClose(t *testing.T) {
 	require.True(t, e.closed)
 	require.Nil(t, e.id)
 	require.Equal(t, parsedPipeline{}, e.parsedPipeline)
-	require.Nil(t, e.writeForwardedFn)
-	require.Nil(t, e.onForwardedWrittenFn)
+	require.Nil(t, e.writeForwardedMetricFn)
+	require.Nil(t, e.onForwardedAggregationWrittenFn)
 	require.Nil(t, e.cachedSourceSets)
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, 0, len(e.toConsume))
@@ -1102,8 +1102,8 @@ func TestTimerElemClose(t *testing.T) {
 	require.True(t, e.closed)
 	require.Nil(t, e.id)
 	require.Equal(t, parsedPipeline{}, e.parsedPipeline)
-	require.Nil(t, e.writeForwardedFn)
-	require.Nil(t, e.onForwardedWrittenFn)
+	require.Nil(t, e.writeForwardedMetricFn)
+	require.Nil(t, e.onForwardedAggregationWrittenFn)
 	require.Nil(t, e.cachedSourceSets)
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, 0, len(e.toConsume))
@@ -1638,8 +1638,8 @@ func TestGaugeElemClose(t *testing.T) {
 	require.True(t, e.closed)
 	require.Nil(t, e.id)
 	require.Equal(t, parsedPipeline{}, e.parsedPipeline)
-	require.Nil(t, e.writeForwardedFn)
-	require.Nil(t, e.onForwardedWrittenFn)
+	require.Nil(t, e.writeForwardedMetricFn)
+	require.Nil(t, e.onForwardedAggregationWrittenFn)
 	require.Nil(t, e.cachedSourceSets)
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, 0, len(e.toConsume))
@@ -1773,7 +1773,7 @@ func testOnForwardedFlushedFn() (
 ) {
 	var result []testOnForwardedFlushedData
 	return func(
-		onDoneFn onAggregationKeyDoneFn,
+		onDoneFn onForwardedAggregationDoneFn,
 		aggregationKey aggregationKey,
 	) {
 		result = append(result, testOnForwardedFlushedData{

--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -27,11 +27,8 @@ import (
 
 	raggregation "github.com/m3db/m3aggregator/aggregation"
 	"github.com/m3db/m3aggregator/aggregation/quantile/cm"
-	"github.com/m3db/m3aggregator/hash"
 	maggregation "github.com/m3db/m3metrics/aggregation"
-	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric"
-	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/pipeline"
@@ -42,6 +39,7 @@ import (
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/willf/bitset"
 )
 
 var (
@@ -260,30 +258,28 @@ func TestCounterElemAddUnique(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a metric.
-	source1 := []byte("source1")
-	require.NoError(t, e.AddUnique(testTimestamps[0], 345, source1))
+	source1 := uint32(1234)
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{345}, source1))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	require.Equal(t, int64(345), e.values[0].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[0].lockedAgg.aggregation.Count())
 	require.Equal(t, int64(0), e.values[0].lockedAgg.aggregation.SumSq())
-	_, exists := e.values[0].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[0].lockedAgg.sourcesSeen.Test(uint(source1)))
 
 	// Add another metric at slightly different time but still within the
 	// same aggregation interval with a different source.
-	source2 := []byte("source2")
-	require.NoError(t, e.AddUnique(testTimestamps[1], 500, source2))
+	source2 := uint32(5678)
+	require.NoError(t, e.AddUnique(testTimestamps[1], []float64{500}, source2))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	require.Equal(t, int64(845), e.values[0].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(2), e.values[0].lockedAgg.aggregation.Count())
 	require.Equal(t, int64(0), e.values[0].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[0].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source2)]
-	require.True(t, exists)
+	require.True(t, e.values[0].lockedAgg.sourcesSeen.Test(uint(source2)))
 
 	// Add the counter metric in the next aggregation interval.
-	require.NoError(t, e.AddUnique(testTimestamps[2], 278, source1))
+	require.NoError(t, e.AddUnique(testTimestamps[2], []float64{278}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -291,12 +287,11 @@ func TestCounterElemAddUnique(t *testing.T) {
 	require.Equal(t, int64(278), e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[1].lockedAgg.aggregation.Count())
 	require.Equal(t, int64(0), e.values[1].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(uint(source1)))
 
 	// Add the counter metric in the same aggregation interval with the same
 	// source results in an error.
-	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], 278, source1))
+	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], []float64{278}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -304,12 +299,11 @@ func TestCounterElemAddUnique(t *testing.T) {
 	require.Equal(t, int64(278), e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[1].lockedAgg.aggregation.Count())
 	require.Equal(t, int64(0), e.values[1].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(uint(source1)))
 
 	// Adding the counter metric to a closed element results in an error.
 	e.closed = true
-	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], 100, []byte("source3")))
+	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], []float64{100}, 1376))
 }
 
 func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
@@ -317,27 +311,26 @@ func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a counter metric.
-	source1 := []byte("source1")
-	require.NoError(t, e.AddUnique(testTimestamps[0], 12, source1))
+	source1 := uint32(1234)
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{12}, source1))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	require.Equal(t, int64(12), e.values[0].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(12), e.values[0].lockedAgg.aggregation.Max())
 	require.Equal(t, int64(144), e.values[0].lockedAgg.aggregation.SumSq())
-	_, exists := e.values[0].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[0].lockedAgg.sourcesSeen.Test(uint(source1)))
 
 	// Add the counter metric at slightly different time
 	// but still within the same aggregation interval.
-	source2 := []byte("source2")
-	require.NoError(t, e.AddUnique(testTimestamps[1], 14, source2))
+	source2 := uint32(5678)
+	require.NoError(t, e.AddUnique(testTimestamps[1], []float64{14}, source2))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	require.Equal(t, int64(26), e.values[0].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(14), e.values[0].lockedAgg.aggregation.Max())
 
 	// Add the counter metric in the next aggregation interval.
-	require.NoError(t, e.AddUnique(testTimestamps[2], 20, source1))
+	require.NoError(t, e.AddUnique(testTimestamps[2], []float64{20}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -348,7 +341,7 @@ func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 
 	// Add the counter metric in the same aggregation interval with the same
 	// source results in an error.
-	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], 30, source1))
+	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], []float64{30}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -356,12 +349,11 @@ func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.Equal(t, int64(20), e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[1].lockedAgg.aggregation.Count())
 	require.Equal(t, int64(400), e.values[1].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(uint(source1)))
 
 	// Adding the counter metric to a closed element results in an error.
 	e.closed = true
-	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], 40, []byte("source3")))
+	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], []float64{40}, 1376))
 }
 
 func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
@@ -373,43 +365,53 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 2, len(e.values))
 
 	// Consume one value.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 1, len(e.values))
 
 	// Consume all values.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values.
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Reading and discarding values from a closed element is no op.
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -422,43 +424,53 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 2, len(e.values))
 
 	// Consume one value.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 1, len(e.values))
 
 	// Consume all values.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values.
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Reading and discarding values from a closed element is no op.
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -476,99 +488,74 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	opts := NewOptions()
 	e := testCounterElem(alignedstartAtNanos[:3], counterVals, aggregationTypes, testPipeline, opts)
 
+	aggKey := aggregationKey{
+		aggregationID: maggregation.MustCompressTypes(maggregation.Count),
+		storagePolicy: testStoragePolicy,
+		pipeline: applied.NewPipeline([]applied.OpUnion{
+			{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
+					ID:            []byte("foo.baz"),
+					AggregationID: maggregation.MustCompressTypes(maggregation.Max),
+				},
+			},
+		}),
+		numForwardedTimes: testNumForwardedTimes + 1,
+	}
+	expectedOnFlushedRes := []testOnForwardedFlushedData{
+		{
+			aggregationKey: aggKey,
+		},
+	}
+
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 3, len(e.values))
 
 	// Consume one value.
-	expectedRes := []aggregated.MetricWithForwardMetadata{
+	expectedForwardedRes := []testForwardedMetricWithMetadata{
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(220, 0).UnixNano(),
-				Value:     nan,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testCounterID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(220, 0).UnixNano(),
+			value:          nan,
 		},
 	}
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
-	verifyForwardedMetrics(t, expectedRes, *forwardRes)
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 2, len(e.values))
 	require.Equal(t, time.Unix(220, 0).UnixNano(), e.lastConsumedAtNanos)
 	require.Equal(t, []float64{123.0}, e.lastConsumedValues)
 
 	// Consume all values.
-	expectedRes = []aggregated.MetricWithForwardMetadata{
+	expectedForwardedRes = []testForwardedMetricWithMetadata{
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(230, 0).UnixNano(),
-				Value:     33.3,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testCounterID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(230, 0).UnixNano(),
+			value:          33.3,
 		},
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(240, 0).UnixNano(),
-				Value:     13.3,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testCounterID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(240, 0).UnixNano(),
+			value:          13.3,
 		},
 	}
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
-	verifyForwardedMetrics(t, expectedRes, *forwardRes)
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, time.Unix(240, 0).UnixNano(), e.lastConsumedAtNanos)
@@ -578,7 +565,9 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(e.values))
@@ -587,9 +576,11 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -606,6 +597,9 @@ func TestCounterElemClose(t *testing.T) {
 	require.True(t, e.closed)
 	require.Nil(t, e.id)
 	require.Equal(t, parsedPipeline{}, e.parsedPipeline)
+	require.Nil(t, e.writeForwardedFn)
+	require.Nil(t, e.onForwardedWrittenFn)
+	require.Nil(t, e.cachedSourceSets)
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, 0, len(e.toConsume))
 	require.Equal(t, 0, len(e.lastConsumedValues))
@@ -640,7 +634,7 @@ func TestCounterFindOrCreateNoSourceSet(t *testing.T) {
 func TestCounterFindOrCreateWithSourceSet(t *testing.T) {
 	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NewOptions())
 	require.NoError(t, err)
-	e.cachedSourceSets = []sourceSet{sourceSet{}}
+	e.cachedSourceSets = []*bitset.BitSet{bitset.New(0)}
 
 	inputs := []int64{10, 20}
 	expected := []testIndexData{
@@ -714,7 +708,7 @@ func TestTimerResetSetData(t *testing.T) {
 			},
 		}),
 	}
-	err = te.ResetSetData(testCounterID, testStoragePolicy, testAggregationTypesExpensive, testPipeline, 0)
+	err = te.ResetSetData(testBatchTimerID, testStoragePolicy, testAggregationTypesExpensive, testPipeline, 0)
 	require.NoError(t, err)
 	require.Equal(t, expectedParsedPipeline, te.parsedPipeline)
 	require.Equal(t, len(testAggregationTypesExpensive), len(te.lastConsumedValues))
@@ -794,9 +788,9 @@ func TestTimerElemAddUnique(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a metric.
-	require.NoError(t, e.AddUnique(testTimestamps[0], 11.1, []byte("source1")))
-	require.NoError(t, e.AddUnique(testTimestamps[0], 12.2, []byte("source2")))
-	require.NoError(t, e.AddUnique(testTimestamps[0], 13.3, []byte("source3")))
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{11.1}, 1))
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{12.2}, 2))
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{13.3}, 3))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	timer := e.values[0].lockedAgg.aggregation
@@ -806,7 +800,7 @@ func TestTimerElemAddUnique(t *testing.T) {
 
 	// Add another metric at slightly different time but still within the
 	// same aggregation interval with a different source.
-	require.NoError(t, e.AddUnique(testTimestamps[1], 14.4, []byte("source4")))
+	require.NoError(t, e.AddUnique(testTimestamps[1], []float64{14.4}, 4))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	timer = e.values[0].lockedAgg.aggregation
@@ -814,7 +808,7 @@ func TestTimerElemAddUnique(t *testing.T) {
 	require.InEpsilon(t, 51, timer.Sum(), 1e-10)
 
 	// Add the metric in the next aggregation interval.
-	require.NoError(t, e.AddUnique(testTimestamps[2], 20.0, []byte("source1")))
+	require.NoError(t, e.AddUnique(testTimestamps[2], []float64{20.0}, 1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -825,7 +819,7 @@ func TestTimerElemAddUnique(t *testing.T) {
 
 	// Add the metric in the same aggregation interval with the same
 	// source results in an error.
-	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], 30.0, []byte("source1")))
+	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], []float64{30.0}, 1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -833,12 +827,11 @@ func TestTimerElemAddUnique(t *testing.T) {
 	require.Equal(t, 20.0, e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[1].lockedAgg.aggregation.Count())
 	require.InEpsilon(t, 400.0, e.values[1].lockedAgg.aggregation.SumSq(), 1e-10)
-	_, exists := e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128([]byte("source1"))]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(1))
 
-	// Adding the counter metric to a closed element results in an error.
+	// Adding the timer metric to a closed element results in an error.
 	e.closed = true
-	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], 100, []byte("source3")))
+	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], []float64{100}, 3))
 }
 
 func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
@@ -855,43 +848,53 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 2, len(e.values))
 
 	// Consume one value.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 1, len(e.values))
 
 	// Consume all values.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values.
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Reading and discarding values from a closed element is no op.
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Verify the streams have been returned to pool.
@@ -912,43 +915,53 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 2, len(e.values))
 
 	// Consume one value.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[1], testStoragePolicy, testTimerAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 1, len(e.values))
 
 	// Consume all values.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[2], testStoragePolicy, testTimerAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values.
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Reading and discarding values from a closed element is no op.
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Verify the streams have been returned to pool.
@@ -973,99 +986,74 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	opts := NewOptions()
 	e := testTimerElem(alignedstartAtNanos[:3], timerVals, aggregationTypes, testPipeline, opts)
 
+	aggKey := aggregationKey{
+		aggregationID: maggregation.MustCompressTypes(maggregation.Count),
+		storagePolicy: testStoragePolicy,
+		pipeline: applied.NewPipeline([]applied.OpUnion{
+			{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
+					ID:            []byte("foo.baz"),
+					AggregationID: maggregation.MustCompressTypes(maggregation.Max),
+				},
+			},
+		}),
+		numForwardedTimes: testNumForwardedTimes + 1,
+	}
+	expectedOnFlushedRes := []testOnForwardedFlushedData{
+		{
+			aggregationKey: aggKey,
+		},
+	}
+
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 3, len(e.values))
 
 	// Consume one value.
-	expectedRes := []aggregated.MetricWithForwardMetadata{
+	expectedForwardedRes := []testForwardedMetricWithMetadata{
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(220, 0).UnixNano(),
-				Value:     nan,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testBatchTimerID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(220, 0).UnixNano(),
+			value:          nan,
 		},
 	}
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
-	verifyForwardedMetrics(t, expectedRes, *forwardRes)
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 2, len(e.values))
 	require.Equal(t, time.Unix(220, 0).UnixNano(), e.lastConsumedAtNanos)
 	require.Equal(t, []float64{123.0}, e.lastConsumedValues)
 
 	// Consume all values.
-	expectedRes = []aggregated.MetricWithForwardMetadata{
+	expectedForwardedRes = []testForwardedMetricWithMetadata{
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(230, 0).UnixNano(),
-				Value:     33.3,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testBatchTimerID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(230, 0).UnixNano(),
+			value:          33.3,
 		},
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(240, 0).UnixNano(),
-				Value:     13.3,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testBatchTimerID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(240, 0).UnixNano(),
+			value:          13.3,
 		},
 	}
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
-	verifyForwardedMetrics(t, expectedRes, *forwardRes)
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, time.Unix(240, 0).UnixNano(), e.lastConsumedAtNanos)
@@ -1075,7 +1063,9 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(e.values))
@@ -1084,9 +1074,11 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -1110,6 +1102,9 @@ func TestTimerElemClose(t *testing.T) {
 	require.True(t, e.closed)
 	require.Nil(t, e.id)
 	require.Equal(t, parsedPipeline{}, e.parsedPipeline)
+	require.Nil(t, e.writeForwardedFn)
+	require.Nil(t, e.onForwardedWrittenFn)
+	require.Nil(t, e.cachedSourceSets)
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, 0, len(e.toConsume))
 	require.Equal(t, 0, len(e.lastConsumedValues))
@@ -1146,7 +1141,7 @@ func TestTimerFindOrCreateNoSourceSet(t *testing.T) {
 func TestTimerFindOrCreateWithSourceSet(t *testing.T) {
 	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NewOptions())
 	require.NoError(t, err)
-	e.cachedSourceSets = []sourceSet{sourceSet{}}
+	e.cachedSourceSets = []*bitset.BitSet{bitset.New(0)}
 
 	inputs := []int64{10, 20}
 	expected := []testIndexData{
@@ -1304,30 +1299,28 @@ func TestGaugeElemAddUnique(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a metric.
-	source1 := []byte("source1")
-	require.NoError(t, e.AddUnique(testTimestamps[0], 34.5, source1))
+	source1 := uint32(1234)
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{12.3, 34.5}, source1))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
-	require.Equal(t, 34.5, e.values[0].lockedAgg.aggregation.Sum())
-	require.Equal(t, int64(1), e.values[0].lockedAgg.aggregation.Count())
+	require.Equal(t, 46.8, e.values[0].lockedAgg.aggregation.Sum())
+	require.Equal(t, int64(2), e.values[0].lockedAgg.aggregation.Count())
 	require.Equal(t, 0.0, e.values[0].lockedAgg.aggregation.SumSq())
-	_, exists := e.values[0].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[0].lockedAgg.sourcesSeen.Test(uint(source1)))
 
 	// Add another metric at slightly different time but still within the
 	// same aggregation interval with a different source.
-	source2 := []byte("source2")
-	require.NoError(t, e.AddUnique(testTimestamps[1], 50, source2))
+	source2 := uint32(5678)
+	require.NoError(t, e.AddUnique(testTimestamps[1], []float64{50}, source2))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
-	require.Equal(t, 84.5, e.values[0].lockedAgg.aggregation.Sum())
-	require.Equal(t, int64(2), e.values[0].lockedAgg.aggregation.Count())
+	require.Equal(t, 96.8, e.values[0].lockedAgg.aggregation.Sum())
+	require.Equal(t, int64(3), e.values[0].lockedAgg.aggregation.Count())
 	require.Equal(t, 0.0, e.values[0].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[0].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source2)]
-	require.True(t, exists)
+	require.True(t, e.values[0].lockedAgg.sourcesSeen.Test(uint(source2)))
 
-	// Add the counter metric in the next aggregation interval.
-	require.NoError(t, e.AddUnique(testTimestamps[2], 27.8, source1))
+	// Add the metric in the next aggregation interval.
+	require.NoError(t, e.AddUnique(testTimestamps[2], []float64{27.8}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -1335,12 +1328,11 @@ func TestGaugeElemAddUnique(t *testing.T) {
 	require.Equal(t, 27.8, e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[1].lockedAgg.aggregation.Count())
 	require.Equal(t, 0.0, e.values[1].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(uint(source1)))
 
-	// Add the counter metric in the same aggregation interval with the same
+	// Add the gauge metric in the same aggregation interval with the same
 	// source results in an error.
-	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], 27.8, source1))
+	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], []float64{27.8}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -1348,12 +1340,11 @@ func TestGaugeElemAddUnique(t *testing.T) {
 	require.Equal(t, 27.8, e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, int64(1), e.values[1].lockedAgg.aggregation.Count())
 	require.Equal(t, 0.0, e.values[1].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(uint(source1)))
 
-	// Adding the counter metric to a closed element results in an error.
+	// Adding the gauge metric to a closed element results in an error.
 	e.closed = true
-	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], 10.0, []byte("source3")))
+	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], []float64{10.0}, 3))
 }
 
 func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
@@ -1361,27 +1352,26 @@ func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a gauge metric.
-	source1 := []byte("source1")
-	require.NoError(t, e.AddUnique(testTimestamps[0], 1.2, source1))
+	source1 := uint32(1234)
+	require.NoError(t, e.AddUnique(testTimestamps[0], []float64{1.2}, source1))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	require.Equal(t, 1.2, e.values[0].lockedAgg.aggregation.Sum())
 	require.Equal(t, 1.2, e.values[0].lockedAgg.aggregation.Max())
 	require.Equal(t, 1.44, e.values[0].lockedAgg.aggregation.SumSq())
-	_, exists := e.values[0].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[0].lockedAgg.sourcesSeen.Test(uint(source1)))
 
-	// Add the counter metric at slightly different time
+	// Add the gauge metric at slightly different time
 	// but still within the same aggregation interval.
-	source2 := []byte("source2")
-	require.NoError(t, e.AddUnique(testTimestamps[1], 1.4, source2))
+	source2 := uint32(5678)
+	require.NoError(t, e.AddUnique(testTimestamps[1], []float64{1.4}, source2))
 	require.Equal(t, 1, len(e.values))
 	require.Equal(t, testAlignedStarts[0], e.values[0].startAtNanos)
 	require.InEpsilon(t, 2.6, e.values[0].lockedAgg.aggregation.Sum(), 1e-10)
 	require.Equal(t, 1.4, e.values[0].lockedAgg.aggregation.Max())
 
-	// Add the counter metric in the next aggregation interval.
-	require.NoError(t, e.AddUnique(testTimestamps[2], 2.0, source1))
+	// Add the gauge metric in the next aggregation interval.
+	require.NoError(t, e.AddUnique(testTimestamps[2], []float64{2.0}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -1390,9 +1380,9 @@ func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.Equal(t, 2.0, e.values[1].lockedAgg.aggregation.Max())
 	require.Equal(t, 4.0, e.values[1].lockedAgg.aggregation.SumSq())
 
-	// Add the counter metric in the same aggregation interval with the same
+	// Add the gauge metric in the same aggregation interval with the same
 	// source results in an error.
-	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], 3.0, source1))
+	require.Equal(t, errDuplicateForwardingSource, e.AddUnique(testTimestamps[2], []float64{3.0}, source1))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
 		require.Equal(t, testAlignedStarts[i], e.values[i].startAtNanos)
@@ -1400,12 +1390,11 @@ func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.Equal(t, 2.0, e.values[1].lockedAgg.aggregation.Sum())
 	require.Equal(t, 2.0, e.values[1].lockedAgg.aggregation.Max())
 	require.Equal(t, 4.0, e.values[1].lockedAgg.aggregation.SumSq())
-	_, exists = e.values[1].lockedAgg.sourcesSeen[hash.Murmur3Hash128(source1)]
-	require.True(t, exists)
+	require.True(t, e.values[1].lockedAgg.sourcesSeen.Test(uint(source1)))
 
-	// Adding the counter metric to a closed element results in an error.
+	// Adding the gauge metric to a closed element results in an error.
 	e.closed = true
-	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], 4.0, []byte("source3")))
+	require.Equal(t, errElemClosed, e.AddUnique(testTimestamps[2], []float64{4.0}, 3))
 }
 
 func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
@@ -1417,44 +1406,53 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 2, len(e.values))
 
 	// Consume one value.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 1, len(e.values))
 
 	// Consume all values.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values.
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
-	require.Equal(t, 0, len(e.values))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Reading and discarding values from a closed element is no op.
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -1467,44 +1465,53 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 2, len(e.values))
 
 	// Consume one value.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 1, len(e.values))
 
 	// Consume all values.
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Tombstone the element and discard all values.
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
-	require.Equal(t, 0, len(e.values))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 
 	// Reading and discarding values from a closed element is no op.
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -1522,99 +1529,74 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	opts := NewOptions()
 	e := testGaugeElem(alignedstartAtNanos[:3], gaugeVals, aggregationTypes, testPipeline, opts)
 
+	aggKey := aggregationKey{
+		aggregationID: maggregation.MustCompressTypes(maggregation.Count),
+		storagePolicy: testStoragePolicy,
+		pipeline: applied.NewPipeline([]applied.OpUnion{
+			{
+				Type: pipeline.RollupOpType,
+				Rollup: applied.RollupOp{
+					ID:            []byte("foo.baz"),
+					AggregationID: maggregation.MustCompressTypes(maggregation.Max),
+				},
+			},
+		}),
+		numForwardedTimes: testNumForwardedTimes + 1,
+	}
+	expectedOnFlushedRes := []testOnForwardedFlushedData{
+		{
+			aggregationKey: aggKey,
+		},
+	}
+
 	// Consume values before an early-enough time.
 	localFn, localRes := testFlushLocalMetricFn()
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
-	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
+	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 3, len(e.values))
 
 	// Consume one value.
-	expectedRes := []aggregated.MetricWithForwardMetadata{
+	expectedForwardedRes := []testForwardedMetricWithMetadata{
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(220, 0).UnixNano(),
-				Value:     nan,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testGaugeID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(220, 0).UnixNano(),
+			value:          nan,
 		},
 	}
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
-	verifyForwardedMetrics(t, expectedRes, *forwardRes)
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 2, len(e.values))
 	require.Equal(t, time.Unix(220, 0).UnixNano(), e.lastConsumedAtNanos)
 	require.Equal(t, []float64{123.0}, e.lastConsumedValues)
 
 	// Consume all values.
-	expectedRes = []aggregated.MetricWithForwardMetadata{
+	expectedForwardedRes = []testForwardedMetricWithMetadata{
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(230, 0).UnixNano(),
-				Value:     33.3,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testGaugeID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(230, 0).UnixNano(),
+			value:          33.3,
 		},
 		{
-			Metric: aggregated.Metric{
-				ID:        id.RawID("foo.bar"),
-				TimeNanos: time.Unix(240, 0).UnixNano(),
-				Value:     13.3,
-			},
-			ForwardMetadata: metadata.ForwardMetadata{
-				AggregationID: maggregation.MustCompressTypes(maggregation.Count),
-				StoragePolicy: testStoragePolicy,
-				Pipeline: applied.NewPipeline([]applied.OpUnion{
-					{
-						Type: pipeline.RollupOpType,
-						Rollup: applied.RollupOp{
-							ID:            []byte("foo.baz"),
-							AggregationID: maggregation.MustCompressTypes(maggregation.Max),
-						},
-					},
-				}),
-				SourceID:          testGaugeID,
-				NumForwardedTimes: testNumForwardedTimes + 1,
-			},
+			aggregationKey: aggKey,
+			timeNanos:      time.Unix(240, 0).UnixNano(),
+			value:          13.3,
 		},
 	}
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
-	verifyForwardedMetrics(t, expectedRes, *forwardRes)
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, time.Unix(240, 0).UnixNano(), e.lastConsumedAtNanos)
@@ -1624,7 +1606,9 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	e.tombstoned = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
+	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(e.values))
@@ -1633,9 +1617,11 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	e.closed = true
 	localFn, localRes = testFlushLocalMetricFn()
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
-	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn))
+	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
+	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, localFn, forwardFn, onForwardedFlushedFn))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
+	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(e.values))
 }
 
@@ -1652,6 +1638,9 @@ func TestGaugeElemClose(t *testing.T) {
 	require.True(t, e.closed)
 	require.Nil(t, e.id)
 	require.Equal(t, parsedPipeline{}, e.parsedPipeline)
+	require.Nil(t, e.writeForwardedFn)
+	require.Nil(t, e.onForwardedWrittenFn)
+	require.Nil(t, e.cachedSourceSets)
 	require.Equal(t, 0, len(e.values))
 	require.Equal(t, 0, len(e.toConsume))
 	require.Equal(t, 0, len(e.lastConsumedValues))
@@ -1685,7 +1674,7 @@ func TestGaugeFindOrCreateNoSourceSet(t *testing.T) {
 func TestGaugeFindOrCreateWithSourceSet(t *testing.T) {
 	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NewOptions())
 	require.NoError(t, err)
-	e.cachedSourceSets = []sourceSet{sourceSet{}}
+	e.cachedSourceSets = []*bitset.BitSet{bitset.New(0)}
 
 	inputs := []int64{10, 20}
 	expected := []testIndexData{
@@ -1725,6 +1714,16 @@ type testLocalMetricWithMetadata struct {
 	sp        policy.StoragePolicy
 }
 
+type testForwardedMetricWithMetadata struct {
+	aggregationKey aggregationKey
+	timeNanos      int64
+	value          float64
+}
+
+type testOnForwardedFlushedData struct {
+	aggregationKey aggregationKey
+}
+
 func testFlushLocalMetricFn() (
 	flushLocalMetricFn,
 	*[]testLocalMetricWithMetadata,
@@ -1751,16 +1750,34 @@ func testFlushLocalMetricFn() (
 
 func testFlushForwardedMetricFn() (
 	flushForwardedMetricFn,
-	*[]aggregated.MetricWithForwardMetadata,
+	*[]testForwardedMetricWithMetadata,
 ) {
-	var result []aggregated.MetricWithForwardMetadata
+	var result []testForwardedMetricWithMetadata
 	return func(
-		metric aggregated.Metric,
-		meta metadata.ForwardMetadata,
+		writeFn writeForwardedMetricFn,
+		aggregationKey aggregationKey,
+		timeNanos int64,
+		value float64,
 	) {
-		result = append(result, aggregated.MetricWithForwardMetadata{
-			Metric:          metric,
-			ForwardMetadata: meta,
+		result = append(result, testForwardedMetricWithMetadata{
+			aggregationKey: aggregationKey,
+			timeNanos:      timeNanos,
+			value:          value,
+		})
+	}, &result
+}
+
+func testOnForwardedFlushedFn() (
+	onForwardingElemFlushedFn,
+	*[]testOnForwardedFlushedData,
+) {
+	var result []testOnForwardedFlushedData
+	return func(
+		onDoneFn onAggregationKeyDoneFn,
+		aggregationKey aggregationKey,
+	) {
+		result = append(result, testOnForwardedFlushedData{
+			aggregationKey: aggregationKey,
 		})
 	}, &result
 }
@@ -1960,17 +1977,23 @@ func expectedLocalMetricsForGauge(
 	}
 }
 
-func verifyForwardedMetrics(t *testing.T, expected, actual []aggregated.MetricWithForwardMetadata) {
+func verifyForwardedMetrics(t *testing.T, expected, actual []testForwardedMetricWithMetadata) {
 	require.Equal(t, len(expected), len(actual))
 	for i := 0; i < len(expected); i++ {
-		require.Equal(t, expected[i].Metric.ID, actual[i].Metric.ID)
-		require.Equal(t, expected[i].Metric.TimeNanos, actual[i].Metric.TimeNanos)
-		if math.IsNaN(expected[i].Metric.Value) {
-			require.True(t, math.IsNaN(actual[i].Metric.Value))
+		require.True(t, expected[i].aggregationKey.Equal(actual[i].aggregationKey))
+		require.Equal(t, expected[i].timeNanos, actual[i].timeNanos)
+		if math.IsNaN(expected[i].value) {
+			require.True(t, math.IsNaN(actual[i].value))
 		} else {
-			require.Equal(t, expected[i].Metric.Value, actual[i].Metric.Value)
+			require.Equal(t, expected[i].value, actual[i].value)
 		}
-		require.Equal(t, expected[i].ForwardMetadata, actual[i].ForwardMetadata)
+	}
+}
+
+func verifyOnForwardedFlushResult(t *testing.T, expected, actual []testOnForwardedFlushedData) {
+	require.Equal(t, len(expected), len(actual))
+	for i := 0; i < len(expected); i++ {
+		require.True(t, expected[i].aggregationKey.Equal(actual[i].aggregationKey))
 	}
 }
 

--- a/aggregator/flush.go
+++ b/aggregator/flush.go
@@ -23,8 +23,6 @@ package aggregator
 import (
 	"time"
 
-	"github.com/m3db/m3metrics/metadata"
-	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 )
@@ -96,6 +94,15 @@ type flushLocalMetricFn func(
 // server) or dropping it. Processing of the datapoint continues after it is
 // flushed as required by the pipeline.
 type flushForwardedMetricFn func(
-	metric aggregated.Metric,
-	meta metadata.ForwardMetadata,
+	writeFn writeForwardedMetricFn,
+	aggregationKey aggregationKey,
+	timeNanos int64,
+	value float64,
+)
+
+// An onForwardingElemFlushedFn is a callback function that should be called
+// when an aggregation element producing forwarded metrics has been flushed.
+type onForwardingElemFlushedFn func(
+	onDoneFn onAggregationKeyDoneFn,
+	aggregationKey aggregationKey,
 )

--- a/aggregator/flush.go
+++ b/aggregator/flush.go
@@ -103,6 +103,6 @@ type flushForwardedMetricFn func(
 // An onForwardingElemFlushedFn is a callback function that should be called
 // when an aggregation element producing forwarded metrics has been flushed.
 type onForwardingElemFlushedFn func(
-	onDoneFn onAggregationKeyDoneFn,
+	onDoneFn onForwardedAggregationDoneFn,
 	aggregationKey aggregationKey,
 )

--- a/aggregator/forwarded_writer.go
+++ b/aggregator/forwarded_writer.go
@@ -1,0 +1,454 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/m3db/m3aggregator/client"
+	"github.com/m3db/m3aggregator/hash"
+	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/id"
+	xerrors "github.com/m3db/m3x/errors"
+
+	"github.com/uber-go/tally"
+)
+
+var (
+	errMetricNotFound         = errors.New("metric not found")
+	errAggregationKeyNotFound = errors.New("aggregation key not found")
+	errForwardedWriterClosed  = errors.New("forwarded metric writer is closed")
+)
+
+type writeForwardedMetricFn func(
+	key aggregationKey,
+	timeNanos int64,
+	value float64,
+)
+
+type onAggregationKeyDoneFn func(key aggregationKey) error
+
+// forwardededMetricWriter writes forwarded metrics.
+type forwardedMetricWriter interface {
+	// Len returns the number of forwarded metric IDs tracked by the writer.
+	Len() int
+
+	// Register registers a forwarded metric.
+	Register(
+		metricType metric.Type,
+		metricID id.RawID,
+		aggKey aggregationKey,
+	) (writeForwardedMetricFn, onAggregationKeyDoneFn, error)
+
+	// Unregister unregisters a forwarded metric.
+	Unregister(
+		metricType metric.Type,
+		metricID id.RawID,
+		aggKey aggregationKey,
+	) error
+
+	// Prepare prepares the writer for a new write cycle.
+	Prepare()
+
+	// Flush flushes any data buffered in the writer.
+	Flush() error
+
+	// Close closes the writer.
+	Close() error
+}
+
+type forwardedWriterMetrics struct {
+	registerSuccess               tally.Counter
+	registerWriterClosed          tally.Counter
+	unregisterSuccess             tally.Counter
+	unregisterWriterClosed        tally.Counter
+	unregisterMetricNotFound      tally.Counter
+	unregisterAggregationNotFound tally.Counter
+	prepare                       tally.Counter
+	flushSuccess                  tally.Counter
+	flushErrors                   tally.Counter
+}
+
+func newForwardedWriterMetrics(scope tally.Scope) forwardedWriterMetrics {
+	registerScope := scope.Tagged(map[string]string{"action": "register"})
+	unregisterScope := scope.Tagged(map[string]string{"action": "unregister"})
+	prepareScope := scope.Tagged(map[string]string{"action": "prepare"})
+	flushScope := scope.Tagged(map[string]string{"action": "flush"})
+	return forwardedWriterMetrics{
+		registerSuccess: registerScope.Counter("success"),
+		registerWriterClosed: registerScope.Tagged(map[string]string{
+			"reason": "writer-closed",
+		}).Counter("errors"),
+		unregisterSuccess: unregisterScope.Counter("success"),
+		unregisterWriterClosed: unregisterScope.Tagged(map[string]string{
+			"reason": "writer-closed",
+		}).Counter("errors"),
+		unregisterMetricNotFound: unregisterScope.Tagged(map[string]string{
+			"reason": "metric-not-found",
+		}).Counter("errors"),
+		unregisterAggregationNotFound: unregisterScope.Tagged(map[string]string{
+			"reason": "aggregation-not-found",
+		}).Counter("errors"),
+		prepare:      prepareScope.Counter("prepare"),
+		flushSuccess: flushScope.Counter("success"),
+		flushErrors:  flushScope.Counter("errors"),
+	}
+}
+
+// forwardWriter writes forwarded metrics. It is not thread-safe. Synchronized
+// access is protected and ensured by the list containing the forward writer.
+//
+// The forward writer makes sure if the same forwarded metric is produced
+// by multiple elements in the containing list, the forwarded metric will
+// only be flushed after all the elements producing the values for this
+// forwarded metric have been processed in this flush cycle. This is to
+// make sure that the list of forwarded metric values can be uniquely
+// associated with the (shard, listID) combination, which is used for value
+// deduplication during leadership re-elections on the destination server.
+type forwardedWriter struct {
+	shard  uint32
+	client client.AdminClient
+
+	closed             bool
+	aggregations       map[idKey]*forwardedAggregation // Aggregations for each forward metric id
+	metrics            forwardedWriterMetrics
+	aggregationMetrics *forwardedAggregationMetrics
+}
+
+func newForwardedWriter(
+	shard uint32,
+	client client.AdminClient,
+	scope tally.Scope,
+) forwardedMetricWriter {
+	return &forwardedWriter{
+		shard:              shard,
+		client:             client,
+		aggregations:       make(map[idKey]*forwardedAggregation),
+		metrics:            newForwardedWriterMetrics(scope),
+		aggregationMetrics: newForwardedAggregationMetrics(scope.SubScope("aggregations")),
+	}
+}
+
+func (w *forwardedWriter) Len() int { return len(w.aggregations) }
+
+func (w *forwardedWriter) Register(
+	metricType metric.Type,
+	metricID id.RawID,
+	aggKey aggregationKey,
+) (writeForwardedMetricFn, onAggregationKeyDoneFn, error) {
+	if w.closed {
+		w.metrics.registerWriterClosed.Inc(1)
+		return nil, nil, errForwardedWriterClosed
+	}
+	key := newIDKey(metricType, metricID)
+	fa, exists := w.aggregations[key]
+	if !exists {
+		fa = newForwardedAggregation(metricType, metricID, w.shard, w.client, w.aggregationMetrics)
+		w.aggregations[key] = fa
+	}
+	fa.add(aggKey)
+	w.metrics.registerSuccess.Inc(1)
+	return fa.writeForwardedMetricFn(), fa.onAggregationKeyDoneFn(), nil
+}
+
+func (w *forwardedWriter) Unregister(
+	metricType metric.Type,
+	metricID id.RawID,
+	aggKey aggregationKey,
+) error {
+	if w.closed {
+		w.metrics.unregisterWriterClosed.Inc(1)
+		return errForwardedWriterClosed
+	}
+	key := newIDKey(metricType, metricID)
+	fa, exists := w.aggregations[key]
+	if !exists {
+		w.metrics.unregisterMetricNotFound.Inc(1)
+		return errMetricNotFound
+	}
+	remaining, ok := fa.remove(aggKey)
+	if !ok {
+		w.metrics.unregisterAggregationNotFound.Inc(1)
+		return errAggregationKeyNotFound
+	}
+	if remaining == 0 {
+		fa.clear()
+		delete(w.aggregations, key)
+	}
+	w.metrics.unregisterSuccess.Inc(1)
+	return nil
+}
+
+func (w *forwardedWriter) Prepare() {
+	for _, agg := range w.aggregations {
+		agg.reset()
+	}
+	w.metrics.prepare.Inc(1)
+}
+
+func (w *forwardedWriter) Flush() error {
+	if err := w.client.Flush(); err != nil {
+		w.metrics.flushErrors.Inc(1)
+		return err
+	}
+	w.metrics.flushSuccess.Inc(1)
+	return nil
+}
+
+// NB: Do not close the client here as it is shared by all the forward
+// writers. The aggregator is responsible for closing the client.
+func (w *forwardedWriter) Close() error {
+	if w.closed {
+		return errForwardedWriterClosed
+	}
+	w.closed = true
+	w.client = nil
+	w.aggregations = nil
+	return nil
+}
+
+type idKey struct {
+	metricType metric.Type
+	idHash     hash.Hash128
+}
+
+func newIDKey(
+	metricType metric.Type,
+	metricID id.RawID,
+) idKey {
+	idHash := hash.Murmur3Hash128(metricID)
+	return idKey{
+		metricType: metricType,
+		idHash:     idHash,
+	}
+}
+
+type forwardedAggregationBucket struct {
+	timeNanos int64
+	values    []float64
+}
+
+type forwardedAggregationBuckets []forwardedAggregationBucket
+
+type forwardedAggregationWithKey struct {
+	key               aggregationKey
+	totalRefCnt       int
+	currRefCnt        int
+	cachedValueArrays [][]float64
+	buckets           forwardedAggregationBuckets
+}
+
+func (agg *forwardedAggregationWithKey) reset() {
+	agg.currRefCnt = 0
+	for i := 0; i < len(agg.buckets); i++ {
+		agg.buckets[i].values = agg.buckets[i].values[:0]
+		agg.cachedValueArrays = append(agg.cachedValueArrays, agg.buckets[i].values)
+		agg.buckets[i].values = nil
+	}
+	agg.buckets = agg.buckets[:0]
+}
+
+func (agg *forwardedAggregationWithKey) add(timeNanos int64, value float64) {
+	for i := 0; i < len(agg.buckets); i++ {
+		if agg.buckets[i].timeNanos == timeNanos {
+			agg.buckets[i].values = append(agg.buckets[i].values, value)
+			return
+		}
+	}
+	var values []float64
+	if numCachedValueArrays := len(agg.cachedValueArrays); numCachedValueArrays > 0 {
+		values = agg.cachedValueArrays[numCachedValueArrays-1]
+		values = values[:0]
+		agg.cachedValueArrays = agg.cachedValueArrays[:numCachedValueArrays-1]
+	} else {
+		values = make([]float64, 0, 2)
+	}
+	values = append(values, value)
+	bucket := forwardedAggregationBucket{
+		timeNanos: timeNanos,
+		values:    values,
+	}
+	agg.buckets = append(agg.buckets, bucket)
+}
+
+type forwardedAggregationMetrics struct {
+	added                  tally.Counter
+	removed                tally.Counter
+	write                  tally.Counter
+	onDoneNoWrite          tally.Counter
+	onDoneWriteSuccess     tally.Counter
+	onDoneWriteErrors      tally.Counter
+	onDoneUnexpectedRefCnt tally.Counter
+}
+
+func newForwardedAggregationMetrics(scope tally.Scope) *forwardedAggregationMetrics {
+	return &forwardedAggregationMetrics{
+		added:                  scope.Counter("added"),
+		removed:                scope.Counter("removed"),
+		write:                  scope.Counter("write"),
+		onDoneNoWrite:          scope.Counter("on-done-not-write"),
+		onDoneWriteSuccess:     scope.Counter("on-done-write-success"),
+		onDoneWriteErrors:      scope.Counter("on-done-write-errors"),
+		onDoneUnexpectedRefCnt: scope.Counter("on-done-unexpected-refcnt"),
+	}
+}
+
+type forwardedAggregation struct {
+	metricType metric.Type
+	metricID   id.RawID
+	shard      uint32
+	client     client.AdminClient
+
+	byKey    []forwardedAggregationWithKey
+	metrics  *forwardedAggregationMetrics
+	writeFn  writeForwardedMetricFn
+	onDoneFn onAggregationKeyDoneFn
+}
+
+func newForwardedAggregation(
+	metricType metric.Type,
+	metricID id.RawID,
+	shard uint32,
+	client client.AdminClient,
+	fm *forwardedAggregationMetrics,
+) *forwardedAggregation {
+	agg := &forwardedAggregation{
+		metricType: metricType,
+		metricID:   metricID,
+		shard:      shard,
+		client:     client,
+		byKey:      make([]forwardedAggregationWithKey, 0, 2),
+		metrics:    fm,
+	}
+	agg.writeFn = agg.write
+	agg.onDoneFn = agg.onDone
+	return agg
+}
+
+func (agg *forwardedAggregation) writeForwardedMetricFn() writeForwardedMetricFn { return agg.writeFn }
+func (agg *forwardedAggregation) onAggregationKeyDoneFn() onAggregationKeyDoneFn { return agg.onDoneFn }
+func (agg *forwardedAggregation) clear()                                         { *agg = forwardedAggregation{} }
+
+func (agg *forwardedAggregation) reset() {
+	for i := 0; i < len(agg.byKey); i++ {
+		agg.byKey[i].reset()
+	}
+}
+
+// add adds the aggregation key to the set of aggregations. If the aggregation
+// key already exists, its ref count is incremented. Otherwise, a new aggregation
+// bucket is created and added to the set of aggregtaions.
+func (agg *forwardedAggregation) add(key aggregationKey) {
+	if idx := agg.index(key); idx >= 0 {
+		agg.byKey[idx].totalRefCnt++
+		return
+	}
+	aggregation := forwardedAggregationWithKey{
+		key:         key,
+		totalRefCnt: 1,
+		currRefCnt:  0,
+		buckets:     make(forwardedAggregationBuckets, 0, 2),
+	}
+	agg.byKey = append(agg.byKey, aggregation)
+	agg.metrics.added.Inc(1)
+}
+
+// remove removes the aggregation key from the set of aggregations, returning
+// the remaining number of aggregations, and whether the removal is successful.
+func (agg *forwardedAggregation) remove(key aggregationKey) (int, bool) {
+	idx := agg.index(key)
+	if idx < 0 {
+		return 0, false
+	}
+	agg.byKey[idx].totalRefCnt--
+	if agg.byKey[idx].totalRefCnt == 0 {
+		numAggregations := len(agg.byKey)
+		agg.byKey[idx] = agg.byKey[numAggregations-1]
+		agg.byKey[numAggregations-1] = forwardedAggregationWithKey{}
+		agg.byKey = agg.byKey[:numAggregations-1]
+		agg.metrics.removed.Inc(1)
+	}
+	return len(agg.byKey), true
+}
+
+func (agg *forwardedAggregation) write(
+	key aggregationKey,
+	timeNanos int64,
+	value float64,
+) {
+	idx := agg.index(key)
+	agg.byKey[idx].add(timeNanos, value)
+	agg.metrics.write.Inc(1)
+}
+
+func (agg *forwardedAggregation) onDone(key aggregationKey) error {
+	idx := agg.index(key)
+	agg.byKey[idx].currRefCnt++
+	if agg.byKey[idx].currRefCnt < agg.byKey[idx].totalRefCnt {
+		agg.metrics.onDoneNoWrite.Inc(1)
+		return nil
+	}
+	if agg.byKey[idx].currRefCnt == agg.byKey[idx].totalRefCnt {
+		var (
+			multiErr = xerrors.NewMultiError()
+			meta     = metadata.ForwardMetadata{
+				AggregationID:     key.aggregationID,
+				StoragePolicy:     key.storagePolicy,
+				Pipeline:          key.pipeline,
+				SourceID:          agg.shard,
+				NumForwardedTimes: key.numForwardedTimes,
+			}
+		)
+		for _, b := range agg.byKey[idx].buckets {
+			if len(b.values) == 0 {
+				continue
+			}
+			metric := aggregated.ForwardedMetric{
+				Type:      agg.metricType,
+				ID:        agg.metricID,
+				TimeNanos: b.timeNanos,
+				Values:    b.values,
+			}
+			if err := agg.client.WriteForwarded(metric, meta); err != nil {
+				multiErr = multiErr.Add(err)
+				agg.metrics.onDoneWriteErrors.Inc(1)
+			} else {
+				agg.metrics.onDoneWriteSuccess.Inc(1)
+			}
+		}
+		return multiErr.FinalError()
+	}
+	// If the current ref count is higher than total, this is likely a logical error.
+	agg.metrics.onDoneUnexpectedRefCnt.Inc(1)
+	panic(fmt.Errorf("unexpected refcount: current=%d, total=%d", agg.byKey[idx].currRefCnt, agg.byKey[idx].totalRefCnt))
+}
+
+func (agg *forwardedAggregation) index(key aggregationKey) int {
+	for i, k := range agg.byKey {
+		if k.key.Equal(key) {
+			return i
+		}
+	}
+	return -1
+}

--- a/aggregator/forwarded_writer_test.go
+++ b/aggregator/forwarded_writer_test.go
@@ -1,0 +1,404 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/m3db/m3metrics/metadata"
+	"github.com/m3db/m3metrics/metric/aggregated"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/m3db/m3aggregator/client"
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3metrics/policy"
+
+	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
+)
+
+var (
+	testForwardedWriterAggregationKey = aggregationKey{
+		aggregationID:     aggregation.MustCompressTypes(aggregation.Count),
+		storagePolicy:     policy.MustParseStoragePolicy("10s:2d"),
+		numForwardedTimes: 1,
+	}
+)
+
+func TestForwardedWriterRegisterWriterClosed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.CounterType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+	w.Close()
+
+	_, _, err := w.Register(mt, mid, aggKey)
+	require.Equal(t, errForwardedWriterClosed, err)
+}
+
+func TestForwardedWriterRegisterNewAggregation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	// Validate that no error is returned.
+	writeFn, onDoneFn, err := w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+	require.NotNil(t, writeFn)
+	require.NotNil(t, onDoneFn)
+
+	// Validate that the new aggregation matches expectation.
+	fw := w.(*forwardedWriter)
+	require.Equal(t, 1, len(fw.aggregations))
+	ik := newIDKey(mt, mid)
+	agg, exists := fw.aggregations[ik]
+	require.True(t, exists)
+	require.Equal(t, mt, agg.metricType)
+	require.Equal(t, mid, agg.metricID)
+	require.Equal(t, uint32(0), agg.shard)
+	require.True(t, c == agg.client)
+
+	// Validate that the aggregation key has been added.
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 1, agg.byKey[0].totalRefCnt)
+	require.True(t, aggKey.Equal(agg.byKey[0].key))
+	require.Equal(t, 0, len(agg.byKey[0].buckets))
+
+	// Validate that writeFn can be used to write data to the aggregation.
+	writeFn(aggKey, 1234, 5.67)
+	require.Equal(t, 1, len(agg.byKey[0].buckets))
+	require.Equal(t, int64(1234), agg.byKey[0].buckets[0].timeNanos)
+	require.Equal(t, []float64{5.67}, agg.byKey[0].buckets[0].values)
+
+	writeFn(aggKey, 1234, 1.78)
+	require.Equal(t, 1, len(agg.byKey[0].buckets))
+	require.Equal(t, int64(1234), agg.byKey[0].buckets[0].timeNanos)
+	require.Equal(t, []float64{5.67, 1.78}, agg.byKey[0].buckets[0].values)
+
+	writeFn(aggKey, 1240, -2.95)
+	require.Equal(t, 2, len(agg.byKey[0].buckets))
+	require.Equal(t, int64(1240), agg.byKey[0].buckets[1].timeNanos)
+	require.Equal(t, []float64{-2.95}, agg.byKey[0].buckets[1].values)
+
+	// Validate that onDoneFn can be used to flush data out.
+	expectedMetric1 := aggregated.ForwardedMetric{
+		Type:      mt,
+		ID:        mid,
+		TimeNanos: 1234,
+		Values:    []float64{5.67, 1.78},
+	}
+	expectedMetric2 := aggregated.ForwardedMetric{
+		Type:      mt,
+		ID:        mid,
+		TimeNanos: 1240,
+		Values:    []float64{-2.95},
+	}
+	expectedMeta := metadata.ForwardMetadata{
+		AggregationID:     aggregation.MustCompressTypes(aggregation.Count),
+		StoragePolicy:     policy.MustParseStoragePolicy("10s:2d"),
+		SourceID:          0,
+		NumForwardedTimes: 1,
+	}
+	c.EXPECT().WriteForwarded(expectedMetric1, expectedMeta).Return(nil)
+	c.EXPECT().WriteForwarded(expectedMetric2, expectedMeta).Return(nil)
+	require.NoError(t, onDoneFn(aggKey))
+	require.Equal(t, 1, agg.byKey[0].currRefCnt)
+}
+
+func TestForwardedWriterRegisterExistingAggregation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	// Register an aggregation first.
+	writeFn, onDoneFn, err := w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+	require.NotNil(t, writeFn)
+	require.NotNil(t, onDoneFn)
+
+	// Validate that the aggregation key has been added.
+	fw := w.(*forwardedWriter)
+	require.Equal(t, 1, len(fw.aggregations))
+	ik := newIDKey(mt, mid)
+	agg, exists := fw.aggregations[ik]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 1, agg.byKey[0].totalRefCnt)
+
+	// Register the same aggregation again.
+	writeFn, onDoneFn, err = w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+	require.NotNil(t, writeFn)
+	require.NotNil(t, onDoneFn)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 2, agg.byKey[0].totalRefCnt)
+}
+
+func TestForwardedWriterUnregisterWriterClosed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	w.Close()
+	require.Equal(t, errForwardedWriterClosed, w.Unregister(mt, mid, aggKey))
+}
+
+func TestForwardedWriterUnregisterMetricNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	require.Equal(t, errMetricNotFound, w.Unregister(mt, mid, aggKey))
+}
+
+func TestForwardedWriterUnregisterAggregationKeyNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	// Register an aggregation first.
+	_, _, err := w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+
+	// Unregister a different aggregation key.
+	aggKey2 := aggKey
+	aggKey2.numForwardedTimes++
+	require.Equal(t, errAggregationKeyNotFound, w.Unregister(mt, mid, aggKey2))
+}
+
+func TestForwardedWriterUnregister(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	// Register an aggregation first.
+	_, _, err := w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+	fw := w.(*forwardedWriter)
+	require.Equal(t, 1, len(fw.aggregations))
+
+	// Register the aggregation again.
+	_, _, err = w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(fw.aggregations))
+
+	// Unregister the aggregation.
+	require.NoError(t, w.Unregister(mt, mid, aggKey))
+	require.Equal(t, 1, len(fw.aggregations))
+
+	// Unregister the aggregation again.
+	require.NoError(t, w.Unregister(mt, mid, aggKey))
+	require.Equal(t, 0, len(fw.aggregations))
+}
+
+func TestForwardedWriterPrepare(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c      = client.NewMockAdminClient(ctrl)
+		w      = newForwardedWriter(0, c, tally.NoopScope)
+		mt     = metric.GaugeType
+		mid    = id.RawID("foo")
+		mid2   = id.RawID("bar")
+		aggKey = testForwardedWriterAggregationKey
+	)
+
+	// Register an aggregation.
+	writeFn, onDoneFn, err := w.Register(mt, mid, aggKey)
+	require.NoError(t, err)
+
+	// Write some datapoints.
+	writeFn(aggKey, 1234, 3.4)
+	writeFn(aggKey, 1234, 3.5)
+	writeFn(aggKey, 1240, 98.2)
+
+	// Register another aggregation.
+	writeFn2, onDoneFn2, err := w.Register(mt, mid2, aggKey)
+	require.NoError(t, err)
+
+	// Write some more datapoints.
+	writeFn2(aggKey, 1238, 3.4)
+	writeFn2(aggKey, 1239, 3.5)
+
+	expectedMetric1 := aggregated.ForwardedMetric{
+		Type:      mt,
+		ID:        mid,
+		TimeNanos: 1234,
+		Values:    []float64{3.4, 3.5},
+	}
+	expectedMetric2 := aggregated.ForwardedMetric{
+		Type:      mt,
+		ID:        mid,
+		TimeNanos: 1240,
+		Values:    []float64{98.2},
+	}
+	expectedMetric3 := aggregated.ForwardedMetric{
+		Type:      mt,
+		ID:        mid2,
+		TimeNanos: 1238,
+		Values:    []float64{3.4},
+	}
+	expectedMetric4 := aggregated.ForwardedMetric{
+		Type:      mt,
+		ID:        mid2,
+		TimeNanos: 1239,
+		Values:    []float64{3.5},
+	}
+	expectedMeta := metadata.ForwardMetadata{
+		AggregationID:     aggregation.MustCompressTypes(aggregation.Count),
+		StoragePolicy:     policy.MustParseStoragePolicy("10s:2d"),
+		SourceID:          0,
+		NumForwardedTimes: 1,
+	}
+	c.EXPECT().WriteForwarded(expectedMetric1, expectedMeta).Return(nil).Times(2)
+	c.EXPECT().WriteForwarded(expectedMetric2, expectedMeta).Return(nil).Times(2)
+	c.EXPECT().WriteForwarded(expectedMetric3, expectedMeta).Return(nil).Times(2)
+	c.EXPECT().WriteForwarded(expectedMetric4, expectedMeta).Return(nil).Times(2)
+	require.NoError(t, onDoneFn(aggKey))
+	require.NoError(t, onDoneFn2(aggKey))
+
+	fw := w.(*forwardedWriter)
+	require.Equal(t, 2, len(fw.aggregations))
+	agg, exists := fw.aggregations[newIDKey(mt, mid)]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 2, len(agg.byKey[0].buckets))
+	require.Equal(t, 1, agg.byKey[0].currRefCnt)
+	require.Equal(t, 0, len(agg.byKey[0].cachedValueArrays))
+	agg, exists = fw.aggregations[newIDKey(mt, mid2)]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 2, len(agg.byKey[0].buckets))
+	require.Equal(t, 1, agg.byKey[0].currRefCnt)
+	require.Equal(t, 0, len(agg.byKey[0].cachedValueArrays))
+
+	w.Prepare()
+
+	// Assert the internal state has been reset.
+	require.Equal(t, 2, len(fw.aggregations))
+	agg, exists = fw.aggregations[newIDKey(mt, mid)]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 0, len(agg.byKey[0].buckets))
+	require.Equal(t, 0, agg.byKey[0].currRefCnt)
+	require.Equal(t, 2, len(agg.byKey[0].cachedValueArrays))
+	agg, exists = fw.aggregations[newIDKey(mt, mid2)]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 0, len(agg.byKey[0].buckets))
+	require.Equal(t, 0, agg.byKey[0].currRefCnt)
+	require.Equal(t, 2, len(agg.byKey[0].cachedValueArrays))
+
+	// Write datapoints again.
+	writeFn(aggKey, 1234, 3.4)
+	writeFn(aggKey, 1234, 3.5)
+	writeFn(aggKey, 1240, 98.2)
+	writeFn2(aggKey, 1238, 3.4)
+	writeFn2(aggKey, 1239, 3.5)
+	require.NoError(t, onDoneFn(aggKey))
+	require.NoError(t, onDoneFn2(aggKey))
+
+	require.Equal(t, 2, len(fw.aggregations))
+	agg, exists = fw.aggregations[newIDKey(mt, mid)]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 2, len(agg.byKey[0].buckets))
+	require.Equal(t, 1, agg.byKey[0].currRefCnt)
+	require.Equal(t, 0, len(agg.byKey[0].cachedValueArrays))
+	agg, exists = fw.aggregations[newIDKey(mt, mid2)]
+	require.True(t, exists)
+	require.Equal(t, 1, len(agg.byKey))
+	require.Equal(t, 2, len(agg.byKey[0].buckets))
+	require.Equal(t, 1, agg.byKey[0].currRefCnt)
+	require.Equal(t, 0, len(agg.byKey[0].cachedValueArrays))
+}
+
+func TestForwardedWriterCloseWriterClosed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		c = client.NewMockAdminClient(ctrl)
+		w = newForwardedWriter(0, c, tally.NoopScope)
+	)
+
+	// Close the writer and validate that the fields are nil'ed out.
+	require.NoError(t, w.Close())
+	fw := w.(*forwardedWriter)
+	require.True(t, fw.closed)
+	require.Nil(t, fw.client)
+	require.Nil(t, fw.aggregations)
+
+	// Closing the writer a second time results in an error.
+	require.Equal(t, errForwardedWriterClosed, w.Close())
+}

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -254,7 +254,7 @@ func (e *GaugeElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -270,8 +270,8 @@ func (e *GaugeElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
-	e.writeForwardedFn = nil
-	e.onForwardedWrittenFn = nil
+	e.writeForwardedMetricFn = nil
+	e.onForwardedAggregationWrittenFn = nil
 	for idx := range e.cachedSourceSets {
 		e.cachedSourceSets[idx] = nil
 	}
@@ -422,7 +422,7 @@ func (e *GaugeElem) processValueWithAggregationLock(
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
+			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -31,13 +31,7 @@ import (
 
 	"time"
 
-	"github.com/m3db/m3aggregator/hash"
-
 	maggregation "github.com/m3db/m3metrics/aggregation"
-
-	"github.com/m3db/m3metrics/metadata"
-
-	"github.com/m3db/m3metrics/metric/aggregated"
 
 	"github.com/m3db/m3metrics/metric/id"
 
@@ -48,13 +42,15 @@ import (
 	"github.com/m3db/m3metrics/policy"
 
 	"github.com/m3db/m3metrics/transformation"
+
+	"github.com/willf/bitset"
 )
 
 type lockedGaugeAggregation struct {
 	sync.Mutex
 
 	closed      bool
-	sourcesSeen sourceSet
+	sourcesSeen *bitset.BitSet
 	aggregation gaugeAggregation
 }
 
@@ -168,7 +164,7 @@ func (e *GaugeElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) e
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
-func (e *GaugeElem) AddUnique(timestamp time.Time, value float64, sourceID []byte) error {
+func (e *GaugeElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
 	if err != nil {
@@ -179,13 +175,15 @@ func (e *GaugeElem) AddUnique(timestamp time.Time, value float64, sourceID []byt
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	sourceHash := hash.Murmur3Hash128(sourceID)
-	if v, exists := lockedAgg.sourcesSeen[sourceHash]; exists && v == alignedStart {
+	source := uint(sourceID)
+	if lockedAgg.sourcesSeen.Test(source) {
 		lockedAgg.Unlock()
 		return errDuplicateForwardingSource
 	}
-	lockedAgg.sourcesSeen[sourceHash] = alignedStart
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.sourcesSeen.Set(source)
+	for _, v := range values {
+		lockedAgg.aggregation.Add(v)
+	}
 	lockedAgg.Unlock()
 	return nil
 }
@@ -201,6 +199,7 @@ func (e *GaugeElem) Consume(
 	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
+	onForwardedFlushedFn onForwardingElemFlushedFn,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	e.Lock()
@@ -240,25 +239,22 @@ func (e *GaugeElem) Consume(
 		e.toConsume[i].lockedAgg.closed = true
 		e.toConsume[i].lockedAgg.aggregation.Close()
 		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			sourceSetSize := len(e.toConsume[i].lockedAgg.sourcesSeen)
-			// If the source set we are about to cache is too big (i.e., bigger than the
-			// configured max size), we do not want to retain it and instead simply discard it.
-			// This is useful if say over the course of a month the metric IDs producing
-			// the forward metric ID have changed significantly so there are a lot of stale
-			// IDs in the map so we regenerate the map once in a while to refresh the map.
-			if sourceSetSize <= e.opts.MaxCachedSourceSetSize() {
-				e.cachedSourceSetsLock.Lock()
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-				}
-				e.cachedSourceSetsLock.Unlock()
+			e.cachedSourceSetsLock.Lock()
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
 			}
+			e.cachedSourceSetsLock.Unlock()
 			e.toConsume[i].lockedAgg.sourcesSeen = nil
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
+	}
+
+	if e.parsedPipeline.HasRollup {
+		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -274,8 +270,15 @@ func (e *GaugeElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
+	e.writeForwardedFn = nil
+	e.onForwardedWrittenFn = nil
+	for idx := range e.cachedSourceSets {
+		e.cachedSourceSets[idx] = nil
+	}
+	e.cachedSourceSets = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
+		e.values[idx].lockedAgg.sourcesSeen = nil
 		e.values[idx].lockedAgg.aggregation.Close()
 		e.values[idx].Reset()
 	}
@@ -329,15 +332,16 @@ func (e *GaugeElem) findOrCreate(
 	e.values = append(e.values, timedGauge{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen sourceSet
+	var sourcesSeen *bitset.BitSet
 	if createOpts.initSourceSet {
 		e.cachedSourceSetsLock.Lock()
 		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
 			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
 			e.cachedSourceSets[numCachedSourceSets-1] = nil
 			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
+			sourcesSeen.ClearAll()
 		} else {
-			sourcesSeen = make(sourceSet, defaultNumSources)
+			sourcesSeen = bitset.New(defaultNumSources)
 		}
 		e.cachedSourceSetsLock.Unlock()
 	}
@@ -417,20 +421,8 @@ func (e *GaugeElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
-			fm := aggregated.Metric{
-				Type:      e.Type(),
-				ID:        e.parsedPipeline.Rollup.ID,
-				TimeNanos: timeNanos,
-				Value:     value,
-			}
-			meta := metadata.ForwardMetadata{
-				AggregationID:     e.parsedPipeline.Rollup.AggregationID,
-				StoragePolicy:     e.sp,
-				Pipeline:          e.parsedPipeline.Remainder,
-				SourceID:          []byte(e.id),
-				NumForwardedTimes: e.numForwardedTimes + 1,
-			}
-			flushForwardedFn(fm, meta)
+			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/generic_elem.go
+++ b/aggregator/generic_elem.go
@@ -26,11 +26,8 @@ import (
 	"time"
 
 	raggregation "github.com/m3db/m3aggregator/aggregation"
-	"github.com/m3db/m3aggregator/hash"
 	maggregation "github.com/m3db/m3metrics/aggregation"
-	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric"
-	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/pipeline/applied"
@@ -38,6 +35,7 @@ import (
 	"github.com/m3db/m3metrics/transformation"
 
 	"github.com/mauricelam/genny/generic"
+	"github.com/willf/bitset"
 )
 
 type typeSpecificAggregation interface {
@@ -99,7 +97,7 @@ type lockedAggregation struct {
 	sync.Mutex
 
 	closed      bool
-	sourcesSeen sourceSet
+	sourcesSeen *bitset.BitSet
 	aggregation typeSpecificAggregation
 }
 
@@ -213,7 +211,7 @@ func (e *GenericElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion)
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
-func (e *GenericElem) AddUnique(timestamp time.Time, value float64, sourceID []byte) error {
+func (e *GenericElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
 	if err != nil {
@@ -224,13 +222,15 @@ func (e *GenericElem) AddUnique(timestamp time.Time, value float64, sourceID []b
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	sourceHash := hash.Murmur3Hash128(sourceID)
-	if v, exists := lockedAgg.sourcesSeen[sourceHash]; exists && v == alignedStart {
+	source := uint(sourceID)
+	if lockedAgg.sourcesSeen.Test(source) {
 		lockedAgg.Unlock()
 		return errDuplicateForwardingSource
 	}
-	lockedAgg.sourcesSeen[sourceHash] = alignedStart
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.sourcesSeen.Set(source)
+	for _, v := range values {
+		lockedAgg.aggregation.Add(v)
+	}
 	lockedAgg.Unlock()
 	return nil
 }
@@ -246,6 +246,7 @@ func (e *GenericElem) Consume(
 	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
+	onForwardedFlushedFn onForwardingElemFlushedFn,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	e.Lock()
@@ -285,25 +286,22 @@ func (e *GenericElem) Consume(
 		e.toConsume[i].lockedAgg.closed = true
 		e.toConsume[i].lockedAgg.aggregation.Close()
 		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			sourceSetSize := len(e.toConsume[i].lockedAgg.sourcesSeen)
-			// If the source set we are about to cache is too big (i.e., bigger than the
-			// configured max size), we do not want to retain it and instead simply discard it.
-			// This is useful if say over the course of a month the metric IDs producing
-			// the forward metric ID have changed significantly so there are a lot of stale
-			// IDs in the map so we regenerate the map once in a while to refresh the map.
-			if sourceSetSize <= e.opts.MaxCachedSourceSetSize() {
-				e.cachedSourceSetsLock.Lock()
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-				}
-				e.cachedSourceSetsLock.Unlock()
+			e.cachedSourceSetsLock.Lock()
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
 			}
+			e.cachedSourceSetsLock.Unlock()
 			e.toConsume[i].lockedAgg.sourcesSeen = nil
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
+	}
+
+	if e.parsedPipeline.HasRollup {
+		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -319,8 +317,15 @@ func (e *GenericElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
+	e.writeForwardedFn = nil
+	e.onForwardedWrittenFn = nil
+	for idx := range e.cachedSourceSets {
+		e.cachedSourceSets[idx] = nil
+	}
+	e.cachedSourceSets = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
+		e.values[idx].lockedAgg.sourcesSeen = nil
 		e.values[idx].lockedAgg.aggregation.Close()
 		e.values[idx].Reset()
 	}
@@ -374,15 +379,16 @@ func (e *GenericElem) findOrCreate(
 	e.values = append(e.values, timedAggregation{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen sourceSet
+	var sourcesSeen *bitset.BitSet
 	if createOpts.initSourceSet {
 		e.cachedSourceSetsLock.Lock()
 		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
 			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
 			e.cachedSourceSets[numCachedSourceSets-1] = nil
 			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
+			sourcesSeen.ClearAll()
 		} else {
-			sourcesSeen = make(sourceSet, defaultNumSources)
+			sourcesSeen = bitset.New(defaultNumSources)
 		}
 		e.cachedSourceSetsLock.Unlock()
 	}
@@ -462,20 +468,8 @@ func (e *GenericElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
-			fm := aggregated.Metric{
-				Type:      e.Type(),
-				ID:        e.parsedPipeline.Rollup.ID,
-				TimeNanos: timeNanos,
-				Value:     value,
-			}
-			meta := metadata.ForwardMetadata{
-				AggregationID:     e.parsedPipeline.Rollup.AggregationID,
-				StoragePolicy:     e.sp,
-				Pipeline:          e.parsedPipeline.Remainder,
-				SourceID:          []byte(e.id),
-				NumForwardedTimes: e.numForwardedTimes + 1,
-			}
-			flushForwardedFn(fm, meta)
+			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/generic_elem.go
+++ b/aggregator/generic_elem.go
@@ -301,7 +301,7 @@ func (e *GenericElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -317,8 +317,8 @@ func (e *GenericElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
-	e.writeForwardedFn = nil
-	e.onForwardedWrittenFn = nil
+	e.writeForwardedMetricFn = nil
+	e.onForwardedAggregationWrittenFn = nil
 	for idx := range e.cachedSourceSets {
 		e.cachedSourceSets[idx] = nil
 	}
@@ -469,7 +469,7 @@ func (e *GenericElem) processValueWithAggregationLock(
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
+			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/m3db/m3aggregator/aggregator/handler"
 	"github.com/m3db/m3aggregator/aggregator/handler/writer"
-	"github.com/m3db/m3aggregator/client"
-	"github.com/m3db/m3metrics/metadata"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	metricid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
@@ -74,6 +72,24 @@ func newMetricProcessingMetrics(scope tally.Scope) metricProcessingMetrics {
 	}
 }
 
+type forwardedMetricProcessingMetrics struct {
+	metricConsumed    tally.Counter
+	metricDiscarded   tally.Counter
+	onConsumedSuccess tally.Counter
+	onConsumedErrors  tally.Counter
+	onDiscarded       tally.Counter
+}
+
+func newForwardedMetricProcessingMetrics(scope tally.Scope) forwardedMetricProcessingMetrics {
+	return forwardedMetricProcessingMetrics{
+		metricConsumed:    scope.Counter("metric-consumed"),
+		metricDiscarded:   scope.Counter("metric-discarded"),
+		onConsumedSuccess: scope.Counter("on-consumed-success"),
+		onConsumedErrors:  scope.Counter("on-consumed-errors"),
+		onDiscarded:       scope.Counter("on-discarded"),
+	}
+}
+
 type writerMetrics struct {
 	flushSuccess tally.Counter
 	flushErrors  tally.Counter
@@ -89,7 +105,7 @@ func newWriterMetrics(scope tally.Scope) writerMetrics {
 type baseMetricListMetrics struct {
 	flushLocal                  metricProcessingMetrics
 	flushLocalWriter            writerMetrics
-	flushForwarded              metricProcessingMetrics
+	flushForwarded              forwardedMetricProcessingMetrics
 	flushForwardedWriter        writerMetrics
 	flushElemCollected          tally.Counter
 	flushDuration               tally.Timer
@@ -112,7 +128,7 @@ func newMetricListMetrics(scope tally.Scope) baseMetricListMetrics {
 	return baseMetricListMetrics{
 		flushLocal:                  newMetricProcessingMetrics(flushLocalScope),
 		flushLocalWriter:            newWriterMetrics(flushLocalWriterScope),
-		flushForwarded:              newMetricProcessingMetrics(flushForwardedScope),
+		flushForwarded:              newForwardedMetricProcessingMetrics(flushForwardedScope),
 		flushForwardedWriter:        newWriterMetrics(flushForwardedWriterScope),
 		flushElemCollected:          flushScope.Counter("elem-collected"),
 		flushDuration:               flushScope.Timer("duration"),
@@ -144,7 +160,7 @@ type baseMetricList struct {
 	timeLock         *sync.RWMutex
 	flushHandler     handler.Handler
 	localWriter      writer.Writer
-	forwardedWriter  client.AdminClient
+	forwardedWriter  forwardedMetricWriter
 	resolution       time.Duration
 	targetNanosFn    targetNanosFn
 	isEarlierThanFn  isEarlierThanFn
@@ -156,11 +172,13 @@ type baseMetricList struct {
 	toCollect        []*list.Element
 	metrics          baseMetricListMetrics
 
-	flushBeforeFn            flushBeforeFn
-	consumeLocalMetricFn     flushLocalMetricFn
-	discardLocalMetricFn     flushLocalMetricFn
-	consumeForwardedMetricFn flushForwardedMetricFn
-	discardForwardedMetricFn flushForwardedMetricFn
+	flushBeforeFn               flushBeforeFn
+	consumeLocalMetricFn        flushLocalMetricFn
+	discardLocalMetricFn        flushLocalMetricFn
+	consumeForwardedMetricFn    flushForwardedMetricFn
+	discardForwardedMetricFn    flushForwardedMetricFn
+	onForwardingElemConsumedFn  onForwardingElemFlushedFn
+	onForwardingElemDiscardedFn onForwardingElemFlushedFn
 }
 
 func newBaseMetricList(
@@ -175,11 +193,13 @@ func newBaseMetricList(
 		map[string]string{"resolution": resolution.String()},
 	)
 	flushHandler := opts.FlushHandler()
-	localWriter, err := flushHandler.NewWriter(scope.SubScope("writer"))
+	localWriterScope := scope.Tagged(map[string]string{"writer-type": "local"}).SubScope("writer")
+	localWriter, err := flushHandler.NewWriter(localWriterScope)
 	if err != nil {
 		return nil, err
 	}
-
+	forwardedWriterScope := scope.Tagged(map[string]string{"writer-type": "forwarded"}).SubScope("writer")
+	forwardedWriter := newForwardedWriter(shard, opts.AdminClient(), forwardedWriterScope)
 	l := &baseMetricList{
 		shard:            shard,
 		opts:             opts,
@@ -187,7 +207,7 @@ func newBaseMetricList(
 		timeLock:         opts.TimeLock(),
 		flushHandler:     flushHandler,
 		localWriter:      localWriter,
-		forwardedWriter:  opts.AdminClient(),
+		forwardedWriter:  forwardedWriter,
 		resolution:       resolution,
 		targetNanosFn:    targetNanosFn,
 		isEarlierThanFn:  isEarlierThanFn,
@@ -200,6 +220,8 @@ func newBaseMetricList(
 	l.discardLocalMetricFn = l.discardLocalMetric
 	l.consumeForwardedMetricFn = l.consumeForwardedMetric
 	l.discardForwardedMetricFn = l.discardForwardedMetric
+	l.onForwardingElemConsumedFn = l.onForwardingElemConsumed
+	l.onForwardingElemDiscardedFn = l.onForwardingElemDiscarded
 
 	return l, nil
 }
@@ -217,18 +239,41 @@ func (l *baseMetricList) Len() int {
 	return numElems
 }
 
-// PushBack adds an element to the list.
+// PushBack adds an element to the list. It also registers the value
+// with the forwarded writer if the metric element passed in produces
+// forwarded metrics, and sets the function responsible for writing
+// forwarded metrics in the metric element.
+//
 // NB(xichen): the container list doesn't provide an API to directly
 // insert a list element, therefore making it impossible to pool the
 // elements and manage their lifetimes. If this becomes an issue,
 // need to switch to a custom type-specific list implementation.
 func (l *baseMetricList) PushBack(value metricElem) (*list.Element, error) {
+	var (
+		forwardedMetricType         = value.Type()
+		forwardedID, hasForwardedID = value.ForwardedID()
+		forwardedAggregationKey, _  = value.ForwardedAggregationKey()
+	)
 	l.Lock()
 	if l.closed {
 		l.Unlock()
 		return nil, errListClosed
 	}
 	elem := l.aggregations.PushBack(value)
+	if !hasForwardedID {
+		l.Unlock()
+		return elem, nil
+	}
+	writeForwardedFn, onForwardedWrittenFn, err := l.forwardedWriter.Register(
+		forwardedMetricType,
+		forwardedID,
+		forwardedAggregationKey,
+	)
+	if err != nil {
+		l.Unlock()
+		return nil, err
+	}
+	value.SetForwardedCallbacks(writeForwardedFn, onForwardedWrittenFn)
 	l.Unlock()
 	return elem, nil
 }
@@ -242,8 +287,7 @@ func (l *baseMetricList) Close() bool {
 		return false
 	}
 	l.localWriter.Close()
-	// NB: forwardedWriter is shared across lists and closed during
-	// aggregator shutdown.
+	l.forwardedWriter.Close()
 	l.closed = true
 	return true
 }
@@ -311,17 +355,26 @@ func (l *baseMetricList) flushBefore(beforeNanos int64, flushType flushType) {
 	l.toCollect = l.toCollect[:0]
 	flushLocalFn := l.consumeLocalMetricFn
 	flushForwardedFn := l.consumeForwardedMetricFn
+	onForwardedFlushedFn := l.onForwardingElemConsumedFn
 	if flushType == discardType {
 		flushLocalFn = l.discardLocalMetricFn
 		flushForwardedFn = l.discardForwardedMetricFn
+		onForwardedFlushedFn = l.onForwardingElemDiscardedFn
 	}
 
 	// Flush out aggregations, may need to do it in batches if the read lock
-	// is held for too long.
+	// is held for too long. If consuming in batches, need to change the forward
+	// writer to take a snapshot of the current refcounts during reset as well as
+	// the last element of the list before the consumption starts to ensure elements
+	// added or removed while consuming do not affect the refcounts in the current cycle.
 	l.RLock()
+	// NB: Ensure the elements are consumed within a read lock so that the
+	// refcounts of forwarded metrics tracked in the forwarded writer do not
+	// change so no elements may be added or removed while holding the lock.
+	l.forwardedWriter.Prepare()
 	for e := l.aggregations.Front(); e != nil; e = e.Next() {
 		// If the element is eligible for collection after the values are
-		// processed, close it and reset the value to nil.
+		// processed, add it to the list of elements to collect.
 		elem := e.Value.(metricElem)
 		if elem.Consume(
 			beforeNanos,
@@ -329,9 +382,8 @@ func (l *baseMetricList) flushBefore(beforeNanos int64, flushType flushType) {
 			l.timestampNanosFn,
 			flushLocalFn,
 			flushForwardedFn,
+			onForwardedFlushedFn,
 		) {
-			elem.Close()
-			e.Value = nil
 			l.toCollect = append(l.toCollect, e)
 		}
 	}
@@ -358,6 +410,15 @@ func (l *baseMetricList) flushBefore(beforeNanos int64, flushType flushType) {
 	// Collect tombstoned elements.
 	l.Lock()
 	for _, e := range l.toCollect {
+		elem := e.Value.(metricElem)
+		// NB: must unregister the element with forwarded writer before closing it.
+		if forwardedID, hasForwardedID := elem.ForwardedID(); hasForwardedID {
+			forwardedType := elem.Type()
+			forwardedAggregationKey, _ := elem.ForwardedAggregationKey()
+			l.forwardedWriter.Unregister(forwardedType, forwardedID, forwardedAggregationKey)
+		}
+		elem.Close()
+		e.Value = nil
 		l.aggregations.Remove(e)
 	}
 	numCollected := len(l.toCollect)
@@ -410,22 +471,42 @@ func (l *baseMetricList) discardLocalMetric(
 }
 
 func (l *baseMetricList) consumeForwardedMetric(
-	metric aggregated.Metric,
-	meta metadata.ForwardMetadata,
+	writeFn writeForwardedMetricFn,
+	aggregationKey aggregationKey,
+	timeNanos int64,
+	value float64,
 ) {
-	if err := l.forwardedWriter.WriteForwarded(metric, meta); err != nil {
-		l.metrics.flushForwarded.metricConsumeErrors.Inc(1)
-	} else {
-		l.metrics.flushForwarded.metricConsumeSuccess.Inc(1)
-	}
+	writeFn(aggregationKey, timeNanos, value)
+	l.metrics.flushForwarded.metricConsumed.Inc(1)
 }
 
 // nolint: unparam
 func (l *baseMetricList) discardForwardedMetric(
-	metric aggregated.Metric,
-	meta metadata.ForwardMetadata,
+	writeFn writeForwardedMetricFn,
+	aggregationKey aggregationKey,
+	timeNanos int64,
+	value float64,
 ) {
 	l.metrics.flushForwarded.metricDiscarded.Inc(1)
+}
+
+func (l *baseMetricList) onForwardingElemConsumed(
+	onForwardedWrittenFn onAggregationKeyDoneFn,
+	aggregationKey aggregationKey,
+) {
+	if err := onForwardedWrittenFn(aggregationKey); err != nil {
+		l.metrics.flushForwarded.onConsumedErrors.Inc(1)
+	} else {
+		l.metrics.flushForwarded.onConsumedSuccess.Inc(1)
+	}
+}
+
+// nolint: unparam
+func (l *baseMetricList) onForwardingElemDiscarded(
+	onForwardedWrittenFn onAggregationKeyDoneFn,
+	aggregationKey aggregationKey,
+) {
+	l.metrics.flushForwarded.onDiscarded.Inc(1)
 }
 
 // Standard metrics whose timestamps are earlier than current time can be flushed.

--- a/aggregator/list.go
+++ b/aggregator/list.go
@@ -491,7 +491,7 @@ func (l *baseMetricList) discardForwardedMetric(
 }
 
 func (l *baseMetricList) onForwardingElemConsumed(
-	onForwardedWrittenFn onAggregationKeyDoneFn,
+	onForwardedWrittenFn onForwardedAggregationDoneFn,
 	aggregationKey aggregationKey,
 ) {
 	if err := onForwardedWrittenFn(aggregationKey); err != nil {
@@ -503,7 +503,7 @@ func (l *baseMetricList) onForwardingElemConsumed(
 
 // nolint: unparam
 func (l *baseMetricList) onForwardingElemDiscarded(
-	onForwardedWrittenFn onAggregationKeyDoneFn,
+	onForwardedWrittenFn onForwardedAggregationDoneFn,
 	aggregationKey aggregationKey,
 ) {
 	l.metrics.flushForwarded.onDiscarded.Inc(1)

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -59,8 +59,8 @@ func TestBaseMetricListPushBackElemWithDefaultPipeline(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, l.aggregations.Len())
 	require.Equal(t, elem, e.Value.(*CounterElem))
-	require.Nil(t, elem.writeForwardedFn)
-	require.Nil(t, elem.onForwardedWrittenFn)
+	require.Nil(t, elem.writeForwardedMetricFn)
+	require.Nil(t, elem.onForwardedAggregationWrittenFn)
 
 	// Push a counter to a closed list should result in an error.
 	l.Lock()
@@ -85,8 +85,8 @@ func TestBaseMetricListPushBackElemWithForwardingPipeline(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, l.aggregations.Len())
 	require.Equal(t, elem, e.Value.(*CounterElem))
-	require.NotNil(t, elem.writeForwardedFn)
-	require.NotNil(t, elem.onForwardedWrittenFn)
+	require.NotNil(t, elem.writeForwardedMetricFn)
+	require.NotNil(t, elem.onForwardedAggregationWrittenFn)
 }
 
 func TestBaseMetricListClose(t *testing.T) {

--- a/aggregator/list_test.go
+++ b/aggregator/list_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBaseMetricListPushBack(t *testing.T) {
+func TestBaseMetricListPushBackElemWithDefaultPipeline(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -59,6 +59,8 @@ func TestBaseMetricListPushBack(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, l.aggregations.Len())
 	require.Equal(t, elem, e.Value.(*CounterElem))
+	require.Nil(t, elem.writeForwardedFn)
+	require.Nil(t, elem.onForwardedWrittenFn)
 
 	// Push a counter to a closed list should result in an error.
 	l.Lock()
@@ -67,6 +69,24 @@ func TestBaseMetricListPushBack(t *testing.T) {
 
 	_, err = l.PushBack(elem)
 	require.Equal(t, err, errListClosed)
+}
+
+func TestBaseMetricListPushBackElemWithForwardingPipeline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	l, err := newBaseMetricList(testShard, time.Second, nil, nil, nil, testOptions(ctrl))
+	require.NoError(t, err)
+	elem, err := NewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, testPipeline, 0, l.opts)
+	require.NoError(t, err)
+
+	// Push a counter to the list.
+	e, err := l.PushBack(elem)
+	require.NoError(t, err)
+	require.Equal(t, 1, l.aggregations.Len())
+	require.Equal(t, elem, e.Value.(*CounterElem))
+	require.NotNil(t, elem.writeForwardedFn)
+	require.NotNil(t, elem.onForwardedWrittenFn)
 }
 
 func TestBaseMetricListClose(t *testing.T) {
@@ -474,11 +494,11 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 		cutoffNanos  = int64(math.MaxInt64)
 		count        int
 		flushLock    sync.Mutex
-		flushed      []aggregated.MetricWithForwardMetadata
+		flushed      []aggregated.ForwardedMetricWithMetadata
 	)
 
 	// Intentionally cause a one-time error during encoding.
-	writeFn := func(metric aggregated.Metric, meta metadata.ForwardMetadata) error {
+	writeFn := func(metric aggregated.ForwardedMetric, meta metadata.ForwardMetadata) error {
 		flushLock.Lock()
 		defer flushLock.Unlock()
 
@@ -486,8 +506,8 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 			count++
 			return errTestWrite
 		}
-		flushed = append(flushed, aggregated.MetricWithForwardMetadata{
-			Metric:          metric,
+		flushed = append(flushed, aggregated.ForwardedMetricWithMetadata{
+			ForwardedMetric: metric,
 			ForwardMetadata: meta,
 		})
 		return nil
@@ -520,6 +540,7 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 	l, err := newForwardedMetricList(testShard, listID, opts)
 	require.NoError(t, err)
 
+	sourceID := uint32(testShard)
 	pipeline := applied.NewPipeline([]applied.OpUnion{
 		{
 			Type: pipeline.RollupOpType,
@@ -531,34 +552,36 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 	})
 	elemPairs := []struct {
 		elem   metricElem
-		metric aggregated.Metric
+		metric aggregated.ForwardedMetric
 	}{
 		{
 			elem: MustNewCounterElem([]byte("testForwardedCounter"), testStoragePolicy, aggregation.DefaultTypes, pipeline, testNumForwardedTimes, opts),
-			metric: aggregated.Metric{
+			metric: aggregated.ForwardedMetric{
 				Type:      metric.CounterType,
 				ID:        []byte("testForwardedCounter"),
 				TimeNanos: alignedTimeNanos,
-				Value:     123,
+				Values:    []float64{123},
 			},
 		},
 		{
 			elem: MustNewGaugeElem([]byte("testForwardedGauge"), testStoragePolicy, aggregation.DefaultTypes, pipeline, testNumForwardedTimes, opts),
-			metric: aggregated.Metric{
+			metric: aggregated.ForwardedMetric{
 				Type:      metric.GaugeType,
 				ID:        []byte("testForwardedGauge"),
 				TimeNanos: alignedTimeNanos,
-				Value:     1.762,
+				Values:    []float64{1.762},
 			},
 		},
 	}
 
 	for _, ep := range elemPairs {
-		require.NoError(t, ep.elem.AddUnique(time.Unix(0, ep.metric.TimeNanos), ep.metric.Value, []byte("source1")))
-		require.NoError(t, ep.elem.AddUnique(time.Unix(0, ep.metric.TimeNanos).Add(l.resolution), ep.metric.Value, []byte("source1")))
+		require.NoError(t, ep.elem.AddUnique(time.Unix(0, ep.metric.TimeNanos), ep.metric.Values, sourceID))
+		require.NoError(t, ep.elem.AddUnique(time.Unix(0, ep.metric.TimeNanos).Add(l.resolution), ep.metric.Values, sourceID))
 		_, err := l.PushBack(ep.elem)
 		require.NoError(t, err)
 	}
+
+	require.Equal(t, len(elemPairs), l.forwardedWriter.Len())
 
 	// Force a flush.
 	l.Flush(flushRequest{
@@ -582,24 +605,24 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 			CutoffNanos:  cutoffNanos,
 		})
 
-		var expected []aggregated.MetricWithForwardMetadata
+		var expected []aggregated.ForwardedMetricWithMetadata
 		alignedStart := (nowTs.Add(-maxLatenessAllowed)).Truncate(l.resolution).UnixNano()
 		for _, ep := range elemPairs {
-			expectedMetric := aggregated.Metric{
+			expectedMetric := aggregated.ForwardedMetric{
 				Type:      ep.metric.Type,
 				ID:        []byte("foo.bar"),
 				TimeNanos: alignedStart,
-				Value:     ep.metric.Value,
+				Values:    ep.metric.Values,
 			}
 			metadata := metadata.ForwardMetadata{
 				AggregationID:     aggregation.MustCompressTypes(aggregation.Max),
 				StoragePolicy:     testStoragePolicy,
 				Pipeline:          applied.NewPipeline([]applied.OpUnion{}),
-				SourceID:          ep.elem.ID(),
+				SourceID:          sourceID,
 				NumForwardedTimes: testNumForwardedTimes + 1,
 			}
-			expected = append(expected, aggregated.MetricWithForwardMetadata{
-				Metric:          expectedMetric,
+			expected = append(expected, aggregated.ForwardedMetricWithMetadata{
+				ForwardedMetric: expectedMetric,
 				ForwardMetadata: metadata,
 			})
 		}
@@ -648,6 +671,9 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 
 	// Assert all elements have been collected.
 	require.Equal(t, 0, l.aggregations.Len())
+
+	// Assert there are no more forwarded metrics tracked by the writer.
+	require.Equal(t, 0, l.forwardedWriter.Len())
 
 	require.Equal(t, l.lastFlushedNanos, nowTs.UnixNano()-maxLatenessAllowed.Nanoseconds())
 }

--- a/aggregator/map.go
+++ b/aggregator/map.go
@@ -159,7 +159,7 @@ func (m *metricMap) AddUntimed(
 }
 
 func (m *metricMap) AddForwarded(
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error {
 	key := entryKey{

--- a/aggregator/map_test.go
+++ b/aggregator/map_test.go
@@ -266,11 +266,11 @@ func TestMetricMapAddForwardedNoRateLimit(t *testing.T) {
 	m := newMetricMap(testShard, opts)
 
 	// Add a counter metric and assert there is one entry afterwards.
-	am := aggregated.Metric{
+	am := aggregated.ForwardedMetric{
 		Type:      metric.CounterType,
 		ID:        []byte("aggregatedMetric"),
 		TimeNanos: 12345,
-		Value:     76109,
+		Values:    []float64{76109},
 	}
 	key := entryKey{
 		metricCategory: forwardedMetric,
@@ -321,11 +321,11 @@ func TestMetricMapAddForwardedNoRateLimit(t *testing.T) {
 	require.False(t, e1 == e2)
 
 	// Add a metric with different type and assert a new entry is added.
-	metricWithDifferentType := aggregated.Metric{
+	metricWithDifferentType := aggregated.ForwardedMetric{
 		Type:      metric.GaugeType,
 		ID:        am.ID,
 		TimeNanos: 1234,
-		Value:     123.456,
+		Values:    []float64{123.456},
 	}
 	key3 := entryKey{
 		metricCategory: forwardedMetric,
@@ -341,11 +341,11 @@ func TestMetricMapAddForwardedNoRateLimit(t *testing.T) {
 	require.False(t, e1 == e3)
 
 	// Add a metric with a different id and assert a new entry is added.
-	metricWithDifferentID := aggregated.Metric{
+	metricWithDifferentID := aggregated.ForwardedMetric{
 		Type:      metric.GaugeType,
 		ID:        []byte("metricWithDifferentID"),
 		TimeNanos: 1234,
-		Value:     123.456,
+		Values:    []float64{123.456},
 	}
 	key4 := entryKey{
 		metricCategory: forwardedMetric,

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -47,7 +47,6 @@ var (
 	defaultEntryCheckBatchPercent    = 0.01
 	defaultMaxTimerBatchSizePerWrite = 0
 	defaultMaxNumCachedSourceSets    = 2
-	defaultMaxCachedSourceSetSize    = 128 * 1024
 	defaultResignTimeout             = 5 * time.Minute
 	defaultDefaultStoragePolicies    = []policy.StoragePolicy{
 		policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*24*time.Hour),
@@ -243,12 +242,6 @@ type Options interface {
 	// MaxNumCachedSourceSets returns the maximum number of cached source sets.
 	MaxNumCachedSourceSets() int
 
-	// SetMaxCachedSourceSetSize sets the maximum size of the cached source set.
-	SetMaxCachedSourceSetSize(value int) Options
-
-	// MaxCachedSourceSetSize returns the maximum size of the cached source set.
-	MaxCachedSourceSetSize() int
-
 	// SetEntryPool sets the entry pool.
 	SetEntryPool(value EntryPool) Options
 
@@ -314,7 +307,6 @@ type options struct {
 	resignTimeout                    time.Duration
 	maxAllowedForwardingDelayFn      MaxAllowedForwardingDelayFn
 	maxNumCachedSourceSets           int
-	maxCachedSourceSetSize           int
 	entryPool                        EntryPool
 	counterElemPool                  CounterElemPool
 	timerElemPool                    TimerElemPool
@@ -355,7 +347,6 @@ func NewOptions() Options {
 		resignTimeout:                    defaultResignTimeout,
 		maxAllowedForwardingDelayFn:      defaultMaxAllowedForwardingDelayFn,
 		maxNumCachedSourceSets:           defaultMaxNumCachedSourceSets,
-		maxCachedSourceSetSize:           defaultMaxCachedSourceSetSize,
 	}
 
 	// Initialize pools.
@@ -639,16 +630,6 @@ func (o *options) SetMaxNumCachedSourceSets(value int) Options {
 
 func (o *options) MaxNumCachedSourceSets() int {
 	return o.maxNumCachedSourceSets
-}
-
-func (o *options) SetMaxCachedSourceSetSize(value int) Options {
-	opts := *o
-	opts.maxCachedSourceSetSize = value
-	return &opts
-}
-
-func (o *options) MaxCachedSourceSetSize() int {
-	return o.maxCachedSourceSetSize
 }
 
 func (o *options) SetEntryPool(value EntryPool) Options {

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -188,12 +188,6 @@ func TestSetMaxNumCachedSourceSets(t *testing.T) {
 	require.Equal(t, value, o.MaxNumCachedSourceSets())
 }
 
-func TestSetMaxCachedSourceSetSize(t *testing.T) {
-	value := 100000
-	o := NewOptions().SetMaxCachedSourceSetSize(value)
-	require.Equal(t, value, o.MaxCachedSourceSetSize())
-}
-
 func TestSetCounterElemPool(t *testing.T) {
 	value := NewCounterElemPool(nil)
 	o := NewOptions().SetCounterElemPool(value)

--- a/aggregator/shard.go
+++ b/aggregator/shard.go
@@ -46,7 +46,7 @@ type addUntimedFn func(
 ) error
 
 type addForwardedFn func(
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error
 
@@ -165,7 +165,7 @@ func (s *aggregatorShard) AddUntimed(
 }
 
 func (s *aggregatorShard) AddForwarded(
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error {
 	s.RLock()

--- a/aggregator/shard_test.go
+++ b/aggregator/shard_test.go
@@ -202,11 +202,11 @@ func TestAggregatorShardAddForwardedSuccess(t *testing.T) {
 	require.Equal(t, testShard, shard.ID())
 
 	var (
-		resultMetric   aggregated.Metric
+		resultMetric   aggregated.ForwardedMetric
 		resultMetadata metadata.ForwardMetadata
 	)
 	shard.addForwardedFn = func(
-		metric aggregated.Metric,
+		metric aggregated.ForwardedMetric,
 		metadata metadata.ForwardMetadata,
 	) error {
 		resultMetric = metric

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -31,13 +31,7 @@ import (
 
 	"time"
 
-	"github.com/m3db/m3aggregator/hash"
-
 	maggregation "github.com/m3db/m3metrics/aggregation"
-
-	"github.com/m3db/m3metrics/metadata"
-
-	"github.com/m3db/m3metrics/metric/aggregated"
 
 	"github.com/m3db/m3metrics/metric/id"
 
@@ -48,13 +42,15 @@ import (
 	"github.com/m3db/m3metrics/policy"
 
 	"github.com/m3db/m3metrics/transformation"
+
+	"github.com/willf/bitset"
 )
 
 type lockedTimerAggregation struct {
 	sync.Mutex
 
 	closed      bool
-	sourcesSeen sourceSet
+	sourcesSeen *bitset.BitSet
 	aggregation timerAggregation
 }
 
@@ -168,7 +164,7 @@ func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) e
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
-func (e *TimerElem) AddUnique(timestamp time.Time, value float64, sourceID []byte) error {
+func (e *TimerElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
 	if err != nil {
@@ -179,13 +175,15 @@ func (e *TimerElem) AddUnique(timestamp time.Time, value float64, sourceID []byt
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	sourceHash := hash.Murmur3Hash128(sourceID)
-	if v, exists := lockedAgg.sourcesSeen[sourceHash]; exists && v == alignedStart {
+	source := uint(sourceID)
+	if lockedAgg.sourcesSeen.Test(source) {
 		lockedAgg.Unlock()
 		return errDuplicateForwardingSource
 	}
-	lockedAgg.sourcesSeen[sourceHash] = alignedStart
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.sourcesSeen.Set(source)
+	for _, v := range values {
+		lockedAgg.aggregation.Add(v)
+	}
 	lockedAgg.Unlock()
 	return nil
 }
@@ -201,6 +199,7 @@ func (e *TimerElem) Consume(
 	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
+	onForwardedFlushedFn onForwardingElemFlushedFn,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	e.Lock()
@@ -240,25 +239,22 @@ func (e *TimerElem) Consume(
 		e.toConsume[i].lockedAgg.closed = true
 		e.toConsume[i].lockedAgg.aggregation.Close()
 		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			sourceSetSize := len(e.toConsume[i].lockedAgg.sourcesSeen)
-			// If the source set we are about to cache is too big (i.e., bigger than the
-			// configured max size), we do not want to retain it and instead simply discard it.
-			// This is useful if say over the course of a month the metric IDs producing
-			// the forward metric ID have changed significantly so there are a lot of stale
-			// IDs in the map so we regenerate the map once in a while to refresh the map.
-			if sourceSetSize <= e.opts.MaxCachedSourceSetSize() {
-				e.cachedSourceSetsLock.Lock()
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-				}
-				e.cachedSourceSetsLock.Unlock()
+			e.cachedSourceSetsLock.Lock()
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
 			}
+			e.cachedSourceSetsLock.Unlock()
 			e.toConsume[i].lockedAgg.sourcesSeen = nil
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
+	}
+
+	if e.parsedPipeline.HasRollup {
+		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -274,8 +270,15 @@ func (e *TimerElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
+	e.writeForwardedFn = nil
+	e.onForwardedWrittenFn = nil
+	for idx := range e.cachedSourceSets {
+		e.cachedSourceSets[idx] = nil
+	}
+	e.cachedSourceSets = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
+		e.values[idx].lockedAgg.sourcesSeen = nil
 		e.values[idx].lockedAgg.aggregation.Close()
 		e.values[idx].Reset()
 	}
@@ -329,15 +332,16 @@ func (e *TimerElem) findOrCreate(
 	e.values = append(e.values, timedTimer{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen sourceSet
+	var sourcesSeen *bitset.BitSet
 	if createOpts.initSourceSet {
 		e.cachedSourceSetsLock.Lock()
 		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
 			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
 			e.cachedSourceSets[numCachedSourceSets-1] = nil
 			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
+			sourcesSeen.ClearAll()
 		} else {
-			sourcesSeen = make(sourceSet, defaultNumSources)
+			sourcesSeen = bitset.New(defaultNumSources)
 		}
 		e.cachedSourceSetsLock.Unlock()
 	}
@@ -417,20 +421,8 @@ func (e *TimerElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
-			fm := aggregated.Metric{
-				Type:      e.Type(),
-				ID:        e.parsedPipeline.Rollup.ID,
-				TimeNanos: timeNanos,
-				Value:     value,
-			}
-			meta := metadata.ForwardMetadata{
-				AggregationID:     e.parsedPipeline.Rollup.AggregationID,
-				StoragePolicy:     e.sp,
-				Pipeline:          e.parsedPipeline.Remainder,
-				SourceID:          []byte(e.id),
-				NumForwardedTimes: e.numForwardedTimes + 1,
-			}
-			flushForwardedFn(fm, meta)
+			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -254,7 +254,7 @@ func (e *TimerElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedWrittenFn, forwardedAggregationKey)
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
 
 	return canCollect
@@ -270,8 +270,8 @@ func (e *TimerElem) Close() {
 	e.closed = true
 	e.id = nil
 	e.parsedPipeline = parsedPipeline{}
-	e.writeForwardedFn = nil
-	e.onForwardedWrittenFn = nil
+	e.writeForwardedMetricFn = nil
+	e.onForwardedAggregationWrittenFn = nil
 	for idx := range e.cachedSourceSets {
 		e.cachedSourceSets[idx] = nil
 	}
@@ -422,7 +422,7 @@ func (e *TimerElem) processValueWithAggregationLock(
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-			flushForwardedFn(e.writeForwardedFn, forwardedAggregationKey, timeNanos, value)
+			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos

--- a/client/client.go
+++ b/client/client.go
@@ -84,7 +84,7 @@ type AdminClient interface {
 
 	// WriteForwarded writes forwarded metrics.
 	WriteForwarded(
-		metric aggregated.Metric,
+		metric aggregated.ForwardedMetric,
 		metadata metadata.ForwardMetadata,
 	) error
 }
@@ -234,7 +234,7 @@ func (c *client) WriteUntimedGauge(
 }
 
 func (c *client) WriteForwarded(
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error {
 	callStart := c.nowFn()

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -163,7 +163,7 @@ func (_mr *_MockAdminClientRecorder) Init() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Init")
 }
 
-func (_m *MockAdminClient) WriteForwarded(_param0 aggregated.Metric, _param1 metadata.ForwardMetadata) error {
+func (_m *MockAdminClient) WriteForwarded(_param0 aggregated.ForwardedMetric, _param1 metadata.ForwardMetadata) error {
 	ret := _m.ctrl.Call(_m, "WriteForwarded", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -64,11 +64,11 @@ var (
 		ID:       []byte("foo"),
 		GaugeVal: 123.456,
 	}
-	testForwarded = aggregated.Metric{
+	testForwarded = aggregated.ForwardedMetric{
 		Type:      metric.CounterType,
 		ID:        []byte("testForwarded"),
 		TimeNanos: 1234,
-		Value:     34567,
+		Values:    []float64{34567, 256, 178},
 	}
 	testStagedMetadatas = metadata.StagedMetadatas{
 		{
@@ -114,7 +114,7 @@ var (
 				},
 			},
 		}),
-		SourceID:          []byte("testForwardSource"),
+		SourceID:          1234,
 		NumForwardedTimes: 3,
 	}
 	testPlacementInstances = []placement.Instance{

--- a/client/payload.go
+++ b/client/payload.go
@@ -41,7 +41,7 @@ type untimedPayload struct {
 }
 
 type forwardedPayload struct {
-	metric   aggregated.Metric
+	metric   aggregated.ForwardedMetric
 	metadata metadata.ForwardMetadata
 }
 

--- a/client/writer.go
+++ b/client/writer.go
@@ -296,16 +296,16 @@ func (w *writer) encodeUntimedWithLock(
 
 func (w *writer) encodeForwardedWithLock(
 	encoder *lockedEncoder,
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error {
 	encoder.Lock()
 
 	sizeBefore := encoder.Len()
 	msg := encoding.UnaggregatedMessageUnion{
-		Type: encoding.TimedMetricWithForwardMetadataType,
-		TimedMetricWithForwardMetadata: aggregated.MetricWithForwardMetadata{
-			Metric:          metric,
+		Type: encoding.ForwardedMetricWithMetadataType,
+		ForwardedMetricWithMetadata: aggregated.ForwardedMetricWithMetadata{
+			ForwardedMetric: metric,
 			ForwardMetadata: metadata,
 		}}
 	if err := encoder.EncodeMessage(msg); err != nil {

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -246,6 +246,7 @@ aggregator:
   defaultStoragePolicies:
     - 10s:2d
     - 1m:40d
+  maxNumCachedSourceSets: 2
   entryPool:
     size: 4096
   counterElemPool:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f54959f5e8c40a774a279d20b9f1149f2b33d4527c83a4de1591c5db7bb949fa
-updated: 2018-06-25T15:28:11.073503-04:00
+hash: 8bb5e23d2c53c338f5d941109855a6177db477546efe68a70f6bece46a69e030
+updated: 2018-06-26T00:05:55.628068-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -186,7 +186,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: 3b2957921f0d4167eecd26346a48cf762fbe3d3d
+  version: ac91954dd6da2f982d0a44521f4a84448c2cd110
   subpackages:
   - aggregation
   - encoding
@@ -349,6 +349,8 @@ imports:
   - trace
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  subpackages:
+  - unix
 - name: golang.org/x/text
   version: 4ee4af566555f5fbe026368b75596286a312663a
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   version: 746eac23a65f8901c29910d74f1644f2be89dae3
 
 - package: github.com/m3db/m3metrics
-  version: 3b2957921f0d4167eecd26346a48cf762fbe3d3d
+  version: ac91954dd6da2f982d0a44521f4a84448c2cd110
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/integration/client.go
+++ b/integration/client.go
@@ -160,13 +160,13 @@ func (c *client) writeUntimedMetricWithMetadatas(
 }
 
 func (c *client) writeForwardedMetricWithMetadata(
-	metric aggregated.Metric,
+	metric aggregated.ForwardedMetric,
 	metadata metadata.ForwardMetadata,
 ) error {
 	msg := encoding.UnaggregatedMessageUnion{
-		Type: encoding.TimedMetricWithForwardMetadataType,
-		TimedMetricWithForwardMetadata: aggregated.MetricWithForwardMetadata{
-			Metric:          metric,
+		Type: encoding.ForwardedMetricWithMetadataType,
+		ForwardedMetricWithMetadata: aggregated.ForwardedMetricWithMetadata{
+			ForwardedMetric: metric,
 			ForwardMetadata: metadata,
 		},
 	}

--- a/integration/multi_server_forwarding_pipeline_test.go
+++ b/integration/multi_server_forwarding_pipeline_test.go
@@ -217,7 +217,7 @@ func TestMultiServerForwardingPipeline(t *testing.T) {
 
 	var (
 		idPrefix      = "foo"
-		numIDs        = 2
+		numIDs        = 100
 		start         = getNowFn()
 		stop          = start.Add(10 * time.Second)
 		interval      = time.Second

--- a/integration/multi_server_forwarding_pipeline_test.go
+++ b/integration/multi_server_forwarding_pipeline_test.go
@@ -193,7 +193,9 @@ func TestMultiServerForwardingPipeline(t *testing.T) {
 		leaders    = make(map[int]struct{})
 		leaderCh   = make(chan int, len(servers)/2)
 		numLeaders int32
+		wg         sync.WaitGroup
 	)
+	wg.Add(len(servers) / 2)
 	for i, server := range servers {
 		i, server := i, server
 		go func() {
@@ -201,13 +203,13 @@ func TestMultiServerForwardingPipeline(t *testing.T) {
 				res := int(atomic.AddInt32(&numLeaders, 1))
 				if res <= len(servers)/2 {
 					leaderCh <- i
-				}
-				if res == len(servers)/2 {
-					close(leaderCh)
+					wg.Done()
 				}
 			}
 		}()
 	}
+	wg.Wait()
+	close(leaderCh)
 
 	for i := range leaderCh {
 		leaders[i] = struct{}{}

--- a/integration/one_client_multi_type_forwarded_test.go
+++ b/integration/one_client_multi_type_forwarded_test.go
@@ -23,7 +23,6 @@
 package integration
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -107,7 +106,7 @@ func TestOneClientMultiTypeForwardedMetrics(t *testing.T) {
 	}
 	metadataFn := func(idx int) metadataUnion {
 		forwardMetadata := testForwardMetadataTemplate
-		forwardMetadata.SourceID = []byte(fmt.Sprintf("%d", idx))
+		forwardMetadata.SourceID = uint32(idx)
 		return metadataUnion{
 			mType:           forwardMetadataType,
 			forwardMetadata: forwardMetadata,

--- a/server/rawtcp/server.go
+++ b/server/rawtcp/server.go
@@ -124,7 +124,7 @@ func (s *handler) Handle(conn net.Conn) {
 	var (
 		untimedMetric   unaggregated.MetricUnion
 		stagedMetadatas metadata.StagedMetadatas
-		forwardedMetric aggregated.Metric
+		forwardedMetric aggregated.ForwardedMetric
 		forwardMetadata metadata.ForwardMetadata
 		err             error
 	)
@@ -143,9 +143,9 @@ func (s *handler) Handle(conn net.Conn) {
 			untimedMetric = current.GaugeWithMetadatas.Gauge.ToUnion()
 			stagedMetadatas = current.GaugeWithMetadatas.StagedMetadatas
 			err = toAddUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
-		case encoding.TimedMetricWithForwardMetadataType:
-			forwardedMetric = current.TimedMetricWithForwardMetadata.Metric
-			forwardMetadata = current.TimedMetricWithForwardMetadata.ForwardMetadata
+		case encoding.ForwardedMetricWithMetadataType:
+			forwardedMetric = current.ForwardedMetricWithMetadata.ForwardedMetric
+			forwardMetadata = current.ForwardedMetricWithMetadata.ForwardMetadata
 			err = toAddForwardedError(s.aggregator.AddForwarded(forwardedMetric, forwardMetadata))
 		default:
 			err = newUnknownMessageTypeError(current.Type)
@@ -183,7 +183,7 @@ func (s *handler) Handle(conn net.Conn) {
 				log.NewField("remoteAddress", remoteAddress),
 				log.NewField("id", forwardedMetric.ID.String()),
 				log.NewField("timestamp", time.Unix(0, forwardedMetric.TimeNanos).String()),
-				log.NewField("value", forwardedMetric.Value),
+				log.NewField("values", forwardedMetric.Values),
 				log.NewErrField(err),
 			).Error("error adding forwarded metric")
 		default:

--- a/server/rawtcp/server_test.go
+++ b/server/rawtcp/server_test.go
@@ -68,11 +68,11 @@ var (
 		ID:       []byte("testGauge"),
 		GaugeVal: 456.780,
 	}
-	testForwarded = aggregated.Metric{
+	testForwarded = aggregated.ForwardedMetric{
 		Type:      metric.CounterType,
 		ID:        []byte("testForwarded"),
 		TimeNanos: 12345,
-		Value:     908,
+		Values:    []float64{908, -13},
 	}
 	testDefaultPoliciesList = policy.DefaultPoliciesList
 	testCustomPoliciesList  = policy.PoliciesList{
@@ -122,7 +122,7 @@ var (
 				},
 			},
 		}),
-		SourceID:          []byte("testForwardSource"),
+		SourceID:          1234,
 		NumForwardedTimes: 3,
 	}
 	testCounterWithPoliciesList = unaggregated.CounterWithPoliciesList{
@@ -149,8 +149,8 @@ var (
 		Gauge:           testGauge.Gauge(),
 		StagedMetadatas: testDefaultMetadatas,
 	}
-	testMetricWithForwardMetadata = aggregated.MetricWithForwardMetadata{
-		Metric:          testForwarded,
+	testForwardedMetricWithMetadata = aggregated.ForwardedMetricWithMetadata{
+		ForwardedMetric: testForwarded,
 		ForwardMetadata: testForwardMetadata,
 	}
 	testCmpOpts = []cmp.Option{
@@ -209,7 +209,7 @@ func testRawTCPServerHandleUnaggregated(
 
 		protocol := protocolSelector(i)
 		if protocol == protobufEncoding {
-			expectedResult.MetricsWithForwardMetadata = append(expectedResult.MetricsWithForwardMetadata, testMetricWithForwardMetadata)
+			expectedResult.ForwardedMetricsWithMetadata = append(expectedResult.ForwardedMetricsWithMetadata, testForwardedMetricWithMetadata)
 			expectedTotalMetrics += 4
 		} else {
 			expectedTotalMetrics += 3
@@ -244,8 +244,8 @@ func testRawTCPServerHandleUnaggregated(
 					GaugeWithMetadatas: testGaugeWithMetadatas,
 				}))
 				require.NoError(t, encoder.EncodeMessage(encoding.UnaggregatedMessageUnion{
-					Type: encoding.TimedMetricWithForwardMetadataType,
-					TimedMetricWithForwardMetadata: testMetricWithForwardMetadata,
+					Type: encoding.ForwardedMetricWithMetadataType,
+					ForwardedMetricWithMetadata: testForwardedMetricWithMetadata,
 				}))
 				buf := encoder.Relinquish()
 				stream = buf.Bytes()

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -125,9 +125,6 @@ type AggregatorConfiguration struct {
 	// Maximum number of cached source sets.
 	MaxNumCachedSourceSets *int `yaml:"maxNumCachedSourceSets"`
 
-	// Maximum size of the cached source set.
-	MaxCachedSourceSetSize *int `yaml:"maxCachedSourceSetSize"`
-
 	// Pool of counter elements.
 	CounterElemPool pool.ObjectPoolConfiguration `yaml:"counterElemPool"`
 
@@ -298,9 +295,6 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	// Set cached source sets options.
 	if c.MaxNumCachedSourceSets != nil {
 		opts = opts.SetMaxNumCachedSourceSets(*c.MaxNumCachedSourceSets)
-	}
-	if c.MaxCachedSourceSetSize != nil {
-		opts = opts.SetMaxCachedSourceSetSize(*c.MaxCachedSourceSetSize)
 	}
 
 	// Set counter elem pool.


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR changes how forwarded metrics are written to ensure that if there are multiple metrics in the same shard that produce the same forwarded metric, the forwarded metric values are accumulated internally and only flushed as one batch after all source metrics have been processed during each flush. This is so that each batch is uniquely associated with the shard on the destination server where the forwarded metric is stored, and as such the shard can be used as the source id for deduplication during a leader re-election, leading to significant memory efficiency improvement. 

Compared to the existing approach that uses the metric ID as the source id, this approach significantly reduces the amount of memory required for computing forwarded metrics. In the worst case, each aggregation window requires ~512 bytes to keep track of the shards assuming a 4K shard setup on the server where the forwarded metric lives, whereas the current approach requires a memory size that's proportional to the number of IDs being rolled up into the forwarded metric to track the source IDs. For example, this would require at least 50K x 200 = 10MB for each aggregation window to store the source metric IDs in a map for rolling up 50K metric IDs into a forwarded metric. 