### PR TITLE
Add metric for empty metadata and no applicable metadata

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -585,6 +585,8 @@ type aggregatorAddMetricMetrics struct {
 	shardNotWriteable          tally.Counter
 	valueRateLimitExceeded     tally.Counter
 	newMetricRateLimitExceeded tally.Counter
+	noApplicableMetadata       tally.Counter
+	emptyMetadatas             tally.Counter
 	uncategorizedErrors        tally.Counter
 }
 
@@ -606,6 +608,12 @@ func newAggregatorAddMetricMetrics(
 		}).Counter("errors"),
 		newMetricRateLimitExceeded: scope.Tagged(map[string]string{
 			"reason": "new-metric-rate-limit-exceeded",
+		}).Counter("errors"),
+		noApplicableMetadata: scope.Tagged(map[string]string{
+			"reason": "no-applicable-metadata",
+		}).Counter("errors"),
+		emptyMetadatas: scope.Tagged(map[string]string{
+			"reason": "empty-metadatas",
 		}).Counter("errors"),
 		uncategorizedErrors: scope.Tagged(map[string]string{
 			"reason": "not-categorized",
@@ -631,6 +639,10 @@ func (m *aggregatorAddMetricMetrics) ReportError(err error) {
 		m.newMetricRateLimitExceeded.Inc(1)
 	case errWriteValueRateLimitExceeded:
 		m.valueRateLimitExceeded.Inc(1)
+	case errNoApplicableMetadata:
+		m.noApplicableMetadata.Inc(1)
+	case errEmptyMetadatas:
+		m.emptyMetadatas.Inc(1)
 	default:
 		m.uncategorizedErrors.Inc(1)
 	}

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -802,13 +802,15 @@ func TestAggregatorAddMetricMetrics(t *testing.T) {
 	m.ReportError(errAggregatorShardNotWriteable)
 	m.ReportError(errWriteNewMetricRateLimitExceeded)
 	m.ReportError(errWriteValueRateLimitExceeded)
+	m.ReportError(errNoApplicableMetadata)
+	m.ReportError(errEmptyMetadatas)
 	m.ReportError(errors.New("foo"))
 
 	snapshot := s.Snapshot()
 	counters, timers, gauges := snapshot.Counters(), snapshot.Timers(), snapshot.Gauges()
 
 	// Validate we count successes and errors correctly.
-	require.Equal(t, 7, len(counters))
+	require.Equal(t, 9, len(counters))
 	for _, id := range []string{
 		"testScope.success+",
 		"testScope.errors+reason=invalid-metric-types",
@@ -816,6 +818,8 @@ func TestAggregatorAddMetricMetrics(t *testing.T) {
 		"testScope.errors+reason=shard-not-writeable",
 		"testScope.errors+reason=value-rate-limit-exceeded",
 		"testScope.errors+reason=new-metric-rate-limit-exceeded",
+		"testScope.errors+reason=no-applicable-metadata",
+		"testScope.errors+reason=empty-metadatas",
 		"testScope.errors+reason=not-categorized",
 	} {
 		c, exists := counters[id]


### PR DESCRIPTION
This commit adds new metrics for additional granularity on errors. 