### PR TITLE
Do not flush NaN values downstream optionally

### DIFF
--- a/aggregator/elem_test.go
+++ b/aggregator/elem_test.go
@@ -485,7 +485,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Sum}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions()
+	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
 	e := testCounterElem(alignedstartAtNanos[:3], counterVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -983,7 +983,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Min}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions()
+	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
 	e := testTimerElem(alignedstartAtNanos[:3], timerVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -1526,7 +1526,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Last}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions()
+	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
 	e := testGaugeElem(alignedstartAtNanos[:3], gaugeVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -27,6 +27,8 @@ package aggregator
 import (
 	"fmt"
 
+	"math"
+
 	"sync"
 
 	"time"
@@ -393,8 +395,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
-		fullPrefix      = e.FullPrefix(e.opts)
-		transformations = e.parsedPipeline.Transformations
+		fullPrefix       = e.FullPrefix(e.opts)
+		transformations  = e.parsedPipeline.Transformations
+		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
 		value := lockedAgg.aggregation.ValueOf(aggType)
@@ -417,7 +420,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 				value = res.Value
 			}
 		}
-		// Do we need to flush or forward NaNs?
+		if discardNaNValues && math.IsNaN(value) {
+			continue
+		}
 		if !e.parsedPipeline.HasRollup {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -38,17 +38,18 @@ import (
 )
 
 var (
-	defaultMetricPrefix              = []byte("stats.")
-	defaultCounterPrefix             = []byte("counts.")
-	defaultTimerPrefix               = []byte("timers.")
-	defaultGaugePrefix               = []byte("gauges.")
-	defaultEntryTTL                  = 24 * time.Hour
-	defaultEntryCheckInterval        = time.Hour
-	defaultEntryCheckBatchPercent    = 0.01
-	defaultMaxTimerBatchSizePerWrite = 0
-	defaultMaxNumCachedSourceSets    = 2
-	defaultResignTimeout             = 5 * time.Minute
-	defaultDefaultStoragePolicies    = []policy.StoragePolicy{
+	defaultMetricPrefix               = []byte("stats.")
+	defaultCounterPrefix              = []byte("counts.")
+	defaultTimerPrefix                = []byte("timers.")
+	defaultGaugePrefix                = []byte("gauges.")
+	defaultEntryTTL                   = 24 * time.Hour
+	defaultEntryCheckInterval         = time.Hour
+	defaultEntryCheckBatchPercent     = 0.01
+	defaultMaxTimerBatchSizePerWrite  = 0
+	defaultMaxNumCachedSourceSets     = 2
+	defaultDiscardNaNAggregatedValues = true
+	defaultResignTimeout              = 5 * time.Minute
+	defaultDefaultStoragePolicies     = []policy.StoragePolicy{
 		policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*24*time.Hour),
 		policy.NewStoragePolicy(time.Minute, xtime.Minute, 40*24*time.Hour),
 	}
@@ -242,6 +243,12 @@ type Options interface {
 	// MaxNumCachedSourceSets returns the maximum number of cached source sets.
 	MaxNumCachedSourceSets() int
 
+	// SetDiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
+	SetDiscardNaNAggregatedValues(value bool) Options
+
+	// DiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
+	DiscardNaNAggregatedValues() bool
+
 	// SetEntryPool sets the entry pool.
 	SetEntryPool(value EntryPool) Options
 
@@ -307,6 +314,7 @@ type options struct {
 	resignTimeout                    time.Duration
 	maxAllowedForwardingDelayFn      MaxAllowedForwardingDelayFn
 	maxNumCachedSourceSets           int
+	discardNaNAggregatedValues       bool
 	entryPool                        EntryPool
 	counterElemPool                  CounterElemPool
 	timerElemPool                    TimerElemPool
@@ -347,6 +355,7 @@ func NewOptions() Options {
 		resignTimeout:                    defaultResignTimeout,
 		maxAllowedForwardingDelayFn:      defaultMaxAllowedForwardingDelayFn,
 		maxNumCachedSourceSets:           defaultMaxNumCachedSourceSets,
+		discardNaNAggregatedValues:       defaultDiscardNaNAggregatedValues,
 	}
 
 	// Initialize pools.
@@ -630,6 +639,16 @@ func (o *options) SetMaxNumCachedSourceSets(value int) Options {
 
 func (o *options) MaxNumCachedSourceSets() int {
 	return o.maxNumCachedSourceSets
+}
+
+func (o *options) SetDiscardNaNAggregatedValues(value bool) Options {
+	opts := *o
+	opts.discardNaNAggregatedValues = value
+	return &opts
+}
+
+func (o *options) DiscardNaNAggregatedValues() bool {
+	return o.discardNaNAggregatedValues
 }
 
 func (o *options) SetEntryPool(value EntryPool) Options {

--- a/aggregator/options_test.go
+++ b/aggregator/options_test.go
@@ -188,6 +188,12 @@ func TestSetMaxNumCachedSourceSets(t *testing.T) {
 	require.Equal(t, value, o.MaxNumCachedSourceSets())
 }
 
+func TestSetDiscardNaNAggregatedValues(t *testing.T) {
+	value := false
+	o := NewOptions().SetDiscardNaNAggregatedValues(value)
+	require.Equal(t, value, o.DiscardNaNAggregatedValues())
+}
+
 func TestSetCounterElemPool(t *testing.T) {
 	value := NewCounterElemPool(nil)
 	o := NewOptions().SetCounterElemPool(value)

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -27,6 +27,8 @@ package aggregator
 import (
 	"fmt"
 
+	"math"
+
 	"sync"
 
 	"time"
@@ -393,8 +395,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
-		fullPrefix      = e.FullPrefix(e.opts)
-		transformations = e.parsedPipeline.Transformations
+		fullPrefix       = e.FullPrefix(e.opts)
+		transformations  = e.parsedPipeline.Transformations
+		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
 		value := lockedAgg.aggregation.ValueOf(aggType)
@@ -417,7 +420,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 				value = res.Value
 			}
 		}
-		// Do we need to flush or forward NaNs?
+		if discardNaNValues && math.IsNaN(value) {
+			continue
+		}
 		if !e.parsedPipeline.HasRollup {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {

--- a/config/m3aggregator.yaml
+++ b/config/m3aggregator.yaml
@@ -247,6 +247,7 @@ aggregator:
     - 10s:2d
     - 1m:40d
   maxNumCachedSourceSets: 2
+  discardNaNAggregatedValues: true
   entryPool:
     size: 4096
   counterElemPool:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d7a40ef10ed1524bd5e532436af5cb0d365491524d812e52a999b5aeff6a84de
-updated: 2018-07-03T09:21:58.509716-04:00
+hash: 5b4baf063ec3de2ee38af1a947cbe58da95c8b6b4a10403d808c41e5b397195a
+updated: 2018-07-05T22:36:18.471062-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -186,7 +186,7 @@ imports:
   - services/leader/election
   - shard
 - name: github.com/m3db/m3metrics
-  version: e39b708273b5091efe546d871e983fb456ad5ee7
+  version: d92603d5788a2012ecfc3f0161deab37462928f8
   subpackages:
   - aggregation
   - encoding
@@ -323,7 +323,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: eeedf312bc6c57391d84767a4cd413f02a917974
+  version: 7e7e266a8dbce911a49554b945538c5b950196b8
   subpackages:
   - buffer
   - internal/bufferpool
@@ -408,7 +408,7 @@ imports:
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/leanovate/gopter
-  version: 7464b68a2409c0e6c6986805c808ca767f3c0054
+  version: 648a4745d07aa9babe7f460c0a0fc09e70562ca4
   subpackages:
   - gen
   - prop

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   version: 746eac23a65f8901c29910d74f1644f2be89dae3
 
 - package: github.com/m3db/m3metrics
-  version: e39b708273b5091efe546d871e983fb456ad5ee7
+  version: d92603d5788a2012ecfc3f0161deab37462928f8
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/integration/options.go
+++ b/integration/options.go
@@ -47,6 +47,7 @@ const (
 	defaultElectionStateChangeTimeout = 10 * time.Second
 	defaultEntryCheckInterval         = time.Second
 	defaultJitterEnabled              = true
+	defaultDiscardNaNAggregatedValues = true
 )
 
 type testServerOptions interface {
@@ -181,6 +182,12 @@ type testServerOptions interface {
 
 	// MaxAllowedForwardingDelayFn returns the maximum allowed forwarding delay function.
 	MaxAllowedForwardingDelayFn() aggregator.MaxAllowedForwardingDelayFn
+
+	// SetDiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
+	SetDiscardNaNAggregatedValues(value bool) testServerOptions
+
+	// DiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
+	DiscardNaNAggregatedValues() bool
 }
 
 type serverOptions struct {
@@ -206,6 +213,7 @@ type serverOptions struct {
 	jitterEnabled               bool
 	maxJitterFn                 aggregator.FlushJitterFn
 	maxAllowedForwardingDelayFn aggregator.MaxAllowedForwardingDelayFn
+	discardNaNAggregatedValues  bool
 }
 
 func newTestServerOptions() testServerOptions {
@@ -235,6 +243,7 @@ func newTestServerOptions() testServerOptions {
 		entryCheckInterval:          defaultEntryCheckInterval,
 		maxJitterFn:                 defaultMaxJitterFn,
 		maxAllowedForwardingDelayFn: defaultMaxAllowedForwardingDelayFn,
+		discardNaNAggregatedValues:  defaultDiscardNaNAggregatedValues,
 	}
 }
 
@@ -456,6 +465,16 @@ func (o *serverOptions) SetMaxAllowedForwardingDelayFn(value aggregator.MaxAllow
 
 func (o *serverOptions) MaxAllowedForwardingDelayFn() aggregator.MaxAllowedForwardingDelayFn {
 	return o.maxAllowedForwardingDelayFn
+}
+
+func (o *serverOptions) SetDiscardNaNAggregatedValues(value bool) testServerOptions {
+	opts := *o
+	opts.discardNaNAggregatedValues = value
+	return &opts
+}
+
+func (o *serverOptions) DiscardNaNAggregatedValues() bool {
+	return o.discardNaNAggregatedValues
 }
 
 func defaultMaxJitterFn(interval time.Duration) time.Duration {

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -95,7 +95,8 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 		SetInstrumentOptions(opts.InstrumentOptions()).
 		SetAggregationTypesOptions(opts.AggregationTypesOptions()).
 		SetEntryCheckInterval(opts.EntryCheckInterval()).
-		SetMaxAllowedForwardingDelayFn(opts.MaxAllowedForwardingDelayFn())
+		SetMaxAllowedForwardingDelayFn(opts.MaxAllowedForwardingDelayFn()).
+		SetDiscardNaNAggregatedValues(opts.DiscardNaNAggregatedValues())
 
 	// Set up placement manager.
 	placementWatcherOpts := placement.NewStagedPlacementWatcherOptions().

--- a/services/m3aggregator/config/aggregator.go
+++ b/services/m3aggregator/config/aggregator.go
@@ -125,6 +125,9 @@ type AggregatorConfiguration struct {
 	// Maximum number of cached source sets.
 	MaxNumCachedSourceSets *int `yaml:"maxNumCachedSourceSets"`
 
+	// Whether to discard NaN aggregated values.
+	DiscardNaNAggregatedValues *bool `yaml:"discardNaNAggregatedValues"`
+
 	// Pool of counter elements.
 	CounterElemPool pool.ObjectPoolConfiguration `yaml:"counterElemPool"`
 
@@ -295,6 +298,11 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	// Set cached source sets options.
 	if c.MaxNumCachedSourceSets != nil {
 		opts = opts.SetMaxNumCachedSourceSets(*c.MaxNumCachedSourceSets)
+	}
+
+	// Set whether to discard NaN aggregated values.
+	if c.DiscardNaNAggregatedValues != nil {
+		opts = opts.SetDiscardNaNAggregatedValues(*c.DiscardNaNAggregatedValues)
 	}
 
 	// Set counter elem pool.


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR provides the logic to optionally discard NaN aggregated values and do not forward them to other servers for further aggregation or flush them to downstream services for indexing and storage.

Forwarding NaN values to other aggregation servers as part of the rollup pipeline will lead to NaN rollup metric values, which are currently treated as no datapoints in our query engine and therefore cause the entire rollup metric value to go "missing". Instead, we can optionally drop NaN values at the source so the multi-level rollup metrics are not affected as long as the remaining constituent metric values are non-NaN values. 