### PR TITLE
Emit forwarding latency metrics when eager forwarding is allowed

### DIFF
--- a/aggregator/counter_elem.gen.go
+++ b/aggregator/counter_elem.gen.go
@@ -321,7 +321,10 @@ func (e *CounterElem) Consume(
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
 		e.toConsume[i].lockedAgg.Lock()
 		if e.toConsume[i].lockedAgg.consumeState != consumed {
-			e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
+			e.processValueWithAggregationLock(
+				timeNanos, eagerForwardingMode, e.toConsume[i].lockedAgg,
+				flushLocalFn, flushForwardedFn,
+			)
 		}
 		e.toConsume[i].lockedAgg.consumeState = consumed
 		if i < aggregationIdxToCloseUntil {
@@ -493,6 +496,7 @@ func (e *CounterElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 func (e *CounterElem) processValueWithAggregationLock(
 	timeNanos int64,
+	eagerForwardingMode eagerForwardingMode,
 	lockedAgg *lockedCounterAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
@@ -538,8 +542,11 @@ func (e *CounterElem) processValueWithAggregationLock(
 	}
 	e.lastConsumedAtNanos = timeNanos
 
-	// Emit latency metrics for forwarded metrics.
-	if e.outgoingMetricType() == localOutgoingMetric && e.incomingMetricType == ForwardedIncomingMetric {
+	// Emit latency metrics for forwarded metrics going to local backends
+	// when eager forwarding is allowed.
+	if eagerForwardingMode == allowEagerForwarding &&
+		e.incomingMetricType == ForwardedIncomingMetric &&
+		e.outgoingMetricType() == localOutgoingMetric {
 		e.opts.FullForwardingLatencyHistograms().RecordDuration(
 			e.sp.Resolution().Window,
 			e.numForwardedTimes,

--- a/aggregator/forwarding_latency_histogram.go
+++ b/aggregator/forwarding_latency_histogram.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	forwardingLatencyBucketVersion = 4
+	forwardingLatencyBucketVersion = 5
 	numForwardingLatencyBuckets    = 40
 )
 

--- a/aggregator/forwarding_latency_histogram_test.go
+++ b/aggregator/forwarding_latency_histogram_test.go
@@ -50,7 +50,7 @@ func TestForwardingLatencyHistogramsRecordDuration(t *testing.T) {
 		expectedDurations map[time.Duration]int64
 	}{
 		{
-			id:           "testScope.forwarding-latency+bucket-version=4,num-forwarded-times=1,resolution=10s",
+			id:           "testScope.forwarding-latency+bucket-version=5,num-forwarded-times=1,resolution=10s",
 			expectedName: "testScope.forwarding-latency",
 			expectedDurations: map[time.Duration]int64{
 				2 * time.Second: 2,
@@ -58,14 +58,14 @@ func TestForwardingLatencyHistogramsRecordDuration(t *testing.T) {
 			},
 		},
 		{
-			id:           "testScope.forwarding-latency+bucket-version=4,num-forwarded-times=2,resolution=10s",
+			id:           "testScope.forwarding-latency+bucket-version=5,num-forwarded-times=2,resolution=10s",
 			expectedName: "testScope.forwarding-latency",
 			expectedDurations: map[time.Duration]int64{
 				2 * time.Second: 1,
 			},
 		},
 		{
-			id:           "testScope.forwarding-latency+bucket-version=4,num-forwarded-times=2,resolution=1m0s",
+			id:           "testScope.forwarding-latency+bucket-version=5,num-forwarded-times=2,resolution=1m0s",
 			expectedName: "testScope.forwarding-latency",
 			expectedDurations: map[time.Duration]int64{
 				21 * time.Second: 1,

--- a/aggregator/gauge_elem.gen.go
+++ b/aggregator/gauge_elem.gen.go
@@ -321,7 +321,10 @@ func (e *GaugeElem) Consume(
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
 		e.toConsume[i].lockedAgg.Lock()
 		if e.toConsume[i].lockedAgg.consumeState != consumed {
-			e.processValueWithAggregationLock(timeNanos, e.toConsume[i].lockedAgg, flushLocalFn, flushForwardedFn)
+			e.processValueWithAggregationLock(
+				timeNanos, eagerForwardingMode, e.toConsume[i].lockedAgg,
+				flushLocalFn, flushForwardedFn,
+			)
 		}
 		e.toConsume[i].lockedAgg.consumeState = consumed
 		if i < aggregationIdxToCloseUntil {
@@ -493,6 +496,7 @@ func (e *GaugeElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 func (e *GaugeElem) processValueWithAggregationLock(
 	timeNanos int64,
+	eagerForwardingMode eagerForwardingMode,
 	lockedAgg *lockedGaugeAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
@@ -538,8 +542,11 @@ func (e *GaugeElem) processValueWithAggregationLock(
 	}
 	e.lastConsumedAtNanos = timeNanos
 
-	// Emit latency metrics for forwarded metrics.
-	if e.outgoingMetricType() == localOutgoingMetric && e.incomingMetricType == ForwardedIncomingMetric {
+	// Emit latency metrics for forwarded metrics going to local backends
+	// when eager forwarding is allowed.
+	if eagerForwardingMode == allowEagerForwarding &&
+		e.incomingMetricType == ForwardedIncomingMetric &&
+		e.outgoingMetricType() == localOutgoingMetric {
 		e.opts.FullForwardingLatencyHistograms().RecordDuration(
 			e.sp.Resolution().Window,
 			e.numForwardedTimes,


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds logic so that the full forwarding latency histogram only records the latency when eager forwarding is allowed (i.e., for leader nodes) as the followers do not perform eager forwarding and only receive KV updates from leaders and as such the latency metrics are delayed and do not represent the actual e2e latency for forwarded metrics.