### PR TITLE
Eager flushing of forwarded metrics

### DIFF
--- a/aggregator/counter_elem.gen.go
+++ b/aggregator/counter_elem.gen.go
@@ -51,9 +51,20 @@ import (
 type lockedCounterAggregation struct {
 	sync.Mutex
 
-	closed      bool
-	sourcesSeen *bitset.BitSet
-	aggregation counterAggregation
+	closed       bool
+	sourcesReady bool           // only used for elements receiving forwarded metrics
+	sourcesSet   *bitset.BitSet // only used for elements receiving forwarded metrics
+	consumeState consumeState   // only used for elements receiving forwarded metrics
+	aggregation  counterAggregation
+}
+
+func (lockedAgg *lockedCounterAggregation) close() {
+	if lockedAgg.closed {
+		return
+	}
+	lockedAgg.closed = true
+	lockedAgg.sourcesSet = nil
+	lockedAgg.aggregation.Close()
 }
 
 type timedCounter struct {
@@ -79,6 +90,7 @@ type CounterElem struct {
 
 // NewCounterElem creates a new element for the given metric type.
 func NewCounterElem(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -90,7 +102,7 @@ func NewCounterElem(
 		elemBase: newElemBase(opts),
 		values:   make([]timedCounter, 0, defaultNumAggregations), // in most cases values will have two entries
 	}
-	if err := e.ResetSetData(id, sp, aggTypes, pipeline, numForwardedTimes); err != nil {
+	if err := e.ResetSetData(incomingMetricType, id, sp, aggTypes, pipeline, numForwardedTimes); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -98,6 +110,7 @@ func NewCounterElem(
 
 // MustNewCounterElem creates a new element, or panics if the input is invalid.
 func MustNewCounterElem(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -105,7 +118,7 @@ func MustNewCounterElem(
 	numForwardedTimes int,
 	opts Options,
 ) *CounterElem {
-	elem, err := NewCounterElem(id, sp, aggTypes, pipeline, numForwardedTimes, opts)
+	elem, err := NewCounterElem(incomingMetricType, id, sp, aggTypes, pipeline, numForwardedTimes, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))
 	}
@@ -114,6 +127,7 @@ func MustNewCounterElem(
 
 // ResetSetData resets the element and sets data.
 func (e *CounterElem) ResetSetData(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -124,7 +138,7 @@ func (e *CounterElem) ResetSetData(
 	if useDefaultAggregation {
 		aggTypes = e.DefaultAggregationTypes(e.aggTypesOpts)
 	}
-	if err := e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation, pipeline, numForwardedTimes); err != nil {
+	if err := e.elemBase.resetSetData(incomingMetricType, id, sp, aggTypes, useDefaultAggregation, pipeline, numForwardedTimes); err != nil {
 		return err
 	}
 	if err := e.counterElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation); err != nil {
@@ -149,7 +163,7 @@ func (e *CounterElem) ResetSetData(
 // AddUnion adds a metric value union at a given timestamp.
 func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
-	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{})
+	lockedAgg, err := e.findOrCreate(alignedStart, sourcesOptions{})
 	if err != nil {
 		return err
 	}
@@ -166,9 +180,10 @@ func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion)
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
+// TODO(xichen): need warmpup time.
 func (e *CounterElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
-	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
+	lockedAgg, err := e.findOrCreate(alignedStart, sourcesOptions{updateSources: true, source: sourceID})
 	if err != nil {
 		return err
 	}
@@ -178,11 +193,29 @@ func (e *CounterElem) AddUnique(timestamp time.Time, values []float64, sourceID 
 		return errAggregationClosed
 	}
 	source := uint(sourceID)
-	if lockedAgg.sourcesSeen.Test(source) {
-		lockedAgg.Unlock()
-		return errDuplicateForwardingSource
+	if !lockedAgg.sourcesReady {
+		// If the sources are not ready, this is an empty source set to start with
+		// so we need to set the source. If the corresponding bit is already set,
+		// it implies a duplicate delivery from that source.
+		if lockedAgg.sourcesSet.Test(source) {
+			lockedAgg.Unlock()
+			return errDuplicateForwardingSource
+		}
+		lockedAgg.sourcesSet.Set(source)
+	} else {
+		// Otherwise, this is a pre-filled source set to start with, so we need to
+		// clear the source. If the corresponding bit is not set, it implies either
+		// a duplicate delivery from that source, or a new source that was not in
+		// the initial cloned source set.
+		if !lockedAgg.sourcesSet.Test(source) {
+			lockedAgg.Unlock()
+			return errDuplicateOrNewForwardingSource
+		}
+		lockedAgg.sourcesSet.Clear(source)
+		if lockedAgg.sourcesSet.None() {
+			lockedAgg.consumeState = readyToConsume
+		}
 	}
-	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
 		lockedAgg.aggregation.Add(v)
 	}
@@ -212,7 +245,8 @@ func (e *CounterElem) Consume(
 	idx := 0
 	for range e.values {
 		// Bail as soon as the timestamp is no later than the target time.
-		if !isEarlierThanFn(e.values[idx].startAtNanos, resolution, targetNanos) {
+		timeNanos := timestampNanosFn(e.values[idx].startAtNanos, resolution)
+		if !isEarlierThanFn(timeNanos, targetNanos) {
 			break
 		}
 		idx++
@@ -230,31 +264,56 @@ func (e *CounterElem) Consume(
 		e.values = e.values[:n]
 	}
 	canCollect := len(e.values) == 0 && e.tombstoned
+
+	// Additionally for elements receiving forwarded metrics and sending aggregated metrics
+	// to local backends, we also check if any aggregations are ready to be consumed. We however
+	// do not remove the aggregations as we do for aggregations whose timestamps are old enough,
+	// since for aggregations receiving forwarded metrics that are marked "consume ready", it is
+	// possible that metrics still go to the such aggregation bucket after they are marked "consume
+	// ready" due to delayed source re-delivery or new sources showing up, and removing such
+	// aggregation prematurely would mean the values from the delayed sources and/or new sources
+	// would be considered as the aggregated value for such aggregation bucket, which is incorrect.
+	// By keeping such aggregation buckets and only removing them when they are considered old enough
+	// (i.e., when their timestmaps are earlier than the target timestamp), we ensure no metrics may
+	// go to such aggregation buckets after they are consumed and therefore avoid the aformentioned
+	// problem.
+	aggregationIdxToCloseUntil := len(e.toConsume)
+	if e.incomingMetricType == ForwardedIncomingMetric && e.isSourcesSetReadyWithLock() {
+		e.maybeRefreshSourcesSetWithLock()
+		// We only attempt to consume if the outgoing metrics type is local instead of forwarded.
+		// This is because forwarded metrics are sent in batches and can only be sent when all sources
+		// in the same shard have been consumed, and as such is not well suited for pre-emptive consumption.
+		if e.outgoingMetricType() == localOutgoingMetric {
+			for i := 0; i < len(e.values); i++ {
+				// NB: This makes the logic easier to understand but it would be more efficient to use
+				// an atomic here to avoid locking aggregations.
+				e.values[i].lockedAgg.Lock()
+				if e.values[i].lockedAgg.consumeState == readyToConsume {
+					e.toConsume = append(e.toConsume, e.values[i])
+					e.values[i].lockedAgg.consumeState = consuming
+				}
+				e.values[i].lockedAgg.Unlock()
+			}
+		}
+	}
 	e.Unlock()
 
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
 		e.toConsume[i].lockedAgg.Lock()
-		e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
-		// Closes the aggregation object after it's processed.
-		e.toConsume[i].lockedAgg.closed = true
-		e.toConsume[i].lockedAgg.aggregation.Close()
-		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			e.cachedSourceSetsLock.Lock()
-			// This is to make sure there aren't too many cached source sets taking up
-			// too much space.
-			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-			}
-			e.cachedSourceSetsLock.Unlock()
-			e.toConsume[i].lockedAgg.sourcesSeen = nil
+		if e.toConsume[i].lockedAgg.consumeState != consumed {
+			e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
+		}
+		e.toConsume[i].lockedAgg.consumeState = consumed
+		if i < aggregationIdxToCloseUntil {
+			e.toConsume[i].lockedAgg.close()
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
 	}
 
-	if e.parsedPipeline.HasRollup {
+	if e.outgoingMetricType() == forwardedOutgoingMetric {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
@@ -274,14 +333,11 @@ func (e *CounterElem) Close() {
 	e.parsedPipeline = parsedPipeline{}
 	e.writeForwardedMetricFn = nil
 	e.onForwardedAggregationWrittenFn = nil
-	for idx := range e.cachedSourceSets {
-		e.cachedSourceSets[idx] = nil
-	}
-	e.cachedSourceSets = nil
+	e.sourcesHeartbeat = nil
+	e.sourcesSet = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
-		e.values[idx].lockedAgg.sourcesSeen = nil
-		e.values[idx].lockedAgg.aggregation.Close()
+		e.values[idx].lockedAgg.close()
 		e.values[idx].Reset()
 	}
 	e.values = e.values[:0]
@@ -302,12 +358,15 @@ func (e *CounterElem) Close() {
 // if it doesn't exist.
 func (e *CounterElem) findOrCreate(
 	alignedStart int64,
-	createOpts createAggregationOptions,
+	sourcesOpts sourcesOptions,
 ) (*lockedCounterAggregation, error) {
 	e.RLock()
 	if e.closed {
 		e.RUnlock()
 		return nil, errElemClosed
+	}
+	if sourcesOpts.updateSources {
+		e.updateSources(sourcesOpts.source)
 	}
 	idx, found := e.indexOfWithLock(alignedStart)
 	if found {
@@ -334,24 +393,29 @@ func (e *CounterElem) findOrCreate(
 	e.values = append(e.values, timedCounter{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen *bitset.BitSet
-	if createOpts.initSourceSet {
-		e.cachedSourceSetsLock.Lock()
-		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
-			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
-			e.cachedSourceSets[numCachedSourceSets-1] = nil
-			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
-			sourcesSeen.ClearAll()
+	var (
+		sourcesReady = e.isSourcesSetReadyWithLock()
+		sourcesSet   *bitset.BitSet
+	)
+	if sourcesOpts.updateSources {
+		if sourcesReady {
+			// If the sources set is ready, we clone it ane use the clone to
+			// determine when we have received from all the expected sources.
+			e.sourcesLock.Lock()
+			sourcesSet = e.sourcesSet.Clone()
+			e.sourcesLock.Unlock()
 		} else {
-			sourcesSeen = bitset.New(defaultNumSources)
+			// Otherwise we create a new sources set and use it to filter out
+			// duplicate delivery from the same sources.
+			sourcesSet = bitset.New(defaultNumSources)
 		}
-		e.cachedSourceSetsLock.Unlock()
 	}
 	e.values[idx] = timedCounter{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedCounterAggregation{
-			sourcesSeen: sourcesSeen,
-			aggregation: e.NewAggregation(e.opts, e.aggOpts),
+			sourcesReady: sourcesReady,
+			sourcesSet:   sourcesSet,
+			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
 		},
 	}
 	agg := e.values[idx].lockedAgg
@@ -394,6 +458,9 @@ func (e *CounterElem) processValueWithAggregationLock(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 ) {
+	if lockedAgg.aggregation.Count() == 0 {
+		return
+	}
 	var (
 		fullPrefix       = e.FullPrefix(e.opts)
 		transformations  = e.parsedPipeline.Transformations
@@ -423,7 +490,7 @@ func (e *CounterElem) processValueWithAggregationLock(
 		if discardNaNValues && math.IsNaN(value) {
 			continue
 		}
-		if !e.parsedPipeline.HasRollup {
+		if e.outgoingMetricType() == localOutgoingMetric {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
@@ -431,4 +498,70 @@ func (e *CounterElem) processValueWithAggregationLock(
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos
+
+	// Emit latency metrics for forwarded metrics.
+	if e.outgoingMetricType() == localOutgoingMetric && e.incomingMetricType == ForwardedIncomingMetric {
+		e.opts.FullForwardingLatencyHistograms().RecordDuration(
+			e.sp.Resolution().Window,
+			e.numForwardedTimes,
+			time.Duration(e.nowFn().UnixNano()-timeNanos),
+		)
+	}
+}
+
+func (e *CounterElem) outgoingMetricType() outgoingMetricType {
+	if !e.parsedPipeline.HasRollup {
+		return localOutgoingMetric
+	}
+	return forwardedOutgoingMetric
+}
+
+func (e *CounterElem) isSourcesSetReadyWithLock() bool {
+	if !e.opts.EnableEagerForwarding() {
+		return false
+	}
+	if e.buildingSourcesAtNanos == 0 {
+		return false
+	}
+	// NB: Allow TTL for the source set to build up.
+	return e.nowFn().UnixNano() >= e.buildingSourcesAtNanos+e.sourcesTTLNanos
+}
+
+func (e *CounterElem) maybeRefreshSourcesSetWithLock() {
+	if !e.opts.EnableEagerForwarding() {
+		return
+	}
+	nowNanos := e.nowFn().UnixNano()
+	if nowNanos-e.lastSourcesRefreshNanos < e.sourcesTTLNanos {
+		return
+	}
+	e.sourcesLock.Lock()
+	for sourceID, lastHeartbeatNanos := range e.sourcesHeartbeat {
+		if nowNanos-lastHeartbeatNanos >= e.sourcesTTLNanos {
+			delete(e.sourcesHeartbeat, sourceID)
+			e.sourcesSet.Clear(uint(sourceID))
+		}
+	}
+	e.lastSourcesRefreshNanos = nowNanos
+	e.sourcesLock.Unlock()
+}
+
+func (e *CounterElem) updateSources(source uint32) {
+	if !e.opts.EnableEagerForwarding() {
+		return
+	}
+	nowNanos := e.nowFn().UnixNano()
+	e.sourcesLock.Lock()
+	// First time a source is received.
+	if e.sourcesHeartbeat == nil {
+		e.sourcesHeartbeat = make(map[uint32]int64, defaultNumSources)
+		e.sourcesSet = bitset.New(defaultNumSources)
+		e.buildingSourcesAtNanos = nowNanos
+		e.lastSourcesRefreshNanos = nowNanos
+	}
+	if v, exists := e.sourcesHeartbeat[source]; !exists || v < nowNanos {
+		e.sourcesHeartbeat[source] = nowNanos
+	}
+	e.sourcesSet.Set(uint(source))
+	e.sourcesLock.Unlock()
 }

--- a/aggregator/elem_base.go
+++ b/aggregator/elem_base.go
@@ -35,6 +35,7 @@ import (
 	mpipeline "github.com/m3db/m3metrics/pipeline"
 	"github.com/m3db/m3metrics/pipeline/applied"
 	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/pool"
 
 	"github.com/willf/bitset"
@@ -55,24 +56,36 @@ const (
 )
 
 var (
-	nan                          = math.NaN()
-	errElemClosed                = errors.New("element is closed")
-	errAggregationClosed         = errors.New("aggregation is closed")
-	errDuplicateForwardingSource = errors.New("duplicate forwarding source")
+	nan                               = math.NaN()
+	errElemClosed                     = errors.New("element is closed")
+	errAggregationClosed              = errors.New("aggregation is closed")
+	errDuplicateOrNewForwardingSource = errors.New("duplicate or new forwarding source")
+	errDuplicateForwardingSource      = errors.New("duplicate forwarding source")
 )
 
 // isEarlierThanFn determines whether the timestamps of the metrics in a given
 // aggregation window are earlier than the given target time.
-type isEarlierThanFn func(windowStartNanos int64, resolution time.Duration, targetNanos int64) bool
+type isEarlierThanFn func(sourceNanos int64, targetNanos int64) bool
 
 // timestampNanosFn determines the final timestamps of metrics in a given aggregation
 // window with a given resolution.
 type timestampNanosFn func(windowStartNanos int64, resolution time.Duration) int64
 
-type createAggregationOptions struct {
-	// initSourceSet determines whether to initialize the source set.
-	initSourceSet bool
+type sourcesOptions struct {
+	// updateSource determines whether to update the source set.
+	updateSources bool
+	// source is the source of the metric.
+	source uint32
 }
+
+type consumeState int
+
+const (
+	notReadyToConsume consumeState = iota
+	readyToConsume
+	consuming
+	consumed
+)
 
 // metricElem is the common interface for metric elements.
 type metricElem interface {
@@ -90,6 +103,7 @@ type metricElem interface {
 
 	// ResetSetData resets the element and sets data.
 	ResetSetData(
+		incomingMetricType IncomingMetricType,
 		id id.RawID,
 		sp policy.StoragePolicy,
 		aggTypes maggregation.Types,
@@ -136,7 +150,9 @@ type elemBase struct {
 
 	// Immutable states.
 	opts                            Options
+	nowFn                           clock.NowFn
 	aggTypesOpts                    maggregation.TypesOptions
+	incomingMetricType              IncomingMetricType
 	id                              id.RawID
 	sp                              policy.StoragePolicy
 	useDefaultAggregation           bool
@@ -148,15 +164,20 @@ type elemBase struct {
 	onForwardedAggregationWrittenFn onForwardedAggregationDoneFn
 
 	// Mutable states.
-	tombstoned           bool
-	closed               bool
-	cachedSourceSetsLock sync.Mutex       // nolint: structcheck
-	cachedSourceSets     []*bitset.BitSet // nolint: structcheck
+	tombstoned              bool
+	closed                  bool
+	sourcesLock             sync.Mutex
+	sourcesHeartbeat        map[uint32]int64
+	sourcesSet              *bitset.BitSet
+	sourcesTTLNanos         int64
+	buildingSourcesAtNanos  int64
+	lastSourcesRefreshNanos int64
 }
 
 func newElemBase(opts Options) elemBase {
 	return elemBase{
 		opts:         opts,
+		nowFn:        opts.ClockOptions().NowFn(),
 		aggTypesOpts: opts.AggregationTypesOptions(),
 		aggOpts:      raggregation.NewOptions(),
 	}
@@ -164,6 +185,7 @@ func newElemBase(opts Options) elemBase {
 
 // resetSetData resets the element base and sets data.
 func (e *elemBase) resetSetData(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -175,6 +197,7 @@ func (e *elemBase) resetSetData(
 	if err != nil {
 		return err
 	}
+	e.incomingMetricType = incomingMetricType
 	e.id = id
 	e.sp = sp
 	e.aggTypes = aggTypes
@@ -184,6 +207,11 @@ func (e *elemBase) resetSetData(
 	e.numForwardedTimes = numForwardedTimes
 	e.tombstoned = false
 	e.closed = false
+	e.sourcesHeartbeat = nil
+	e.sourcesSet = nil
+	e.sourcesTTLNanos = e.opts.ForwardingSourcesTTLFn()(sp.Resolution().Window).Nanoseconds()
+	e.buildingSourcesAtNanos = 0
+	e.lastSourcesRefreshNanos = 0
 	return nil
 }
 

--- a/aggregator/entry.go
+++ b/aggregator/entry.go
@@ -96,18 +96,20 @@ func newUntimedEntryMetrics(scope tally.Scope) untimedEntryMetrics {
 }
 
 type forwardedEntryMetrics struct {
-	rateLimit        rateLimitEntryMetrics
-	arrivedTooLate   tally.Counter
-	duplicateSources tally.Counter
-	metadataUpdates  tally.Counter
+	rateLimit             rateLimitEntryMetrics
+	arrivedTooLate        tally.Counter
+	duplicateSources      tally.Counter
+	duplicateOrNewSources tally.Counter
+	metadataUpdates       tally.Counter
 }
 
 func newForwardedEntryMetrics(scope tally.Scope) forwardedEntryMetrics {
 	return forwardedEntryMetrics{
-		rateLimit:        newRateLimitEntryMetrics(scope),
-		arrivedTooLate:   scope.Counter("arrived-too-late"),
-		duplicateSources: scope.Counter("duplicate-sources"),
-		metadataUpdates:  scope.Counter("metadata-updates"),
+		rateLimit:             newRateLimitEntryMetrics(scope),
+		arrivedTooLate:        scope.Counter("arrived-too-late"),
+		duplicateSources:      scope.Counter("duplicate-sources"),
+		duplicateOrNewSources: scope.Counter("duplicate-or-new-sources"),
+		metadataUpdates:       scope.Counter("metadata-updates"),
 	}
 }
 
@@ -505,7 +507,7 @@ func (e *Entry) addNewAggregationKey(
 	}
 	// NB: The pipeline may not be owned by us and as such we need to make a copy here.
 	key.pipeline = key.pipeline.Clone()
-	if err = newElem.ResetSetData(metricID, key.storagePolicy, aggTypes, key.pipeline, key.numForwardedTimes); err != nil {
+	if err = newElem.ResetSetData(listID.incomingMetricType, metricID, key.storagePolicy, aggTypes, key.pipeline, key.numForwardedTimes); err != nil {
 		return nil, err
 	}
 	list, err := e.lists.FindOrCreate(listID)
@@ -712,6 +714,13 @@ func (e *Entry) addForwardedWithLock(
 		// Duplicate forwarding sources may occur during a leader re-election and is not
 		// considered an external facing error. Hence, we record it and move on.
 		e.metrics.forwarded.duplicateSources.Inc(1)
+		return nil
+	}
+	if err == errDuplicateOrNewForwardingSource {
+		// Duplicate or new forwarding sources may occur during a leader re-election, or
+		// when a new source is added producing the forwarded metric that was not in the
+		// initial set of expected sources for an aggregation window.
+		e.metrics.forwarded.duplicateOrNewSources.Inc(1)
 		return nil
 	}
 	return err

--- a/aggregator/flush_mgr.go
+++ b/aggregator/flush_mgr.go
@@ -278,16 +278,23 @@ func (mgr *flushManager) findOrCreateBucketWithLock(l flushingMetricList) (*flus
 	// immediately after we have waited long enough, whereas a standard metric list has a flexible
 	// flush offset to more evenly spread out the load during flushing.
 	var (
-		flushInterval = l.FlushInterval()
+		resolution    time.Duration
 		flushOffset   time.Duration
+		flushInterval = l.FlushInterval()
 	)
+	if bucketID.incomingMetricType == StandardIncomingMetric {
+		resolution = bucketID.standard.resolution
+	} else {
+		resolution = bucketID.forwarded.resolution
+	}
 	if fl, ok := l.(fixedOffsetFlushingMetricList); ok {
 		flushOffset = fl.FlushOffset()
 	} else {
 		flushOffset = mgr.computeFlushIntervalOffset(flushInterval)
 	}
 	scope := mgr.scope.SubScope("bucket").Tagged(map[string]string{
-		"bucket-type": bucketID.listType.String(),
+		"bucket-type": bucketID.incomingMetricType.String(),
+		"resolution":  resolution.String(),
 		"interval":    flushInterval.String(),
 	})
 	bucket = newBucket(bucketID, flushInterval, flushOffset, scope)

--- a/aggregator/follower_flush_mgr.go
+++ b/aggregator/follower_flush_mgr.go
@@ -289,10 +289,10 @@ func (mgr *followerFlushManager) flushersFromKVUpdateWithLock(buckets []*flushBu
 		bucketID := bucket.bucketID
 		flushersByInterval[i].interval = bucket.interval
 		flushersByInterval[i].duration = bucket.duration
-		switch bucketID.listType {
-		case standardMetricListType:
+		switch bucketID.incomingMetricType {
+		case StandardIncomingMetric:
 			flushersByInterval[i].flushers = mgr.standardFlushersFromKVUpdateWithLock(bucketID.standard, bucket.flushers)
-		case forwardedMetricListType:
+		case ForwardedIncomingMetric:
 			flushersByInterval[i].flushers = mgr.forwardedFlushersFromKVUpdateWithLock(bucketID.forwarded, bucket.flushers)
 		default:
 			panic("should never get here")

--- a/aggregator/forwarded_latency_histogram.go
+++ b/aggregator/forwarded_latency_histogram.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+// ForwardingLatencyBucketsFn creates forwarding latency buckets.
+type ForwardingLatencyBucketsFn func(
+	key ForwardingLatencyBucketKey,
+	numLatencyBuckets int,
+) tally.Buckets
+
+// ForwardingLatencyBucketKey is the key for a forwarding latency bucket.
+type ForwardingLatencyBucketKey struct {
+	Resolution        time.Duration
+	NumForwardedTimes int
+}
+
+// ForwardingLatencyHistograms record forwarded latencies as histograms.
+type ForwardingLatencyHistograms struct {
+	sync.RWMutex
+
+	scope      tally.Scope
+	bucketsFn  ForwardingLatencyBucketsFn
+	histograms map[ForwardingLatencyBucketKey]tally.Histogram
+}
+
+// NewForwardingLatencyHistograms create a new set of forwarding latency histograms.
+func NewForwardingLatencyHistograms(
+	scope tally.Scope,
+	bucketsFn ForwardingLatencyBucketsFn,
+) *ForwardingLatencyHistograms {
+	return &ForwardingLatencyHistograms{
+		scope:      scope,
+		bucketsFn:  bucketsFn,
+		histograms: make(map[ForwardingLatencyBucketKey]tally.Histogram),
+	}
+}
+
+// RecordDuration record a forwarding latency.
+func (m *ForwardingLatencyHistograms) RecordDuration(
+	resolution time.Duration,
+	numForwardedTimes int,
+	duration time.Duration,
+) {
+	key := ForwardingLatencyBucketKey{
+		Resolution:        resolution,
+		NumForwardedTimes: numForwardedTimes,
+	}
+	m.RLock()
+	histogram, exists := m.histograms[key]
+	m.RUnlock()
+	if exists {
+		histogram.RecordDuration(duration)
+		return
+	}
+	m.Lock()
+	histogram, exists = m.histograms[key]
+	if exists {
+		m.Unlock()
+		histogram.RecordDuration(duration)
+		return
+	}
+	buckets := m.bucketsFn(key, numForwardingLatencyBuckets)
+	histogram = m.scope.Tagged(map[string]string{
+		"bucket-version":      strconv.Itoa(forwardingLatencyBucketVersion),
+		"resolution":          resolution.String(),
+		"num-forwarded-times": strconv.Itoa(numForwardedTimes),
+	}).Histogram("forwarding-latency", buckets)
+	m.histograms[key] = histogram
+	m.Unlock()
+	histogram.RecordDuration(duration)
+}
+
+const (
+	forwardingLatencyBucketVersion = 3
+	numForwardingLatencyBuckets    = 40
+)

--- a/aggregator/forwarded_writer.go
+++ b/aggregator/forwarded_writer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3x/clock"
 	xerrors "github.com/m3db/m3x/errors"
 
 	"github.com/uber-go/tally"
@@ -72,8 +73,8 @@ type forwardedMetricWriter interface {
 		aggKey aggregationKey,
 	) error
 
-	// Prepare prepares the writer for a new write cycle.
-	Prepare()
+	// Prepare prepares the writer for a new write cycle flushing for given timestamp.
+	Prepare(targetNanos int64)
 
 	// Flush flushes any data buffered in the writer.
 	Flush() error
@@ -131,8 +132,12 @@ func newForwardedWriterMetrics(scope tally.Scope) forwardedWriterMetrics {
 // associated with the (shard, listID) combination, which is used for value
 // deduplication during leadership re-elections on the destination server.
 type forwardedWriter struct {
-	shard  uint32
-	client client.AdminClient
+	shard                  uint32
+	client                 client.AdminClient
+	eagerForwardingEnabled bool
+	maxForwardingWindows   int
+	isEarlierThanFn        isEarlierThanFn
+	nowFn                  clock.NowFn
 
 	closed             bool
 	aggregations       map[idKey]*forwardedAggregation // Aggregations for each forward metric id
@@ -143,14 +148,22 @@ type forwardedWriter struct {
 func newForwardedWriter(
 	shard uint32,
 	client client.AdminClient,
+	eagerForwardingEnabled bool,
+	maxForwardingWindows int,
+	isEarlierThanFn isEarlierThanFn,
+	nowFn clock.NowFn,
 	scope tally.Scope,
 ) forwardedMetricWriter {
 	return &forwardedWriter{
-		shard:              shard,
-		client:             client,
-		aggregations:       make(map[idKey]*forwardedAggregation),
-		metrics:            newForwardedWriterMetrics(scope),
-		aggregationMetrics: newForwardedAggregationMetrics(scope.SubScope("aggregations")),
+		shard:                  shard,
+		client:                 client,
+		eagerForwardingEnabled: eagerForwardingEnabled,
+		maxForwardingWindows:   maxForwardingWindows,
+		isEarlierThanFn:        isEarlierThanFn,
+		nowFn:                  nowFn,
+		aggregations:           make(map[idKey]*forwardedAggregation),
+		metrics:                newForwardedWriterMetrics(scope),
+		aggregationMetrics:     newForwardedAggregationMetrics(scope.SubScope("aggregations")),
 	}
 }
 
@@ -168,7 +181,10 @@ func (w *forwardedWriter) Register(
 	key := newIDKey(metricType, metricID)
 	fa, exists := w.aggregations[key]
 	if !exists {
-		fa = newForwardedAggregation(metricType, metricID, w.shard, w.client, w.aggregationMetrics)
+		fa = newForwardedAggregation(
+			metricType, metricID, w.shard, w.client, w.eagerForwardingEnabled,
+			w.maxForwardingWindows, w.isEarlierThanFn, w.nowFn, w.aggregationMetrics,
+		)
 		w.aggregations[key] = fa
 	}
 	fa.add(aggKey)
@@ -204,9 +220,9 @@ func (w *forwardedWriter) Unregister(
 	return nil
 }
 
-func (w *forwardedWriter) Prepare() {
+func (w *forwardedWriter) Prepare(targetFlushNanos int64) {
 	for _, agg := range w.aggregations {
-		agg.reset()
+		agg.reset(targetFlushNanos)
 	}
 	w.metrics.prepare.Inc(1)
 }
@@ -270,26 +286,40 @@ type forwardedAggregationWithKey struct {
 	// is called.
 	currRefCnt        int
 	cachedValueArrays [][]float64
-	buckets           forwardedAggregationBuckets
+	bucketsByTimeAsc  forwardedAggregationBuckets
+	// lastWriteNanos is the last timestamp of the aggregation written to the destination server.
+	lastWriteNanos int64
 }
 
+// NB: Intetionally do not reset last write nanos so we can use it to figure out the last written
+// timestamp and determine when we start writing forwarded metrics.
 func (agg *forwardedAggregationWithKey) reset() {
 	agg.currRefCnt = 0
-	for i := 0; i < len(agg.buckets); i++ {
-		agg.buckets[i].values = agg.buckets[i].values[:0]
-		agg.cachedValueArrays = append(agg.cachedValueArrays, agg.buckets[i].values)
-		agg.buckets[i].values = nil
+	for i := 0; i < len(agg.bucketsByTimeAsc); i++ {
+		agg.bucketsByTimeAsc[i].values = agg.bucketsByTimeAsc[i].values[:0]
+		agg.cachedValueArrays = append(agg.cachedValueArrays, agg.bucketsByTimeAsc[i].values)
+		agg.bucketsByTimeAsc[i].values = nil
 	}
-	agg.buckets = agg.buckets[:0]
+	agg.bucketsByTimeAsc = agg.bucketsByTimeAsc[:0]
 }
 
 func (agg *forwardedAggregationWithKey) add(timeNanos int64, value float64) {
-	for i := 0; i < len(agg.buckets); i++ {
-		if agg.buckets[i].timeNanos == timeNanos {
-			agg.buckets[i].values = append(agg.buckets[i].values, value)
+	var idx int
+	for idx = 0; idx < len(agg.bucketsByTimeAsc); idx++ {
+		if agg.bucketsByTimeAsc[idx].timeNanos == timeNanos {
+			agg.bucketsByTimeAsc[idx].values = append(agg.bucketsByTimeAsc[idx].values, value)
 			return
 		}
+		if agg.bucketsByTimeAsc[idx].timeNanos > timeNanos {
+			break
+		}
 	}
+
+	// Bucket not found.
+	numBuckets := len(agg.bucketsByTimeAsc)
+	agg.bucketsByTimeAsc = append(agg.bucketsByTimeAsc, forwardedAggregationBucket{})
+	copy(agg.bucketsByTimeAsc[idx+1:numBuckets+1], agg.bucketsByTimeAsc[idx:numBuckets])
+
 	var values []float64
 	if numCachedValueArrays := len(agg.cachedValueArrays); numCachedValueArrays > 0 {
 		values = agg.cachedValueArrays[numCachedValueArrays-1]
@@ -299,11 +329,10 @@ func (agg *forwardedAggregationWithKey) add(timeNanos int64, value float64) {
 		values = make([]float64, 0, initialValueArrayCapacity)
 	}
 	values = append(values, value)
-	bucket := forwardedAggregationBucket{
+	agg.bucketsByTimeAsc[idx] = forwardedAggregationBucket{
 		timeNanos: timeNanos,
 		values:    values,
 	}
-	agg.buckets = append(agg.buckets, bucket)
 }
 
 type forwardedAggregationMetrics struct {
@@ -313,6 +342,8 @@ type forwardedAggregationMetrics struct {
 	onDoneNoWrite          tally.Counter
 	onDoneWriteSuccess     tally.Counter
 	onDoneWriteErrors      tally.Counter
+	onDoneHeartbeatSuccess tally.Counter
+	onDoneHeartbeatErrors  tally.Counter
 	onDoneUnexpectedRefCnt tally.Counter
 }
 
@@ -324,20 +355,27 @@ func newForwardedAggregationMetrics(scope tally.Scope) *forwardedAggregationMetr
 		onDoneNoWrite:          scope.Counter("on-done-not-write"),
 		onDoneWriteSuccess:     scope.Counter("on-done-write-success"),
 		onDoneWriteErrors:      scope.Counter("on-done-write-errors"),
+		onDoneHeartbeatSuccess: scope.Counter("on-done-heartbeat-success"),
+		onDoneHeartbeatErrors:  scope.Counter("on-done-heartbeat-errors"),
 		onDoneUnexpectedRefCnt: scope.Counter("on-done-unexpected-refcnt"),
 	}
 }
 
 type forwardedAggregation struct {
-	metricType metric.Type
-	metricID   id.RawID
-	shard      uint32
-	client     client.AdminClient
+	metricType             metric.Type
+	metricID               id.RawID
+	shard                  uint32
+	client                 client.AdminClient
+	eagerForwardingEnabled bool
+	maxForwardingWindows   int
+	isEarlierThanFn        isEarlierThanFn
+	nowFn                  clock.NowFn
 
-	byKey    []forwardedAggregationWithKey
-	metrics  *forwardedAggregationMetrics
-	writeFn  writeForwardedMetricFn
-	onDoneFn onForwardedAggregationDoneFn
+	targetFlushNanos int64
+	byKey            []forwardedAggregationWithKey
+	metrics          *forwardedAggregationMetrics
+	writeFn          writeForwardedMetricFn
+	onDoneFn         onForwardedAggregationDoneFn
 }
 
 func newForwardedAggregation(
@@ -345,15 +383,23 @@ func newForwardedAggregation(
 	metricID id.RawID,
 	shard uint32,
 	client client.AdminClient,
+	eagerForwardingEnabled bool,
+	maxForwardingWindows int,
+	isEarlierThanFn isEarlierThanFn,
+	nowFn clock.NowFn,
 	fm *forwardedAggregationMetrics,
 ) *forwardedAggregation {
 	agg := &forwardedAggregation{
-		metricType: metricType,
-		metricID:   metricID,
-		shard:      shard,
-		client:     client,
-		byKey:      make([]forwardedAggregationWithKey, 0, 2),
-		metrics:    fm,
+		metricType:             metricType,
+		metricID:               metricID,
+		shard:                  shard,
+		client:                 client,
+		eagerForwardingEnabled: eagerForwardingEnabled,
+		maxForwardingWindows:   maxForwardingWindows,
+		isEarlierThanFn:        isEarlierThanFn,
+		nowFn:                  nowFn,
+		byKey:                  make([]forwardedAggregationWithKey, 0, 2),
+		metrics:                fm,
 	}
 	agg.writeFn = agg.write
 	agg.onDoneFn = agg.onDone
@@ -370,7 +416,8 @@ func (agg *forwardedAggregation) onAggregationKeyDoneFn() onForwardedAggregation
 
 func (agg *forwardedAggregation) clear() { *agg = forwardedAggregation{} }
 
-func (agg *forwardedAggregation) reset() {
+func (agg *forwardedAggregation) reset(targetFlushNanos int64) {
+	agg.targetFlushNanos = targetFlushNanos
 	for i := 0; i < len(agg.byKey); i++ {
 		agg.byKey[i].reset()
 	}
@@ -385,10 +432,10 @@ func (agg *forwardedAggregation) add(key aggregationKey) {
 		return
 	}
 	aggregation := forwardedAggregationWithKey{
-		key:         key,
-		totalRefCnt: 1,
-		currRefCnt:  0,
-		buckets:     make(forwardedAggregationBuckets, 0, 2),
+		key:              key,
+		totalRefCnt:      1,
+		currRefCnt:       0,
+		bucketsByTimeAsc: make(forwardedAggregationBuckets, 0, 2),
 	}
 	agg.byKey = append(agg.byKey, aggregation)
 	agg.metrics.added.Inc(1)
@@ -396,6 +443,8 @@ func (agg *forwardedAggregation) add(key aggregationKey) {
 
 // remove removes the aggregation key from the set of aggregations, returning
 // the remaining number of aggregations, and whether the removal is successful.
+// NB: could unregister metric on destination server when key is removed to
+// facilitate faster flushing for forwarded metric.
 func (agg *forwardedAggregation) remove(key aggregationKey) (int, bool) {
 	idx := agg.index(key)
 	if idx < 0 {
@@ -429,21 +478,31 @@ func (agg *forwardedAggregation) onDone(key aggregationKey) error {
 		agg.metrics.onDoneNoWrite.Inc(1)
 		return nil
 	}
-	if agg.byKey[idx].currRefCnt == agg.byKey[idx].totalRefCnt {
-		var (
-			multiErr = xerrors.NewMultiError()
-			meta     = metadata.ForwardMetadata{
-				AggregationID:     key.aggregationID,
-				StoragePolicy:     key.storagePolicy,
-				Pipeline:          key.pipeline,
-				SourceID:          agg.shard,
-				NumForwardedTimes: key.numForwardedTimes,
-			}
-		)
-		for _, b := range agg.byKey[idx].buckets {
-			if len(b.values) == 0 {
-				continue
-			}
+	if agg.byKey[idx].currRefCnt > agg.byKey[idx].totalRefCnt {
+		// If the current ref count is higher than total, this is likely a logical error.
+		agg.metrics.onDoneUnexpectedRefCnt.Inc(1)
+		return fmt.Errorf("unexpected refcount: current=%d, total=%d", agg.byKey[idx].currRefCnt, agg.byKey[idx].totalRefCnt)
+	}
+	var (
+		multiErr = xerrors.NewMultiError()
+		meta     = metadata.ForwardMetadata{
+			AggregationID:     key.aggregationID,
+			StoragePolicy:     key.storagePolicy,
+			Pipeline:          key.pipeline,
+			SourceID:          agg.shard,
+			NumForwardedTimes: key.numForwardedTimes,
+		}
+		resolutionNanos       = key.storagePolicy.Resolution().Window.Nanoseconds()
+		numAggregationWindows = int((agg.targetFlushNanos - agg.byKey[idx].lastWriteNanos) / resolutionNanos)
+		lastWriteNanos        int64
+	)
+	if !agg.eagerForwardingEnabled || agg.byKey[idx].lastWriteNanos == 0 || numAggregationWindows > agg.maxForwardingWindows {
+		// If this is first time this aggregation key is flushed or the number of aggregation windows
+		// that we need to send empty batches for exceeds the threshold, we only send what are stored
+		// in the aggregation buckets to initialize lastWriteNanos and rely on the maxForwardingDelay
+		// on the destination server to flush the forward metric for aggregation windows where no
+		// batch is sent.
+		for _, b := range agg.byKey[idx].bucketsByTimeAsc {
 			metric := aggregated.ForwardedMetric{
 				Type:      agg.metricType,
 				ID:        agg.metricID,
@@ -456,12 +515,70 @@ func (agg *forwardedAggregation) onDone(key aggregationKey) error {
 			} else {
 				agg.metrics.onDoneWriteSuccess.Inc(1)
 			}
+			lastWriteNanos = b.timeNanos
 		}
-		return multiErr.FinalError()
+	} else {
+		// We have flushed before, so we ensure we send a batch for every aggregation
+		// in between so the destination server knows when it has received from all
+		// sources and can perform its flush as soon as possible.
+		var (
+			currWriteNanos = agg.byKey[idx].lastWriteNanos + resolutionNanos
+			bucketIdx      = 0
+		)
+		lastWriteNanos = agg.byKey[idx].lastWriteNanos
+		for agg.isEarlierThanFn(currWriteNanos, agg.targetFlushNanos) || bucketIdx < len(agg.byKey[idx].bucketsByTimeAsc) {
+			var compareResult int
+			if bucketIdx >= len(agg.byKey[idx].bucketsByTimeAsc) {
+				compareResult = -1
+			} else if !agg.isEarlierThanFn(currWriteNanos, agg.targetFlushNanos) {
+				compareResult = 1
+			} else {
+				if currWriteNanos == agg.byKey[idx].bucketsByTimeAsc[bucketIdx].timeNanos {
+					compareResult = 0
+				} else if currWriteNanos < agg.byKey[idx].bucketsByTimeAsc[bucketIdx].timeNanos {
+					compareResult = -1
+				} else {
+					compareResult = 1
+				}
+			}
+
+			var metric aggregated.ForwardedMetric
+			if compareResult == 0 {
+				metric = aggregated.ForwardedMetric{
+					Type:      agg.metricType,
+					ID:        agg.metricID,
+					TimeNanos: agg.byKey[idx].bucketsByTimeAsc[bucketIdx].timeNanos,
+					Values:    agg.byKey[idx].bucketsByTimeAsc[bucketIdx].values,
+				}
+				currWriteNanos += resolutionNanos
+				bucketIdx++
+			} else if compareResult < 0 {
+				metric = aggregated.ForwardedMetric{
+					Type:      agg.metricType,
+					ID:        agg.metricID,
+					TimeNanos: currWriteNanos,
+				}
+				currWriteNanos += resolutionNanos
+			} else {
+				metric = aggregated.ForwardedMetric{
+					Type:      agg.metricType,
+					ID:        agg.metricID,
+					TimeNanos: agg.byKey[idx].bucketsByTimeAsc[bucketIdx].timeNanos,
+					Values:    agg.byKey[idx].bucketsByTimeAsc[bucketIdx].values,
+				}
+				bucketIdx++
+			}
+			if err := agg.client.WriteForwarded(metric, meta); err != nil {
+				multiErr = multiErr.Add(err)
+				agg.metrics.onDoneWriteErrors.Inc(1)
+			} else {
+				agg.metrics.onDoneWriteSuccess.Inc(1)
+			}
+			lastWriteNanos = metric.TimeNanos
+		}
 	}
-	// If the current ref count is higher than total, this is likely a logical error.
-	agg.metrics.onDoneUnexpectedRefCnt.Inc(1)
-	return fmt.Errorf("unexpected refcount: current=%d, total=%d", agg.byKey[idx].currRefCnt, agg.byKey[idx].totalRefCnt)
+	agg.byKey[idx].lastWriteNanos = lastWriteNanos
+	return multiErr.FinalError()
 }
 
 func (agg *forwardedAggregation) index(key aggregationKey) int {

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -51,9 +51,20 @@ import (
 type lockedGaugeAggregation struct {
 	sync.Mutex
 
-	closed      bool
-	sourcesSeen *bitset.BitSet
-	aggregation gaugeAggregation
+	closed       bool
+	sourcesReady bool           // only used for elements receiving forwarded metrics
+	sourcesSet   *bitset.BitSet // only used for elements receiving forwarded metrics
+	consumeState consumeState   // only used for elements receiving forwarded metrics
+	aggregation  gaugeAggregation
+}
+
+func (lockedAgg *lockedGaugeAggregation) close() {
+	if lockedAgg.closed {
+		return
+	}
+	lockedAgg.closed = true
+	lockedAgg.sourcesSet = nil
+	lockedAgg.aggregation.Close()
 }
 
 type timedGauge struct {
@@ -79,6 +90,7 @@ type GaugeElem struct {
 
 // NewGaugeElem creates a new element for the given metric type.
 func NewGaugeElem(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -90,7 +102,7 @@ func NewGaugeElem(
 		elemBase: newElemBase(opts),
 		values:   make([]timedGauge, 0, defaultNumAggregations), // in most cases values will have two entries
 	}
-	if err := e.ResetSetData(id, sp, aggTypes, pipeline, numForwardedTimes); err != nil {
+	if err := e.ResetSetData(incomingMetricType, id, sp, aggTypes, pipeline, numForwardedTimes); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -98,6 +110,7 @@ func NewGaugeElem(
 
 // MustNewGaugeElem creates a new element, or panics if the input is invalid.
 func MustNewGaugeElem(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -105,7 +118,7 @@ func MustNewGaugeElem(
 	numForwardedTimes int,
 	opts Options,
 ) *GaugeElem {
-	elem, err := NewGaugeElem(id, sp, aggTypes, pipeline, numForwardedTimes, opts)
+	elem, err := NewGaugeElem(incomingMetricType, id, sp, aggTypes, pipeline, numForwardedTimes, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))
 	}
@@ -114,6 +127,7 @@ func MustNewGaugeElem(
 
 // ResetSetData resets the element and sets data.
 func (e *GaugeElem) ResetSetData(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -124,7 +138,7 @@ func (e *GaugeElem) ResetSetData(
 	if useDefaultAggregation {
 		aggTypes = e.DefaultAggregationTypes(e.aggTypesOpts)
 	}
-	if err := e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation, pipeline, numForwardedTimes); err != nil {
+	if err := e.elemBase.resetSetData(incomingMetricType, id, sp, aggTypes, useDefaultAggregation, pipeline, numForwardedTimes); err != nil {
 		return err
 	}
 	if err := e.gaugeElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation); err != nil {
@@ -149,7 +163,7 @@ func (e *GaugeElem) ResetSetData(
 // AddUnion adds a metric value union at a given timestamp.
 func (e *GaugeElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
-	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{})
+	lockedAgg, err := e.findOrCreate(alignedStart, sourcesOptions{})
 	if err != nil {
 		return err
 	}
@@ -166,9 +180,10 @@ func (e *GaugeElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) e
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
+// TODO(xichen): need warmpup time.
 func (e *GaugeElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
-	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
+	lockedAgg, err := e.findOrCreate(alignedStart, sourcesOptions{updateSources: true, source: sourceID})
 	if err != nil {
 		return err
 	}
@@ -178,11 +193,29 @@ func (e *GaugeElem) AddUnique(timestamp time.Time, values []float64, sourceID ui
 		return errAggregationClosed
 	}
 	source := uint(sourceID)
-	if lockedAgg.sourcesSeen.Test(source) {
-		lockedAgg.Unlock()
-		return errDuplicateForwardingSource
+	if !lockedAgg.sourcesReady {
+		// If the sources are not ready, this is an empty source set to start with
+		// so we need to set the source. If the corresponding bit is already set,
+		// it implies a duplicate delivery from that source.
+		if lockedAgg.sourcesSet.Test(source) {
+			lockedAgg.Unlock()
+			return errDuplicateForwardingSource
+		}
+		lockedAgg.sourcesSet.Set(source)
+	} else {
+		// Otherwise, this is a pre-filled source set to start with, so we need to
+		// clear the source. If the corresponding bit is not set, it implies either
+		// a duplicate delivery from that source, or a new source that was not in
+		// the initial cloned source set.
+		if !lockedAgg.sourcesSet.Test(source) {
+			lockedAgg.Unlock()
+			return errDuplicateOrNewForwardingSource
+		}
+		lockedAgg.sourcesSet.Clear(source)
+		if lockedAgg.sourcesSet.None() {
+			lockedAgg.consumeState = readyToConsume
+		}
 	}
-	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
 		lockedAgg.aggregation.Add(v)
 	}
@@ -212,7 +245,8 @@ func (e *GaugeElem) Consume(
 	idx := 0
 	for range e.values {
 		// Bail as soon as the timestamp is no later than the target time.
-		if !isEarlierThanFn(e.values[idx].startAtNanos, resolution, targetNanos) {
+		timeNanos := timestampNanosFn(e.values[idx].startAtNanos, resolution)
+		if !isEarlierThanFn(timeNanos, targetNanos) {
 			break
 		}
 		idx++
@@ -230,31 +264,56 @@ func (e *GaugeElem) Consume(
 		e.values = e.values[:n]
 	}
 	canCollect := len(e.values) == 0 && e.tombstoned
+
+	// Additionally for elements receiving forwarded metrics and sending aggregated metrics
+	// to local backends, we also check if any aggregations are ready to be consumed. We however
+	// do not remove the aggregations as we do for aggregations whose timestamps are old enough,
+	// since for aggregations receiving forwarded metrics that are marked "consume ready", it is
+	// possible that metrics still go to the such aggregation bucket after they are marked "consume
+	// ready" due to delayed source re-delivery or new sources showing up, and removing such
+	// aggregation prematurely would mean the values from the delayed sources and/or new sources
+	// would be considered as the aggregated value for such aggregation bucket, which is incorrect.
+	// By keeping such aggregation buckets and only removing them when they are considered old enough
+	// (i.e., when their timestmaps are earlier than the target timestamp), we ensure no metrics may
+	// go to such aggregation buckets after they are consumed and therefore avoid the aformentioned
+	// problem.
+	aggregationIdxToCloseUntil := len(e.toConsume)
+	if e.incomingMetricType == ForwardedIncomingMetric && e.isSourcesSetReadyWithLock() {
+		e.maybeRefreshSourcesSetWithLock()
+		// We only attempt to consume if the outgoing metrics type is local instead of forwarded.
+		// This is because forwarded metrics are sent in batches and can only be sent when all sources
+		// in the same shard have been consumed, and as such is not well suited for pre-emptive consumption.
+		if e.outgoingMetricType() == localOutgoingMetric {
+			for i := 0; i < len(e.values); i++ {
+				// NB: This makes the logic easier to understand but it would be more efficient to use
+				// an atomic here to avoid locking aggregations.
+				e.values[i].lockedAgg.Lock()
+				if e.values[i].lockedAgg.consumeState == readyToConsume {
+					e.toConsume = append(e.toConsume, e.values[i])
+					e.values[i].lockedAgg.consumeState = consuming
+				}
+				e.values[i].lockedAgg.Unlock()
+			}
+		}
+	}
 	e.Unlock()
 
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
 		e.toConsume[i].lockedAgg.Lock()
-		e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
-		// Closes the aggregation object after it's processed.
-		e.toConsume[i].lockedAgg.closed = true
-		e.toConsume[i].lockedAgg.aggregation.Close()
-		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			e.cachedSourceSetsLock.Lock()
-			// This is to make sure there aren't too many cached source sets taking up
-			// too much space.
-			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-			}
-			e.cachedSourceSetsLock.Unlock()
-			e.toConsume[i].lockedAgg.sourcesSeen = nil
+		if e.toConsume[i].lockedAgg.consumeState != consumed {
+			e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
+		}
+		e.toConsume[i].lockedAgg.consumeState = consumed
+		if i < aggregationIdxToCloseUntil {
+			e.toConsume[i].lockedAgg.close()
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
 	}
 
-	if e.parsedPipeline.HasRollup {
+	if e.outgoingMetricType() == forwardedOutgoingMetric {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
@@ -274,14 +333,11 @@ func (e *GaugeElem) Close() {
 	e.parsedPipeline = parsedPipeline{}
 	e.writeForwardedMetricFn = nil
 	e.onForwardedAggregationWrittenFn = nil
-	for idx := range e.cachedSourceSets {
-		e.cachedSourceSets[idx] = nil
-	}
-	e.cachedSourceSets = nil
+	e.sourcesHeartbeat = nil
+	e.sourcesSet = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
-		e.values[idx].lockedAgg.sourcesSeen = nil
-		e.values[idx].lockedAgg.aggregation.Close()
+		e.values[idx].lockedAgg.close()
 		e.values[idx].Reset()
 	}
 	e.values = e.values[:0]
@@ -302,12 +358,15 @@ func (e *GaugeElem) Close() {
 // if it doesn't exist.
 func (e *GaugeElem) findOrCreate(
 	alignedStart int64,
-	createOpts createAggregationOptions,
+	sourcesOpts sourcesOptions,
 ) (*lockedGaugeAggregation, error) {
 	e.RLock()
 	if e.closed {
 		e.RUnlock()
 		return nil, errElemClosed
+	}
+	if sourcesOpts.updateSources {
+		e.updateSources(sourcesOpts.source)
 	}
 	idx, found := e.indexOfWithLock(alignedStart)
 	if found {
@@ -334,24 +393,29 @@ func (e *GaugeElem) findOrCreate(
 	e.values = append(e.values, timedGauge{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen *bitset.BitSet
-	if createOpts.initSourceSet {
-		e.cachedSourceSetsLock.Lock()
-		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
-			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
-			e.cachedSourceSets[numCachedSourceSets-1] = nil
-			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
-			sourcesSeen.ClearAll()
+	var (
+		sourcesReady = e.isSourcesSetReadyWithLock()
+		sourcesSet   *bitset.BitSet
+	)
+	if sourcesOpts.updateSources {
+		if sourcesReady {
+			// If the sources set is ready, we clone it ane use the clone to
+			// determine when we have received from all the expected sources.
+			e.sourcesLock.Lock()
+			sourcesSet = e.sourcesSet.Clone()
+			e.sourcesLock.Unlock()
 		} else {
-			sourcesSeen = bitset.New(defaultNumSources)
+			// Otherwise we create a new sources set and use it to filter out
+			// duplicate delivery from the same sources.
+			sourcesSet = bitset.New(defaultNumSources)
 		}
-		e.cachedSourceSetsLock.Unlock()
 	}
 	e.values[idx] = timedGauge{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedGaugeAggregation{
-			sourcesSeen: sourcesSeen,
-			aggregation: e.NewAggregation(e.opts, e.aggOpts),
+			sourcesReady: sourcesReady,
+			sourcesSet:   sourcesSet,
+			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
 		},
 	}
 	agg := e.values[idx].lockedAgg
@@ -394,6 +458,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 ) {
+	if lockedAgg.aggregation.Count() == 0 {
+		return
+	}
 	var (
 		fullPrefix       = e.FullPrefix(e.opts)
 		transformations  = e.parsedPipeline.Transformations
@@ -423,7 +490,7 @@ func (e *GaugeElem) processValueWithAggregationLock(
 		if discardNaNValues && math.IsNaN(value) {
 			continue
 		}
-		if !e.parsedPipeline.HasRollup {
+		if e.outgoingMetricType() == localOutgoingMetric {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
@@ -431,4 +498,70 @@ func (e *GaugeElem) processValueWithAggregationLock(
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos
+
+	// Emit latency metrics for forwarded metrics.
+	if e.outgoingMetricType() == localOutgoingMetric && e.incomingMetricType == ForwardedIncomingMetric {
+		e.opts.FullForwardingLatencyHistograms().RecordDuration(
+			e.sp.Resolution().Window,
+			e.numForwardedTimes,
+			time.Duration(e.nowFn().UnixNano()-timeNanos),
+		)
+	}
+}
+
+func (e *GaugeElem) outgoingMetricType() outgoingMetricType {
+	if !e.parsedPipeline.HasRollup {
+		return localOutgoingMetric
+	}
+	return forwardedOutgoingMetric
+}
+
+func (e *GaugeElem) isSourcesSetReadyWithLock() bool {
+	if !e.opts.EnableEagerForwarding() {
+		return false
+	}
+	if e.buildingSourcesAtNanos == 0 {
+		return false
+	}
+	// NB: Allow TTL for the source set to build up.
+	return e.nowFn().UnixNano() >= e.buildingSourcesAtNanos+e.sourcesTTLNanos
+}
+
+func (e *GaugeElem) maybeRefreshSourcesSetWithLock() {
+	if !e.opts.EnableEagerForwarding() {
+		return
+	}
+	nowNanos := e.nowFn().UnixNano()
+	if nowNanos-e.lastSourcesRefreshNanos < e.sourcesTTLNanos {
+		return
+	}
+	e.sourcesLock.Lock()
+	for sourceID, lastHeartbeatNanos := range e.sourcesHeartbeat {
+		if nowNanos-lastHeartbeatNanos >= e.sourcesTTLNanos {
+			delete(e.sourcesHeartbeat, sourceID)
+			e.sourcesSet.Clear(uint(sourceID))
+		}
+	}
+	e.lastSourcesRefreshNanos = nowNanos
+	e.sourcesLock.Unlock()
+}
+
+func (e *GaugeElem) updateSources(source uint32) {
+	if !e.opts.EnableEagerForwarding() {
+		return
+	}
+	nowNanos := e.nowFn().UnixNano()
+	e.sourcesLock.Lock()
+	// First time a source is received.
+	if e.sourcesHeartbeat == nil {
+		e.sourcesHeartbeat = make(map[uint32]int64, defaultNumSources)
+		e.sourcesSet = bitset.New(defaultNumSources)
+		e.buildingSourcesAtNanos = nowNanos
+		e.lastSourcesRefreshNanos = nowNanos
+	}
+	if v, exists := e.sourcesHeartbeat[source]; !exists || v < nowNanos {
+		e.sourcesHeartbeat[source] = nowNanos
+	}
+	e.sourcesSet.Set(uint(source))
+	e.sourcesLock.Unlock()
 }

--- a/aggregator/leader_flush_mgr.go
+++ b/aggregator/leader_flush_mgr.go
@@ -264,10 +264,10 @@ func (mgr *leaderFlushManager) updateFlushTimesWithLock(
 	}
 	for _, bucket := range buckets {
 		bucketID := bucket.bucketID
-		switch bucketID.listType {
-		case standardMetricListType:
+		switch bucketID.incomingMetricType {
+		case StandardIncomingMetric:
 			mgr.updateStandardFlushTimesWithLock(bucketID.standard, bucket.flushers)
-		case forwardedMetricListType:
+		case ForwardedIncomingMetric:
 			mgr.updateForwardedFlushTimesWithLock(bucketID.forwarded, bucket.flushers)
 		default:
 			panic("should never get here")

--- a/aggregator/metric_type.go
+++ b/aggregator/metric_type.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregator
+
+// IncomingMetricType describes the type of an incoming metric.
+type IncomingMetricType int
+
+const (
+	// UnknownIncomingMetric is an incoming metric with unknown type.
+	UnknownIncomingMetric IncomingMetricType = iota
+
+	// StandardIncomingMetric is a standard (currently untimed) incoming metric.
+	StandardIncomingMetric
+
+	// ForwardedIncomingMetric is a forwarded incoming metric.
+	ForwardedIncomingMetric
+)
+
+func (t IncomingMetricType) String() string {
+	switch t {
+	case StandardIncomingMetric:
+		return "standardIncomingMetric"
+	case ForwardedIncomingMetric:
+		return "forwardedIncomingMetric"
+	default:
+		// Should never get here.
+		return "unknown"
+	}
+}
+
+type outgoingMetricType int
+
+const (
+	// localOutgoingMetric is an outgoing metric that gets flushed to backends
+	// locally known to the server.
+	localOutgoingMetric outgoingMetricType = iota
+
+	// forwardedOutgoingMetric is an outgoing metric that gets forwarded to
+	// other aggregation servers for further aggregation and rollup.
+	forwardedOutgoingMetric
+)
+
+func (t outgoingMetricType) String() string {
+	switch t {
+	case localOutgoingMetric:
+		return "localOutgoingMetric"
+	case forwardedOutgoingMetric:
+		return "forwardedOutgoingMetric"
+	default:
+		// Should never get here.
+		return "unknown"
+	}
+}

--- a/aggregator/options.go
+++ b/aggregator/options.go
@@ -35,21 +35,26 @@ import (
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 	xtime "github.com/m3db/m3x/time"
+
+	"github.com/uber-go/tally"
 )
 
 var (
-	defaultMetricPrefix               = []byte("stats.")
-	defaultCounterPrefix              = []byte("counts.")
-	defaultTimerPrefix                = []byte("timers.")
-	defaultGaugePrefix                = []byte("gauges.")
-	defaultEntryTTL                   = 24 * time.Hour
-	defaultEntryCheckInterval         = time.Hour
-	defaultEntryCheckBatchPercent     = 0.01
-	defaultMaxTimerBatchSizePerWrite  = 0
-	defaultMaxNumCachedSourceSets     = 2
-	defaultDiscardNaNAggregatedValues = true
-	defaultResignTimeout              = 5 * time.Minute
-	defaultDefaultStoragePolicies     = []policy.StoragePolicy{
+	defaultMetricPrefix                     = []byte("stats.")
+	defaultCounterPrefix                    = []byte("counts.")
+	defaultTimerPrefix                      = []byte("timers.")
+	defaultGaugePrefix                      = []byte("gauges.")
+	defaultEntryTTL                         = 24 * time.Hour
+	defaultEntryCheckInterval               = time.Hour
+	defaultEntryCheckBatchPercent           = 0.01
+	defaultMaxTimerBatchSizePerWrite        = 0
+	defaultEnableEagerForwarding            = true
+	defaultMaxForwardingWindows             = 10
+	defaultForwardingSourcesTTLByResolution = 10
+	defaultForwardingSourcesTTLByDuration   = 5 * time.Minute
+	defaultDiscardNaNAggregatedValues       = true
+	defaultResignTimeout                    = 5 * time.Minute
+	defaultDefaultStoragePolicies           = []policy.StoragePolicy{
 		policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*24*time.Hour),
 		policy.NewStoragePolicy(time.Minute, xtime.Minute, 40*24*time.Hour),
 	}
@@ -64,6 +69,10 @@ var (
 	defaultBufferDurationAfterShardCutoff = time.Hour
 )
 
+// FlushIntervalFn determines the flush interval for lists containing metrics of
+// the given type associated with the given resolution.
+type FlushIntervalFn func(metricType IncomingMetricType, resolution time.Duration) time.Duration
+
 // MaxAllowedForwardingDelayFn returns the maximum allowed forwarding delay given
 // the metric resolution and number of times the metric has been forwarded. The forwarding
 // delay refers to the maximum tolerated delay between when a metric is ready to be
@@ -74,6 +83,9 @@ var (
 // if any, flushing delay, queuing delay, encoding delay, network delay, decoding delay at
 // destination server, and ingestion delay at the destination server.
 type MaxAllowedForwardingDelayFn func(resolution time.Duration, numForwardedTimes int) time.Duration
+
+// ForwardingSourcesTTLFn returns the ttl for forwarding sources given a resolution.
+type ForwardingSourcesTTLFn func(resolution time.Duration) time.Duration
 
 // Options provide a set of base and derived options for the aggregator.
 type Options interface {
@@ -229,6 +241,12 @@ type Options interface {
 	// ResignTimeout returns the resign timeout.
 	ResignTimeout() time.Duration
 
+	// SetFlushIntervalFn sets the flush interval function.
+	SetFlushIntervalFn(value FlushIntervalFn) Options
+
+	// FlushIntervalFn returns the flush interval function.
+	FlushIntervalFn() FlushIntervalFn
+
 	// SetMaxAllowedForwardingDelayFn sets the function that determines the maximum forwarding
 	// delay for given metric resolution and number of times the metric has been forwarded.
 	SetMaxAllowedForwardingDelayFn(value MaxAllowedForwardingDelayFn) Options
@@ -237,11 +255,41 @@ type Options interface {
 	// delay for given metric resolution and number of times the metric has been forwarded.
 	MaxAllowedForwardingDelayFn() MaxAllowedForwardingDelayFn
 
-	// SetMaxNumCachedSourceSets sets the maximum number of cached source sets.
-	SetMaxNumCachedSourceSets(value int) Options
+	// SetEnableEagerForwarding determines whether eager forwarding is enabled.
+	SetEnableEagerForwarding(value bool) Options
 
-	// MaxNumCachedSourceSets returns the maximum number of cached source sets.
-	MaxNumCachedSourceSets() int
+	// EnableEagerForwarding return whether eager forwarding is enabled.
+	EnableEagerForwarding() bool
+
+	// SetMaxAggregationWindowsForEagerForwarding sets the maximum aggregation windows
+	// for which we always forward metrics to notify the destination server where the forwarded
+	// metrics are stored of the liveliness of the source for the purpose of eager flushing.
+	// This is so that when the destination server has received results from all expected sources,
+	// it can flush the forwarded metric as soon as possible.
+	SetMaxAggregationWindowsForEagerForwarding(value int) Options
+
+	// MaxAggregationWindowsForEagerForwarding returns the maximum aggregation windows
+	// for which we always forward metrics to notify the destination server where the forwarded
+	// metrics are stored of the liveliness of the source for the purpose of eager flushing.
+	// This is so that when the destination server has received results from all expected sources
+	// for an aggregation window, it can flush the forwarded metric as soon as possible.
+	MaxAggregationWindowsForEagerForwarding() int
+
+	// SetForwardingSourcesTTLFn sets the ttl function for forwarding sources.
+	SetForwardingSourcesTTLFn(value ForwardingSourcesTTLFn) Options
+
+	// ForwardingSourcesTTLFn returns the ttl function for forwarding sources.
+	ForwardingSourcesTTLFn() ForwardingSourcesTTLFn
+
+	// SetFullForwardingLatencyHistograms sets the histograms for recording the full
+	// latency of forwarded metrics between when the metric is timestamped and when
+	// the metric is flushed to backends.
+	SetFullForwardingLatencyHistograms(value *ForwardingLatencyHistograms) Options
+
+	// FullForwardingLatencyHistograms returns the histograms for recording the full
+	// latency of forwarded metrics between when the metric is timestamped and when
+	// the metric is flushed to backends.
+	FullForwardingLatencyHistograms() *ForwardingLatencyHistograms
 
 	// SetDiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
 	SetDiscardNaNAggregatedValues(value bool) Options
@@ -272,6 +320,8 @@ type Options interface {
 
 	// GaugeElemPool returns the gauge element pool.
 	GaugeElemPool() GaugeElemPool
+
+	// For internal use.
 
 	/// Read-only derived options.
 
@@ -312,9 +362,13 @@ type options struct {
 	flushTimesManager                FlushTimesManager
 	electionManager                  ElectionManager
 	resignTimeout                    time.Duration
+	flushIntervalFn                  FlushIntervalFn
 	maxAllowedForwardingDelayFn      MaxAllowedForwardingDelayFn
-	maxNumCachedSourceSets           int
+	enableEagerForwarding            bool
+	maxForwardingWindows             int
+	forwardingSourcesTTLFn           ForwardingSourcesTTLFn
 	discardNaNAggregatedValues       bool
+	forwardingLatencyHistograms      *ForwardingLatencyHistograms
 	entryPool                        EntryPool
 	counterElemPool                  CounterElemPool
 	timerElemPool                    TimerElemPool
@@ -353,9 +407,13 @@ func NewOptions() Options {
 		maxTimerBatchSizePerWrite:        defaultMaxTimerBatchSizePerWrite,
 		defaultStoragePolicies:           defaultDefaultStoragePolicies,
 		resignTimeout:                    defaultResignTimeout,
+		flushIntervalFn:                  defaultFlushIntervalFn,
 		maxAllowedForwardingDelayFn:      defaultMaxAllowedForwardingDelayFn,
-		maxNumCachedSourceSets:           defaultMaxNumCachedSourceSets,
+		enableEagerForwarding:            defaultEnableEagerForwarding,
+		maxForwardingWindows:             defaultMaxForwardingWindows,
+		forwardingSourcesTTLFn:           defaultForwardingSourcesTTLFn,
 		discardNaNAggregatedValues:       defaultDiscardNaNAggregatedValues,
+		forwardingLatencyHistograms:      NewForwardingLatencyHistograms(tally.NoopScope, defaultForwardingLatencyBucketsFn),
 	}
 
 	// Initialize pools.
@@ -621,6 +679,16 @@ func (o *options) ResignTimeout() time.Duration {
 	return o.resignTimeout
 }
 
+func (o *options) SetFlushIntervalFn(value FlushIntervalFn) Options {
+	opts := *o
+	opts.flushIntervalFn = value
+	return &opts
+}
+
+func (o *options) FlushIntervalFn() FlushIntervalFn {
+	return o.flushIntervalFn
+}
+
 func (o *options) SetMaxAllowedForwardingDelayFn(value MaxAllowedForwardingDelayFn) Options {
 	opts := *o
 	opts.maxAllowedForwardingDelayFn = value
@@ -631,14 +699,44 @@ func (o *options) MaxAllowedForwardingDelayFn() MaxAllowedForwardingDelayFn {
 	return o.maxAllowedForwardingDelayFn
 }
 
-func (o *options) SetMaxNumCachedSourceSets(value int) Options {
+func (o *options) SetEnableEagerForwarding(value bool) Options {
 	opts := *o
-	opts.maxNumCachedSourceSets = value
+	opts.enableEagerForwarding = value
 	return &opts
 }
 
-func (o *options) MaxNumCachedSourceSets() int {
-	return o.maxNumCachedSourceSets
+func (o *options) EnableEagerForwarding() bool {
+	return o.enableEagerForwarding
+}
+
+func (o *options) SetMaxAggregationWindowsForEagerForwarding(value int) Options {
+	opts := *o
+	opts.maxForwardingWindows = value
+	return &opts
+}
+
+func (o *options) MaxAggregationWindowsForEagerForwarding() int {
+	return o.maxForwardingWindows
+}
+
+func (o *options) SetForwardingSourcesTTLFn(value ForwardingSourcesTTLFn) Options {
+	opts := *o
+	opts.forwardingSourcesTTLFn = value
+	return &opts
+}
+
+func (o *options) ForwardingSourcesTTLFn() ForwardingSourcesTTLFn {
+	return o.forwardingSourcesTTLFn
+}
+
+func (o *options) SetFullForwardingLatencyHistograms(value *ForwardingLatencyHistograms) Options {
+	opts := *o
+	opts.forwardingLatencyHistograms = value
+	return &opts
+}
+
+func (o *options) FullForwardingLatencyHistograms() *ForwardingLatencyHistograms {
+	return o.forwardingLatencyHistograms
 }
 
 func (o *options) SetDiscardNaNAggregatedValues(value bool) Options {
@@ -716,17 +814,17 @@ func (o *options) initPools() {
 
 	o.counterElemPool = NewCounterElemPool(nil)
 	o.counterElemPool.Init(func() *CounterElem {
-		return MustNewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, o)
+		return MustNewCounterElem(UnknownIncomingMetric, nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, o)
 	})
 
 	o.timerElemPool = NewTimerElemPool(nil)
 	o.timerElemPool.Init(func() *TimerElem {
-		return MustNewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, o)
+		return MustNewTimerElem(UnknownIncomingMetric, nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, o)
 	})
 
 	o.gaugeElemPool = NewGaugeElemPool(nil)
 	o.gaugeElemPool.Init(func() *GaugeElem {
-		return MustNewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, o)
+		return MustNewGaugeElem(UnknownIncomingMetric, nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, o)
 	})
 }
 
@@ -761,9 +859,28 @@ func (o *options) computeFullGaugePrefix() {
 	o.fullGaugePrefix = fullGaugePrefix
 }
 
+func defaultFlushIntervalFn(_ IncomingMetricType, resolution time.Duration) time.Duration {
+	return resolution
+}
+
 func defaultMaxAllowedForwardingDelayFn(
 	resolution time.Duration,
 	numForwardedTimes int,
 ) time.Duration {
 	return resolution * time.Duration(numForwardedTimes)
+}
+
+func defaultForwardingSourcesTTLFn(resolution time.Duration) time.Duration {
+	dur := time.Duration(defaultForwardingSourcesTTLByResolution) * resolution
+	if dur >= defaultForwardingSourcesTTLByDuration {
+		return dur
+	}
+	return defaultForwardingSourcesTTLByDuration
+}
+
+func defaultForwardingLatencyBucketsFn(
+	key ForwardingLatencyBucketKey,
+	numLatencyBuckets int,
+) tally.Buckets {
+	return tally.MustMakeLinearDurationBuckets(0, 2*key.Resolution, numLatencyBuckets)
 }

--- a/aggregator/tick_result.go
+++ b/aggregator/tick_result.go
@@ -22,16 +22,16 @@ package aggregator
 
 import "time"
 
-type tickResultForMetricCategory struct {
+type tickResultForIncomingMetricType struct {
 	activeEntries  int
 	expiredEntries int
 	activeElems    map[time.Duration]int
 }
 
-func (r *tickResultForMetricCategory) merge(
-	other tickResultForMetricCategory,
-) tickResultForMetricCategory {
-	res := tickResultForMetricCategory{
+func (r *tickResultForIncomingMetricType) merge(
+	other tickResultForIncomingMetricType,
+) tickResultForIncomingMetricType {
+	res := tickResultForIncomingMetricType{
 		activeEntries:  r.activeEntries + other.activeEntries,
 		expiredEntries: r.expiredEntries + other.expiredEntries,
 	}
@@ -51,8 +51,8 @@ func (r *tickResultForMetricCategory) merge(
 }
 
 type tickResult struct {
-	standard  tickResultForMetricCategory
-	forwarded tickResultForMetricCategory
+	standard  tickResultForIncomingMetricType
+	forwarded tickResultForIncomingMetricType
 }
 
 // merge merges two results. Both input results may become invalid after merge is called.

--- a/aggregator/timer_elem.gen.go
+++ b/aggregator/timer_elem.gen.go
@@ -51,9 +51,20 @@ import (
 type lockedTimerAggregation struct {
 	sync.Mutex
 
-	closed      bool
-	sourcesSeen *bitset.BitSet
-	aggregation timerAggregation
+	closed       bool
+	sourcesReady bool           // only used for elements receiving forwarded metrics
+	sourcesSet   *bitset.BitSet // only used for elements receiving forwarded metrics
+	consumeState consumeState   // only used for elements receiving forwarded metrics
+	aggregation  timerAggregation
+}
+
+func (lockedAgg *lockedTimerAggregation) close() {
+	if lockedAgg.closed {
+		return
+	}
+	lockedAgg.closed = true
+	lockedAgg.sourcesSet = nil
+	lockedAgg.aggregation.Close()
 }
 
 type timedTimer struct {
@@ -79,6 +90,7 @@ type TimerElem struct {
 
 // NewTimerElem creates a new element for the given metric type.
 func NewTimerElem(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -90,7 +102,7 @@ func NewTimerElem(
 		elemBase: newElemBase(opts),
 		values:   make([]timedTimer, 0, defaultNumAggregations), // in most cases values will have two entries
 	}
-	if err := e.ResetSetData(id, sp, aggTypes, pipeline, numForwardedTimes); err != nil {
+	if err := e.ResetSetData(incomingMetricType, id, sp, aggTypes, pipeline, numForwardedTimes); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -98,6 +110,7 @@ func NewTimerElem(
 
 // MustNewTimerElem creates a new element, or panics if the input is invalid.
 func MustNewTimerElem(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -105,7 +118,7 @@ func MustNewTimerElem(
 	numForwardedTimes int,
 	opts Options,
 ) *TimerElem {
-	elem, err := NewTimerElem(id, sp, aggTypes, pipeline, numForwardedTimes, opts)
+	elem, err := NewTimerElem(incomingMetricType, id, sp, aggTypes, pipeline, numForwardedTimes, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))
 	}
@@ -114,6 +127,7 @@ func MustNewTimerElem(
 
 // ResetSetData resets the element and sets data.
 func (e *TimerElem) ResetSetData(
+	incomingMetricType IncomingMetricType,
 	id id.RawID,
 	sp policy.StoragePolicy,
 	aggTypes maggregation.Types,
@@ -124,7 +138,7 @@ func (e *TimerElem) ResetSetData(
 	if useDefaultAggregation {
 		aggTypes = e.DefaultAggregationTypes(e.aggTypesOpts)
 	}
-	if err := e.elemBase.resetSetData(id, sp, aggTypes, useDefaultAggregation, pipeline, numForwardedTimes); err != nil {
+	if err := e.elemBase.resetSetData(incomingMetricType, id, sp, aggTypes, useDefaultAggregation, pipeline, numForwardedTimes); err != nil {
 		return err
 	}
 	if err := e.timerElemBase.ResetSetData(e.aggTypesOpts, aggTypes, useDefaultAggregation); err != nil {
@@ -149,7 +163,7 @@ func (e *TimerElem) ResetSetData(
 // AddUnion adds a metric value union at a given timestamp.
 func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
-	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{})
+	lockedAgg, err := e.findOrCreate(alignedStart, sourcesOptions{})
 	if err != nil {
 		return err
 	}
@@ -166,9 +180,10 @@ func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) e
 // AddUnique adds a metric value from a given source at a given timestamp.
 // If previous values from the same source have already been added to the
 // same aggregation, the incoming value is discarded.
+// TODO(xichen): need warmpup time.
 func (e *TimerElem) AddUnique(timestamp time.Time, values []float64, sourceID uint32) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
-	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{initSourceSet: true})
+	lockedAgg, err := e.findOrCreate(alignedStart, sourcesOptions{updateSources: true, source: sourceID})
 	if err != nil {
 		return err
 	}
@@ -178,11 +193,29 @@ func (e *TimerElem) AddUnique(timestamp time.Time, values []float64, sourceID ui
 		return errAggregationClosed
 	}
 	source := uint(sourceID)
-	if lockedAgg.sourcesSeen.Test(source) {
-		lockedAgg.Unlock()
-		return errDuplicateForwardingSource
+	if !lockedAgg.sourcesReady {
+		// If the sources are not ready, this is an empty source set to start with
+		// so we need to set the source. If the corresponding bit is already set,
+		// it implies a duplicate delivery from that source.
+		if lockedAgg.sourcesSet.Test(source) {
+			lockedAgg.Unlock()
+			return errDuplicateForwardingSource
+		}
+		lockedAgg.sourcesSet.Set(source)
+	} else {
+		// Otherwise, this is a pre-filled source set to start with, so we need to
+		// clear the source. If the corresponding bit is not set, it implies either
+		// a duplicate delivery from that source, or a new source that was not in
+		// the initial cloned source set.
+		if !lockedAgg.sourcesSet.Test(source) {
+			lockedAgg.Unlock()
+			return errDuplicateOrNewForwardingSource
+		}
+		lockedAgg.sourcesSet.Clear(source)
+		if lockedAgg.sourcesSet.None() {
+			lockedAgg.consumeState = readyToConsume
+		}
 	}
-	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
 		lockedAgg.aggregation.Add(v)
 	}
@@ -212,7 +245,8 @@ func (e *TimerElem) Consume(
 	idx := 0
 	for range e.values {
 		// Bail as soon as the timestamp is no later than the target time.
-		if !isEarlierThanFn(e.values[idx].startAtNanos, resolution, targetNanos) {
+		timeNanos := timestampNanosFn(e.values[idx].startAtNanos, resolution)
+		if !isEarlierThanFn(timeNanos, targetNanos) {
 			break
 		}
 		idx++
@@ -230,31 +264,56 @@ func (e *TimerElem) Consume(
 		e.values = e.values[:n]
 	}
 	canCollect := len(e.values) == 0 && e.tombstoned
+
+	// Additionally for elements receiving forwarded metrics and sending aggregated metrics
+	// to local backends, we also check if any aggregations are ready to be consumed. We however
+	// do not remove the aggregations as we do for aggregations whose timestamps are old enough,
+	// since for aggregations receiving forwarded metrics that are marked "consume ready", it is
+	// possible that metrics still go to the such aggregation bucket after they are marked "consume
+	// ready" due to delayed source re-delivery or new sources showing up, and removing such
+	// aggregation prematurely would mean the values from the delayed sources and/or new sources
+	// would be considered as the aggregated value for such aggregation bucket, which is incorrect.
+	// By keeping such aggregation buckets and only removing them when they are considered old enough
+	// (i.e., when their timestmaps are earlier than the target timestamp), we ensure no metrics may
+	// go to such aggregation buckets after they are consumed and therefore avoid the aformentioned
+	// problem.
+	aggregationIdxToCloseUntil := len(e.toConsume)
+	if e.incomingMetricType == ForwardedIncomingMetric && e.isSourcesSetReadyWithLock() {
+		e.maybeRefreshSourcesSetWithLock()
+		// We only attempt to consume if the outgoing metrics type is local instead of forwarded.
+		// This is because forwarded metrics are sent in batches and can only be sent when all sources
+		// in the same shard have been consumed, and as such is not well suited for pre-emptive consumption.
+		if e.outgoingMetricType() == localOutgoingMetric {
+			for i := 0; i < len(e.values); i++ {
+				// NB: This makes the logic easier to understand but it would be more efficient to use
+				// an atomic here to avoid locking aggregations.
+				e.values[i].lockedAgg.Lock()
+				if e.values[i].lockedAgg.consumeState == readyToConsume {
+					e.toConsume = append(e.toConsume, e.values[i])
+					e.values[i].lockedAgg.consumeState = consuming
+				}
+				e.values[i].lockedAgg.Unlock()
+			}
+		}
+	}
 	e.Unlock()
 
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
 		e.toConsume[i].lockedAgg.Lock()
-		e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
-		// Closes the aggregation object after it's processed.
-		e.toConsume[i].lockedAgg.closed = true
-		e.toConsume[i].lockedAgg.aggregation.Close()
-		if e.toConsume[i].lockedAgg.sourcesSeen != nil {
-			e.cachedSourceSetsLock.Lock()
-			// This is to make sure there aren't too many cached source sets taking up
-			// too much space.
-			if len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-				e.cachedSourceSets = append(e.cachedSourceSets, e.toConsume[i].lockedAgg.sourcesSeen)
-			}
-			e.cachedSourceSetsLock.Unlock()
-			e.toConsume[i].lockedAgg.sourcesSeen = nil
+		if e.toConsume[i].lockedAgg.consumeState != consumed {
+			e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
+		}
+		e.toConsume[i].lockedAgg.consumeState = consumed
+		if i < aggregationIdxToCloseUntil {
+			e.toConsume[i].lockedAgg.close()
 		}
 		e.toConsume[i].lockedAgg.Unlock()
 		e.toConsume[i].Reset()
 	}
 
-	if e.parsedPipeline.HasRollup {
+	if e.outgoingMetricType() == forwardedOutgoingMetric {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey)
 	}
@@ -274,14 +333,11 @@ func (e *TimerElem) Close() {
 	e.parsedPipeline = parsedPipeline{}
 	e.writeForwardedMetricFn = nil
 	e.onForwardedAggregationWrittenFn = nil
-	for idx := range e.cachedSourceSets {
-		e.cachedSourceSets[idx] = nil
-	}
-	e.cachedSourceSets = nil
+	e.sourcesHeartbeat = nil
+	e.sourcesSet = nil
 	for idx := range e.values {
 		// Close the underlying aggregation objects.
-		e.values[idx].lockedAgg.sourcesSeen = nil
-		e.values[idx].lockedAgg.aggregation.Close()
+		e.values[idx].lockedAgg.close()
 		e.values[idx].Reset()
 	}
 	e.values = e.values[:0]
@@ -302,12 +358,15 @@ func (e *TimerElem) Close() {
 // if it doesn't exist.
 func (e *TimerElem) findOrCreate(
 	alignedStart int64,
-	createOpts createAggregationOptions,
+	sourcesOpts sourcesOptions,
 ) (*lockedTimerAggregation, error) {
 	e.RLock()
 	if e.closed {
 		e.RUnlock()
 		return nil, errElemClosed
+	}
+	if sourcesOpts.updateSources {
+		e.updateSources(sourcesOpts.source)
 	}
 	idx, found := e.indexOfWithLock(alignedStart)
 	if found {
@@ -334,24 +393,29 @@ func (e *TimerElem) findOrCreate(
 	e.values = append(e.values, timedTimer{})
 	copy(e.values[idx+1:numValues+1], e.values[idx:numValues])
 
-	var sourcesSeen *bitset.BitSet
-	if createOpts.initSourceSet {
-		e.cachedSourceSetsLock.Lock()
-		if numCachedSourceSets := len(e.cachedSourceSets); numCachedSourceSets > 0 {
-			sourcesSeen = e.cachedSourceSets[numCachedSourceSets-1]
-			e.cachedSourceSets[numCachedSourceSets-1] = nil
-			e.cachedSourceSets = e.cachedSourceSets[:numCachedSourceSets-1]
-			sourcesSeen.ClearAll()
+	var (
+		sourcesReady = e.isSourcesSetReadyWithLock()
+		sourcesSet   *bitset.BitSet
+	)
+	if sourcesOpts.updateSources {
+		if sourcesReady {
+			// If the sources set is ready, we clone it ane use the clone to
+			// determine when we have received from all the expected sources.
+			e.sourcesLock.Lock()
+			sourcesSet = e.sourcesSet.Clone()
+			e.sourcesLock.Unlock()
 		} else {
-			sourcesSeen = bitset.New(defaultNumSources)
+			// Otherwise we create a new sources set and use it to filter out
+			// duplicate delivery from the same sources.
+			sourcesSet = bitset.New(defaultNumSources)
 		}
-		e.cachedSourceSetsLock.Unlock()
 	}
 	e.values[idx] = timedTimer{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedTimerAggregation{
-			sourcesSeen: sourcesSeen,
-			aggregation: e.NewAggregation(e.opts, e.aggOpts),
+			sourcesReady: sourcesReady,
+			sourcesSet:   sourcesSet,
+			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
 		},
 	}
 	agg := e.values[idx].lockedAgg
@@ -394,6 +458,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 ) {
+	if lockedAgg.aggregation.Count() == 0 {
+		return
+	}
 	var (
 		fullPrefix       = e.FullPrefix(e.opts)
 		transformations  = e.parsedPipeline.Transformations
@@ -423,7 +490,7 @@ func (e *TimerElem) processValueWithAggregationLock(
 		if discardNaNValues && math.IsNaN(value) {
 			continue
 		}
-		if !e.parsedPipeline.HasRollup {
+		if e.outgoingMetricType() == localOutgoingMetric {
 			flushLocalFn(fullPrefix, e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
@@ -431,4 +498,70 @@ func (e *TimerElem) processValueWithAggregationLock(
 		}
 	}
 	e.lastConsumedAtNanos = timeNanos
+
+	// Emit latency metrics for forwarded metrics.
+	if e.outgoingMetricType() == localOutgoingMetric && e.incomingMetricType == ForwardedIncomingMetric {
+		e.opts.FullForwardingLatencyHistograms().RecordDuration(
+			e.sp.Resolution().Window,
+			e.numForwardedTimes,
+			time.Duration(e.nowFn().UnixNano()-timeNanos),
+		)
+	}
+}
+
+func (e *TimerElem) outgoingMetricType() outgoingMetricType {
+	if !e.parsedPipeline.HasRollup {
+		return localOutgoingMetric
+	}
+	return forwardedOutgoingMetric
+}
+
+func (e *TimerElem) isSourcesSetReadyWithLock() bool {
+	if !e.opts.EnableEagerForwarding() {
+		return false
+	}
+	if e.buildingSourcesAtNanos == 0 {
+		return false
+	}
+	// NB: Allow TTL for the source set to build up.
+	return e.nowFn().UnixNano() >= e.buildingSourcesAtNanos+e.sourcesTTLNanos
+}
+
+func (e *TimerElem) maybeRefreshSourcesSetWithLock() {
+	if !e.opts.EnableEagerForwarding() {
+		return
+	}
+	nowNanos := e.nowFn().UnixNano()
+	if nowNanos-e.lastSourcesRefreshNanos < e.sourcesTTLNanos {
+		return
+	}
+	e.sourcesLock.Lock()
+	for sourceID, lastHeartbeatNanos := range e.sourcesHeartbeat {
+		if nowNanos-lastHeartbeatNanos >= e.sourcesTTLNanos {
+			delete(e.sourcesHeartbeat, sourceID)
+			e.sourcesSet.Clear(uint(sourceID))
+		}
+	}
+	e.lastSourcesRefreshNanos = nowNanos
+	e.sourcesLock.Unlock()
+}
+
+func (e *TimerElem) updateSources(source uint32) {
+	if !e.opts.EnableEagerForwarding() {
+		return
+	}
+	nowNanos := e.nowFn().UnixNano()
+	e.sourcesLock.Lock()
+	// First time a source is received.
+	if e.sourcesHeartbeat == nil {
+		e.sourcesHeartbeat = make(map[uint32]int64, defaultNumSources)
+		e.sourcesSet = bitset.New(defaultNumSources)
+		e.buildingSourcesAtNanos = nowNanos
+		e.lastSourcesRefreshNanos = nowNanos
+	}
+	if v, exists := e.sourcesHeartbeat[source]; !exists || v < nowNanos {
+		e.sourcesHeartbeat[source] = nowNanos
+	}
+	e.sourcesSet.Set(uint(source))
+	e.sourcesLock.Unlock()
 }

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -183,19 +183,19 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 	counterElemPool := aggregator.NewCounterElemPool(nil)
 	aggregatorOpts = aggregatorOpts.SetCounterElemPool(counterElemPool)
 	counterElemPool.Init(func() *aggregator.CounterElem {
-		return aggregator.MustNewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, aggregatorOpts)
+		return aggregator.MustNewCounterElem(aggregator.UnknownIncomingMetric, nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, aggregatorOpts)
 	})
 
 	timerElemPool := aggregator.NewTimerElemPool(nil)
 	aggregatorOpts = aggregatorOpts.SetTimerElemPool(timerElemPool)
 	timerElemPool.Init(func() *aggregator.TimerElem {
-		return aggregator.MustNewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, aggregatorOpts)
+		return aggregator.MustNewTimerElem(aggregator.UnknownIncomingMetric, nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, aggregatorOpts)
 	})
 
 	gaugeElemPool := aggregator.NewGaugeElemPool(nil)
 	aggregatorOpts = aggregatorOpts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem {
-		return aggregator.MustNewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, aggregatorOpts)
+		return aggregator.MustNewGaugeElem(aggregator.UnknownIncomingMetric, nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, aggregatorOpts)
 	})
 
 	return &testServerSetup{


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds support to enable eager flushing of forwarded metrics. With eager flushing enabled, the destination server where forwarded metrics are stored will build up the set of forwarding sources, and once the source set is built, it will use the source set to determine when to eagerly flush forwarded metrics once it has received data from all the expected sources therefore reducing full forwarding delay.